### PR TITLE
More usage of castleconf.inc

### DIFF
--- a/src/3d/castle3d.pas
+++ b/src/3d/castle3d.pas
@@ -16,6 +16,8 @@
 { Base 3D objects (T3D, T3DList, T3DTransform, T3DOrient, T3DMoving). }
 unit Castle3D;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, Math, CastleVectors, CastleFrustum,

--- a/src/3d/castleboxes.pas
+++ b/src/3d/castleboxes.pas
@@ -16,6 +16,8 @@
 { Axis-aligned 3D boxes (TBox3D). }
 unit CastleBoxes;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, SysUtils, CastleUtils, CastleGenericLists, CastleTriangles,

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -16,6 +16,8 @@
 { Cameras to navigate in 3D space (TExamineCamera, TWalkCamera, TUniversalCamera). }
 unit CastleCameras;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleVectors, CastleUtils, CastleKeysMouse, CastleBoxes, CastleQuaternions,

--- a/src/3d/castleconvexhull.pas
+++ b/src/3d/castleconvexhull.pas
@@ -21,6 +21,8 @@
 
 unit CastleConvexHull;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, CastleUtils, Math;

--- a/src/3d/castlecubemaps.pas
+++ b/src/3d/castlecubemaps.pas
@@ -16,6 +16,8 @@
 { Utilities for cube (environment) maps. }
 unit CastleCubeMaps;
 
+{$I castleconf.inc}
+
 interface
 
 uses Math,

--- a/src/3d/castlefrustum.pas
+++ b/src/3d/castlefrustum.pas
@@ -16,6 +16,8 @@
 { Frustum object (TFrustum) and helpers. }
 unit CastleFrustum;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, CastleBoxes;

--- a/src/3d/castlegeometryarrays.pas
+++ b/src/3d/castlegeometryarrays.pas
@@ -16,6 +16,8 @@
 { Geometry represented as arrays (TGeometryArrays). }
 unit CastleGeometryArrays;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleUtils, CastleVectors, FGL, CastleTriangles;

--- a/src/3d/castleoctree.pas
+++ b/src/3d/castleoctree.pas
@@ -62,6 +62,8 @@ end;
 *)
 unit CastleOctree;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleVectors, CastleBoxes, CastleUtils, CastleFrustum, Contnrs;

--- a/src/3d/castlequaternions.pas
+++ b/src/3d/castlequaternions.pas
@@ -17,6 +17,8 @@
   @noAutoLinkHere }
 unit CastleQuaternions;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors;

--- a/src/3d/castlerays.pas
+++ b/src/3d/castlerays.pas
@@ -19,6 +19,8 @@
   the current mouse position). }
 unit CastleRays;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors;

--- a/src/3d/castlesectors.pas
+++ b/src/3d/castlesectors.pas
@@ -19,6 +19,8 @@
   [http://castle-engine.sourceforge.net/castle-development.php]. }
 unit CastleSectors;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleUtils, CastleClassUtils, Classes, CastleVectors, CastleBoxes,

--- a/src/3d/castlespacefillingcurves.pas
+++ b/src/3d/castlespacefillingcurves.pas
@@ -17,6 +17,8 @@
   These are sequences of points that completely fill some 2D space. }
 unit CastleSpaceFillingCurves;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleVectors;

--- a/src/3d/castlespheresampling.pas
+++ b/src/3d/castlespheresampling.pas
@@ -55,6 +55,8 @@
 
 unit CastleSphereSampling;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, CastleUtils;

--- a/src/3d/castlesphericalharmonics.pas
+++ b/src/3d/castlesphericalharmonics.pas
@@ -16,6 +16,8 @@
 { Spherical harmonic basis functions. }
 unit CastleSphericalHarmonics;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, CastleUtils, Math, CastleCubeMaps;

--- a/src/3d/castletriangles.pas
+++ b/src/3d/castletriangles.pas
@@ -43,6 +43,8 @@
 }
 unit CastleTriangles;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleUtils, CastleVectors, CastleGenericLists;

--- a/src/3d/castletriangulate.pas
+++ b/src/3d/castletriangulate.pas
@@ -16,6 +16,8 @@
 { @abstract(Triangulating a polygon.) }
 unit CastleTriangulate;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleVectors, CastleUtils, CastleTriangles;

--- a/src/audio/castlealutils.pas
+++ b/src/audio/castlealutils.pas
@@ -25,6 +25,8 @@
 
 unit CastleALUtils;
 
+{$I castleconf.inc}
+
 interface
 
 {$define read_interface}

--- a/src/audio/castleefx.pas
+++ b/src/audio/castleefx.pas
@@ -19,6 +19,8 @@
   through wine). }
 unit CastleEFX;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, CastleOpenAL, Math;

--- a/src/audio/castleogg.pas
+++ b/src/audio/castleogg.pas
@@ -14,6 +14,7 @@
   original C headers.) }
 unit CastleOgg;
 
+{$I castleconf.inc}
 {$packrecords C}
 
 interface

--- a/src/audio/castlesoundallocator.pas
+++ b/src/audio/castlesoundallocator.pas
@@ -16,6 +16,8 @@
 { 3D sound smart allocation (TSoundAllocator). }
 unit CastleSoundAllocator;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleOpenAL, CastleClassUtils, Classes, CastleUtils, CastleVectors,

--- a/src/audio/castlesoundengine.pas
+++ b/src/audio/castlesoundengine.pas
@@ -16,6 +16,8 @@
 { 3D sound engine (TSoundEngine and TRepoSoundEngine). }
 unit CastleSoundEngine;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, CastleOpenAL, CastleSoundAllocator, CastleVectors,

--- a/src/audio/castlesoundfile.pas
+++ b/src/audio/castlesoundfile.pas
@@ -21,6 +21,8 @@
   initialized are clearly marked as such in the documentation. }
 unit CastleSoundFile;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleUtils, Classes, CastleOpenAL, CastleTimeUtils;

--- a/src/audio/castlevorbiscodec.pas
+++ b/src/audio/castlevorbiscodec.pas
@@ -2,6 +2,7 @@
   @exclude (This is only a C header translation --- no nice PasDoc docs.) }
 unit CastleVorbisCodec;
 
+{$I castleconf.inc}
 {$packrecords C}
 
 interface

--- a/src/audio/castlevorbisdecoder.pas
+++ b/src/audio/castlevorbisdecoder.pas
@@ -1,6 +1,8 @@
 { OggVorbis decoder. }
 unit CastleVorbisDecoder;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, CastleOpenAL;

--- a/src/base/android/castleandroidinternalassetmanager.pas
+++ b/src/base/android/castleandroidinternalassetmanager.pas
@@ -17,6 +17,8 @@
 { @exclude Internal for the engine. }
 unit CastleAndroidInternalAssetManager;
 
+{$I castleconf.inc}
+
 interface
 
 uses ctypes;

--- a/src/base/android/castleandroidinternalassetstream.pas
+++ b/src/base/android/castleandroidinternalassetstream.pas
@@ -16,6 +16,8 @@
 { Reading Android asset files as streams. }
 unit CastleAndroidInternalAssetStream;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, CastleAndroidInternalAssetManager;

--- a/src/base/android/castleandroidinternalconfiguration.pas
+++ b/src/base/android/castleandroidinternalconfiguration.pas
@@ -16,6 +16,8 @@
 
 unit CastleAndroidInternalConfiguration;
 
+{$I castleconf.inc}
+
 interface
 
 uses ctypes, CastleAndroidInternalAssetManager;

--- a/src/base/android/castleandroidinternalcwstring.pas
+++ b/src/base/android/castleandroidinternalcwstring.pas
@@ -21,7 +21,7 @@
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  **********************************************************************}
 
-{$mode objfpc}
+{$I castleconf.inc}
 {$inline on}
 {$implicitexceptions off}
 

--- a/src/base/android/castleandroidinternalinput.pas
+++ b/src/base/android/castleandroidinternalinput.pas
@@ -17,6 +17,8 @@
 { @exclude Internal for the engine. }
 unit CastleAndroidInternalInput;
 
+{$I castleconf.inc}
+
 interface
 
 uses ctypes, CastleAndroidInternalLooper, CastleAndroidInternalKeycodes;

--- a/src/base/android/castleandroidinternalkeycodes.pas
+++ b/src/base/android/castleandroidinternalkeycodes.pas
@@ -22,6 +22,8 @@
 { @exclude Internal for the engine. }
 unit CastleAndroidInternalKeycodes;
 
+{$I castleconf.inc}
+
 interface
 
 uses ctypes;

--- a/src/base/android/castleandroidinternallog.pas
+++ b/src/base/android/castleandroidinternallog.pas
@@ -2,6 +2,8 @@
   @exclude Internal for the engine. }
 unit CastleAndroidInternalLog;
 
+{$I castleconf.inc}
+
 interface
 
 { Based on Android NDK platforms/android-4/arch-arm/usr/include/android/log.h .

--- a/src/base/android/castleandroidinternallooper.pas
+++ b/src/base/android/castleandroidinternallooper.pas
@@ -17,6 +17,8 @@
 { @exclude Internal for the engine. }
 unit CastleAndroidInternalLooper;
 
+{$I castleconf.inc}
+
 interface
 
 uses ctypes;

--- a/src/base/android/castleandroidinternalnativeactivity.pas
+++ b/src/base/android/castleandroidinternalnativeactivity.pas
@@ -17,6 +17,8 @@
 { @exclude Internal for the engine. }
 unit CastleAndroidInternalNativeActivity;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleAndroidInternalAssetManager, CastleAndroidInternalInput, CastleAndroidInternalNativeWindow,

--- a/src/base/android/castleandroidinternalnativewindow.pas
+++ b/src/base/android/castleandroidinternalnativewindow.pas
@@ -17,6 +17,8 @@
 { @exclude Internal for the engine. }
 unit CastleAndroidInternalNativeWindow;
 
+{$I castleconf.inc}
+
 interface
 
 uses ctypes, CastleAndroidInternalRect;

--- a/src/base/android/castleandroidinternalrect.pas
+++ b/src/base/android/castleandroidinternalrect.pas
@@ -16,6 +16,8 @@
 
 unit CastleAndroidInternalRect;
 
+{$I castleconf.inc}
+
 interface
 
 uses ctypes;

--- a/src/base/android/castleandroidnativeappglue.pas
+++ b/src/base/android/castleandroidnativeappglue.pas
@@ -17,6 +17,8 @@
 
 unit CastleAndroidNativeAppGlue;
 
+{$I castleconf.inc}
+
 interface
 
 uses

--- a/src/base/castleapplicationproperties.pas
+++ b/src/base/castleapplicationproperties.pas
@@ -17,6 +17,8 @@
   (TCastleApplicationProperties). }
 unit CastleApplicationProperties;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleClassUtils, CastleGenericLists;

--- a/src/base/castleconf.inc
+++ b/src/base/castleconf.inc
@@ -74,6 +74,12 @@
 {$ifdef VER2_4} {$fatal FPC 2.4.x is not supported anymore, see http://castle-engine.sourceforge.net/engine.php#section_fpc_ver} {$endif}
 {$ifdef VER2_6_0} {$fatal FPC 2.6.0 is not supported anymore, see http://castle-engine.sourceforge.net/engine.php#section_fpc_ver} {$endif}
 
+{ we use ObjFPC mode with AnsiString everywhere }
+{$mode objfpc}{$H+}
+
+{ we use macros in various parts }
+{$macro on}
+
 {$define TOBJECT_HAS_EQUALS}
 {$ifdef VER2_0}   {$undef TOBJECT_HAS_EQUALS} {$endif}
 {$ifdef VER2_2_0} {$undef TOBJECT_HAS_EQUALS} {$endif}

--- a/src/base/castleconfig.pas
+++ b/src/base/castleconfig.pas
@@ -16,6 +16,8 @@
 { Loading and saving user preferences (UserConfig). }
 unit CastleConfig;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleXMLConfig;

--- a/src/base/castledynlib.pas
+++ b/src/base/castledynlib.pas
@@ -16,6 +16,8 @@
 { Dynamic libraries loading (TDynLib). }
 unit CastleDynLib;
 
+{$I castleconf.inc}
+
 interface
 
 uses

--- a/src/base/castlefilefilters.pas
+++ b/src/base/castlefilefilters.pas
@@ -16,6 +16,8 @@
 { File filters, for TCastleWindowCustom.FileDialog and Lazarus file dialogs. }
 unit CastleFileFilters;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, FGL;

--- a/src/base/castlegenericlists.pas
+++ b/src/base/castlegenericlists.pas
@@ -11,7 +11,7 @@
   Some small comfortable methods added. }
 unit CastleGenericLists;
 
-{$mode objfpc}{$H+}
+{$I castleconf.inc}
 
 {$ifdef VER2_2} {$define OldSyntax} {$endif}
 {$ifdef VER2_4} {$define OldSyntax} {$endif}

--- a/src/base/castlegziointernal.pas
+++ b/src/base/castlegziointernal.pas
@@ -41,6 +41,8 @@
   @exclude }
 unit CastleGzioInternal;
 
+{$I castleconf.inc}
+
 interface
 
 uses zbase, crc, zdeflate, zinflate, Classes;

--- a/src/base/castleinterfaces.pas
+++ b/src/base/castleinterfaces.pas
@@ -31,6 +31,8 @@
 { Utilities for interfaces. }
 unit CastleInterfaces;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes;

--- a/src/base/castleprogress.pas
+++ b/src/base/castleprogress.pas
@@ -16,6 +16,8 @@
 { Progress bar functionality (TProgress, global variable Progress). }
 unit CastleProgress;
 
+{$I castleconf.inc}
+
 { Define this only for testing }
 { $define TESTING_PROGRESS_DELAY}
 

--- a/src/base/castlerecentfiles.pas
+++ b/src/base/castlerecentfiles.pas
@@ -16,6 +16,8 @@
 { Manage a list of recently open files (TRecentFiles). }
 unit CastleRecentFiles;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, CastleXMLConfig;

--- a/src/base/castlerectangles.pas
+++ b/src/base/castlerectangles.pas
@@ -16,6 +16,8 @@
 { Rectangle representation (TRectangle, TFloatRectangle). }
 unit CastleRectangles;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleGenericLists, CastleVectors;

--- a/src/base/castleshaders.pas
+++ b/src/base/castleshaders.pas
@@ -1,6 +1,8 @@
 { Shaders types. Independent from OpenGL and X3D. }
 unit CastleShaders;
 
+{$I castleconf.inc}
+
 interface
 
 type

--- a/src/base/castlestringutils.pas
+++ b/src/base/castlestringutils.pas
@@ -39,6 +39,8 @@
 
 unit CastleStringUtils;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, FGL,

--- a/src/base/castleunicode.pas
+++ b/src/base/castleunicode.pas
@@ -19,6 +19,8 @@
 { Unicode utilities. }
 unit CastleUnicode;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleUtils, CastleStringUtils;

--- a/src/base/castlewarnings.pas
+++ b/src/base/castlewarnings.pas
@@ -16,6 +16,8 @@
 { Reporting warnings (OnWarning). }
 unit CastleWarnings;
 
+{$I castleconf.inc}
+
 interface
 
 type

--- a/src/base/castlexmlcfginternal.pas
+++ b/src/base/castlexmlcfginternal.pas
@@ -42,11 +42,10 @@
   configuration data
 }
 
-{$ifdef fpc}{$MODE objfpc}{$endif}
-{$H+}
-
 { @exclude Not ready for PasDoc, also internal. }
 unit CastleXMLCfgInternal;
+
+{$I castleconf.inc}
 
 interface
 

--- a/src/base/castlexmlconfig.pas
+++ b/src/base/castlexmlconfig.pas
@@ -16,6 +16,8 @@
 { Storing configuration files in XML (TCastleConfig). }
 unit CastleXMLConfig;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, DOM,

--- a/src/base/castlezstream.pas
+++ b/src/base/castlezstream.pas
@@ -29,6 +29,8 @@
   the only class useful for reading/writing gz files. }
 unit CastleZStream;
 
+{$I castleconf.inc}
+
 interface
 
 uses

--- a/src/base/opengl/castlegles20.pas
+++ b/src/base/opengl/castlegles20.pas
@@ -38,7 +38,6 @@
  ** 2.0. For details, see http://oss.sgi.com/projects/FreeB/
  **}
 unit CastleGLES20;
-{$mode objfpc}
 {$i castleconf.inc}
 
 {$ifdef linux}

--- a/src/castlescript/castlenoise.pas
+++ b/src/castlescript/castlenoise.pas
@@ -16,6 +16,8 @@
 { Generating noise. }
 unit CastleNoise;
 
+{$I castleconf.inc}
+
 interface
 
 { Noise for 2D coords, resulting in float 0..1 range.

--- a/src/castlescript/castlescript.pas
+++ b/src/castlescript/castlescript.pas
@@ -64,6 +64,8 @@
 }
 unit CastleScript;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Math, Contnrs, CastleUtils, CastleClassUtils, Classes, FGL;

--- a/src/castlescript/castlescriptarrays.pas
+++ b/src/castlescript/castlescriptarrays.pas
@@ -16,6 +16,8 @@
 { CastleScript array types and built-in functions. }
 unit CastleScriptArrays;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, CastleScript, CastleScriptVectors, CastleUtils, CastleStringUtils;

--- a/src/castlescript/castlescriptconfig.pas
+++ b/src/castlescript/castlescriptconfig.pas
@@ -17,6 +17,8 @@
   (TCastleConfigScriptHelper). }
 unit CastleScriptConfig;
 
+{$I castleconf.inc}
+
 interface
 
 uses Math,

--- a/src/castlescript/castlescriptcorefunctions.pas
+++ b/src/castlescript/castlescriptcorefunctions.pas
@@ -16,6 +16,8 @@
 { CastleScript built-in simple functions on four "core" types. }
 unit CastleScriptCoreFunctions;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleScript;

--- a/src/castlescript/castlescriptimages.pas
+++ b/src/castlescript/castlescriptimages.pas
@@ -16,6 +16,8 @@
 { CastleScript image types and built-in functions. }
 unit CastleScriptImages;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, CastleScript, CastleImages;

--- a/src/castlescript/castlescriptlexer.pas
+++ b/src/castlescript/castlescriptlexer.pas
@@ -21,6 +21,8 @@
 
 unit CastleScriptLexer;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleUtils, CastleScript, SysUtils, Math;

--- a/src/castlescript/castlescriptparser.pas
+++ b/src/castlescript/castlescriptparser.pas
@@ -25,6 +25,8 @@
 
 unit CastleScriptParser;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleScript, CastleScriptLexer, Math;

--- a/src/castlescript/castlescriptvectors.pas
+++ b/src/castlescript/castlescriptvectors.pas
@@ -16,6 +16,8 @@
 { CastleScript vector and matrix types and built-in functions. }
 unit CastleScriptVectors;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, CastleScript;

--- a/src/components/castlecontrol.pas
+++ b/src/components/castlecontrol.pas
@@ -18,7 +18,6 @@
 unit CastleControl;
 
 {$I castleconf.inc}
-{$mode objfpc}{$H+}
 
 interface
 

--- a/src/components/castledialogs.pas
+++ b/src/components/castledialogs.pas
@@ -16,6 +16,8 @@
 { Dialog windows. }
 unit CastleDialogs;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, Dialogs, ExtDlgs;

--- a/src/components/castlelclrecentfiles.pas
+++ b/src/components/castlelclrecentfiles.pas
@@ -17,6 +17,8 @@
   See TRecentFiles class. }
 unit CastleLCLRecentFiles;
 
+{$I castleconf.inc}
+
 interface
 
 uses Menus, CastleRecentFiles;

--- a/src/components/castlelclutils.pas
+++ b/src/components/castlelclutils.pas
@@ -16,6 +16,8 @@
 { Utilities for cooperation between LCL and "Castle Game Engine". }
 unit CastleLCLUtils;
 
+{$I castleconf.inc}
+
 interface
 
 uses Dialogs, Classes, Controls, CastleFileFilters, CastleKeysMouse,

--- a/src/components/castlepropedits.pas
+++ b/src/components/castlepropedits.pas
@@ -21,6 +21,8 @@
   by PasDoc. It's only for Lazarus registration.) }
 unit CastlePropEdits;
 
+{$I castleconf.inc}
+
 interface
 
 procedure Register;

--- a/src/fonts/castlefont2pascal.pas
+++ b/src/fonts/castlefont2pascal.pas
@@ -16,6 +16,8 @@
 { Converting fonts (TTextureFontData) to Pascal source code. }
 unit CastleFont2Pascal;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleTextureFontData, Classes;

--- a/src/fonts/castlefreetype.pas
+++ b/src/fonts/castlefreetype.pas
@@ -30,9 +30,10 @@
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
  **********************************************************************}
-{$mode objfpc}{$h+}
 { @exclude Not ready for PasDoc. }
 unit CastleFreeType;
+
+{$I castleconf.inc}
 
 interface
 

--- a/src/fonts/castlefreetypeh.pas
+++ b/src/fonts/castlefreetypeh.pas
@@ -29,7 +29,6 @@
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
  **********************************************************************}
-{$mode objfpc}
 { @exclude Not ready for PasDoc. }
 unit CastleFreeTypeH;
 

--- a/src/fonts/castleftfont.pas
+++ b/src/fonts/castleftfont.pas
@@ -24,9 +24,10 @@
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
  **********************************************************************}
-{$mode objfpc}{$h+}
 { @exclude Not ready for PasDoc. }
 unit CastleFtFont;
+
+{$I castleconf.inc}
 
 interface
 

--- a/src/fonts/windows/castlewindowsfonts.pas
+++ b/src/fonts/windows/castlewindowsfonts.pas
@@ -17,6 +17,8 @@
 
 unit CastleWindowsFonts;
 
+{$I castleconf.inc}
+
 interface
 
 uses Windows, SysUtils, CastleUtils;

--- a/src/game/castle2dscenemanager.pas
+++ b/src/game/castle2dscenemanager.pas
@@ -16,6 +16,8 @@
 { Scene manager (T2DSceneManager) and scene (T2DScene) best suited for 2D worlds. }
 unit Castle2DSceneManager;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes,

--- a/src/game/castlegamenotifications.pas
+++ b/src/game/castlegamenotifications.pas
@@ -18,6 +18,8 @@
   them as notifications. }
 unit CastleGameNotifications;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleNotifications;

--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -17,6 +17,8 @@
   management of available game levels (TLevelInfo, @link(Levels)). }
 unit CastleLevels;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, DOM, FGL,

--- a/src/game/castleresources.pas
+++ b/src/game/castleresources.pas
@@ -17,6 +17,8 @@
   that need to be loaded and reference counted. }
 unit CastleResources;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, DOM, FGL,

--- a/src/images/castlecompositeimage.pas
+++ b/src/images/castlecompositeimage.pas
@@ -16,6 +16,8 @@
 { Composite (like DDS) image file format handling (TCompositeImage). }
 unit CastleCompositeImage;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, CastleImages;

--- a/src/images/castlepng_dynamic.inc
+++ b/src/images/castlepng_dynamic.inc
@@ -64,8 +64,6 @@
 
 unit CastlePng;
 
-{$I castleconf.inc}
-
 interface
 
 uses CastleZLib;

--- a/src/images/castletextureimages.pas
+++ b/src/images/castletextureimages.pas
@@ -30,6 +30,8 @@
   that only returns TCastleImage (a "normal" way to deal with image data). }
 unit CastleTextureImages;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleImages, CastleCompositeImage, CastleUtils, FGL, CastleVideos;

--- a/src/images/castlevideos.pas
+++ b/src/images/castlevideos.pas
@@ -16,6 +16,8 @@
 { Video (movie) data (TVideo and helpers). }
 unit CastleVideos;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, FGL,

--- a/src/images/opengl/castlescreeneffects.pas
+++ b/src/images/opengl/castlescreeneffects.pas
@@ -16,6 +16,8 @@
 { Utilities for creating custom screen effects. }
 unit CastleScreenEffects;
 
+{$I castleconf.inc}
+
 interface
 
 { Standard GLSL vertex shader for screen effect. }

--- a/src/library/castlelib_dynloader.pas
+++ b/src/library/castlelib_dynloader.pas
@@ -39,6 +39,8 @@
 
 unit castlelib_dynloader;
 
+{$I castleconf.inc}
+
 interface
 uses
   ctypes;

--- a/src/net/castledatauri.pas
+++ b/src/net/castledatauri.pas
@@ -15,6 +15,8 @@
 { Reading data URI scheme (TDataURI). }
 unit CastleDataURI;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes;

--- a/src/net/castleuriutils.pas
+++ b/src/net/castleuriutils.pas
@@ -16,6 +16,8 @@
 { URI utilities. These extend standard FPC URIParser unit. }
 unit CastleURIUtils;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes;

--- a/src/services/castleads.pas
+++ b/src/services/castleads.pas
@@ -16,6 +16,8 @@
 { Ads (advertisements) in game (TAds). }
 unit CastleAds;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, CastleRectangles, CastleStringUtils;

--- a/src/services/castleanalytics.pas
+++ b/src/services/castleanalytics.pas
@@ -16,6 +16,8 @@
 { Analytics (TAnalytics). }
 unit CastleAnalytics;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, CastleTimeUtils;

--- a/src/services/castlegiftiz.pas
+++ b/src/services/castlegiftiz.pas
@@ -16,6 +16,8 @@
 { Giftiz (http://www.giftiz.com/) integration (TGiftiz). }
 unit CastleGiftiz;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes,

--- a/src/services/castlegoogleplaygames.pas
+++ b/src/services/castlegoogleplaygames.pas
@@ -16,6 +16,8 @@
 { Google Play Game Services integration (TGooglePlayGames). }
 unit CastleGooglePlayGames;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes,

--- a/src/services/castleinapppurchases.pas
+++ b/src/services/castleinapppurchases.pas
@@ -16,6 +16,8 @@
 { In-app purchases (TInAppPurchases). }
 unit CastleInAppPurchases;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, FGL,

--- a/src/services/castlemessaging.pas
+++ b/src/services/castlemessaging.pas
@@ -17,6 +17,8 @@
   (TMessaging). }
 unit CastleMessaging;
 
+{$I castleconf.inc}
+
 interface
 
 uses {$ifdef ANDROID} JNI, {$endif} SyncObjs,

--- a/src/ui/castleinputs.pas
+++ b/src/ui/castleinputs.pas
@@ -84,6 +84,8 @@
   to the final application. }
 unit CastleInputs;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, FGL,

--- a/src/ui/castlejoysticks.pas
+++ b/src/ui/castlejoysticks.pas
@@ -22,6 +22,8 @@
 { Receiving input from joysticks and gamepads. }
 unit CastleJoysticks;
 
+{$I castleconf.inc}
+
 interface
 
 {$IFDEF LINUX}

--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -18,6 +18,8 @@
   and by non-Lazarus CastleWindow. }
 unit CastleKeysMouse;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleUtils, CastleStringUtils, CastleVectors, CastleXMLConfig;

--- a/src/ui/castleuicontrols.pas
+++ b/src/ui/castleuicontrols.pas
@@ -17,6 +17,8 @@
 { User interface (2D) basic classes: @link(TUIControl) and @link(TUIContainer). }
 unit CastleUIControls;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, FGL,

--- a/src/ui/opengl/castlecontrols.pas
+++ b/src/ui/opengl/castlecontrols.pas
@@ -16,6 +16,8 @@
 { Standard 2D controls: buttons, labels, sliders etc. }
 unit CastleControls;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, CastleVectors, CastleUIControls, CastleFonts, CastleTextureFontData,

--- a/src/ui/opengl/castlecontrolsimages.pas
+++ b/src/ui/opengl/castlecontrolsimages.pas
@@ -7,6 +7,8 @@ unit CastleControlsImages;
 
 interface
 
+{$I castleconf.inc}
+
 uses CastleImages;
 
 var

--- a/src/ui/opengl/castleflasheffect.pas
+++ b/src/ui/opengl/castleflasheffect.pas
@@ -16,6 +16,8 @@
 { Screen effects done by blending screen with given color (TCastleFlashEffect). }
 unit CastleFlashEffect;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes,

--- a/src/ui/opengl/castleinspectorcontrol.pas
+++ b/src/ui/opengl/castleinspectorcontrol.pas
@@ -16,6 +16,8 @@
 { Inspector of 2D controls (@link(TCastleInspectorControl)). }
 unit CastleInspectorControl;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes,

--- a/src/ui/opengl/castlenotifications.pas
+++ b/src/ui/opengl/castlenotifications.pas
@@ -16,6 +16,8 @@
 { Notifications displayed in the OpenGL window (TCastleNotifications). }
 unit CastleNotifications;
 
+{$I castleconf.inc}
+
 interface
 
 uses FGL,

--- a/src/ui/pk3dconnexion.pas
+++ b/src/ui/pk3dconnexion.pas
@@ -48,6 +48,8 @@ unit pk3DConnexion;
 
 { TODO -oPatrick : React to newly connected devices! }
 
+{$I castleconf.inc}
+
 interface
 
 {$ifdef MSWINDOWS}

--- a/src/ui/windows/tdxinput_tlb.pas
+++ b/src/ui/windows/tdxinput_tlb.pas
@@ -42,6 +42,7 @@ unit TDxInput_TLB;
 // removing them from the $IFDEF blocks. However, such items must still be    
 // programmatically created via a method of the appropriate CoClass before    
 // they can be used.                                                          
+{$I castleconf.inc}
 {$TYPEDADDRESS OFF} // Unit must be compiled without type-checked pointers. 
 {$WARN SYMBOL_PLATFORM OFF}
 {$WRITEABLECONST ON}

--- a/src/window/castlenpapi.pas
+++ b/src/window/castlenpapi.pas
@@ -22,6 +22,8 @@
 }
 unit CastleNPAPI;
 
+{$I castleconf.inc}
+
 {$PACKRECORDS C}
 {$PACKENUM 4} // is default in ObjPas anyway, see http://www.freepascal.org/docs-html/prog/progsu59.html
 

--- a/src/window/castlesoundmenu.pas
+++ b/src/window/castlesoundmenu.pas
@@ -16,6 +16,8 @@
 { Menu items (suitable for TCastleOnScreenMenu) to control the TRepoSoundEngine. }
 unit CastleSoundMenu;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleWindow, CastleOnScreenMenu, CastleSoundEngine, CastleUIControls,

--- a/src/window/castlewindowrecentfiles.pas
+++ b/src/window/castlewindowrecentfiles.pas
@@ -17,6 +17,8 @@
   See TRecentFiles class. }
 unit CastleWindowRecentFiles;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, CastleWindow, CastleRecentFiles;

--- a/src/window/castlewindowtouch.pas
+++ b/src/window/castlewindowtouch.pas
@@ -16,6 +16,8 @@
 { Window with controls for easy navigation on touch interfaces. }
 unit CastleWindowTouch;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, CastleWindow, CastleControls, CastleCameras;

--- a/src/window/unix/castleglx.pas
+++ b/src/window/unix/castleglx.pas
@@ -35,6 +35,8 @@
 { @exclude (This is only a C header translation --- no nice PasDoc docs.) }
 unit CastleGlx;
 
+{$I castleconf.inc}
+
 interface
 
 {$MACRO ON}

--- a/src/window/unix/castlexf86vmode.pas
+++ b/src/window/unix/castlexf86vmode.pas
@@ -56,6 +56,8 @@
 
 unit CastleXF86VMode;
 
+{$I castleconf.inc}
+
 {$ifdef VER1_0_10}
   {$FATAL This unit cannot be safely
     used with FPC 1.0.10 due to some bugs in compiler (that were not present

--- a/src/x3d/castlearraysgenerator.pas
+++ b/src/x3d/castlearraysgenerator.pas
@@ -16,6 +16,8 @@
 { Generating TGeometryArrays for VRML/X3D shapes (TArraysGenerator). }
 unit CastleArraysGenerator;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleShapes, X3DNodes, X3DFields, CastleUtils, CastleGeometryArrays,

--- a/src/x3d/castleinternalnodeinterpolator.pas
+++ b/src/x3d/castleinternalnodeinterpolator.pas
@@ -17,6 +17,8 @@
   used by CastlePrecalculatedAnimation now. }
 unit CastleInternalNodeInterpolator;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes,

--- a/src/x3d/castleinternalnormals.pas
+++ b/src/x3d/castleinternalnormals.pas
@@ -21,6 +21,8 @@
   So it can be used in other situations too. }
 unit CastleInternalNormals;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, CastleUtils, CastleVectors, X3DNodes;

--- a/src/x3d/castlematerialproperties.pas
+++ b/src/x3d/castlematerialproperties.pas
@@ -17,6 +17,8 @@
   global MaterialProperties collection). }
 unit CastleMaterialProperties;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, DOM, FGL,

--- a/src/x3d/castlerenderingcamera.pas
+++ b/src/x3d/castlerenderingcamera.pas
@@ -16,6 +16,8 @@
 { @abstract(Current rendering camera (TRenderingCamera).) }
 unit CastleRenderingCamera;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleUtils, CastleVectors, CastleFrustum, CastleCameras, CastleGenericLists, X3DNodes;

--- a/src/x3d/castlescenecore.pas
+++ b/src/x3d/castlescenecore.pas
@@ -17,6 +17,7 @@
 
 unit CastleSceneCore;
 
+{$I castleconf.inc}
 {$I octreeconf.inc}
 
 interface

--- a/src/x3d/castleshapeinternalshadowvolumes.pas
+++ b/src/x3d/castleshapeinternalshadowvolumes.pas
@@ -15,6 +15,8 @@
 { Internal data for shadow volumes rendering in shapes. }
 unit CastleShapeInternalShadowVolumes;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleGenericLists, CastleVectors, CastleTriangles;

--- a/src/x3d/castleshapeoctree.pas
+++ b/src/x3d/castleshapeoctree.pas
@@ -32,6 +32,7 @@
 
 unit CastleShapeOctree;
 
+{$I castleconf.inc}
 {$I octreeconf.inc}
 
 interface

--- a/src/x3d/castleshapes.pas
+++ b/src/x3d/castleshapes.pas
@@ -16,6 +16,8 @@
 { Shape (TShape class) and a simple tree of shapes (TShapeTree class). }
 unit CastleShapes;
 
+{$I castleconf.inc}
+
 { $define SHAPE_ITERATOR_SOPHISTICATED}
 
 {$I octreeconf.inc}

--- a/src/x3d/castleterrain.pas
+++ b/src/x3d/castleterrain.pas
@@ -16,6 +16,8 @@
 { Terrain (height map) implementations. }
 unit CastleTerrain;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, CastleScript, CastleImages, X3DNodes,

--- a/src/x3d/castletriangleoctree.pas
+++ b/src/x3d/castletriangleoctree.pas
@@ -16,6 +16,8 @@
 { Triangle octrees (TTriangleOctree). }
 unit CastleTriangleOctree;
 
+{$I castleconf.inc}
+
 {
   TODO
   - Right now, since we keep pointers to TTriangle created by TCastleSceneCore,

--- a/src/x3d/opengl/castlebackground.pas
+++ b/src/x3d/opengl/castlebackground.pas
@@ -16,6 +16,8 @@
 { Background for 3D world (TBackground). }
 unit CastleBackground;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, SysUtils, CastleUtils, CastleImages, X3DNodes,

--- a/src/x3d/opengl/castleprecalculatedanimation.pas
+++ b/src/x3d/opengl/castleprecalculatedanimation.pas
@@ -17,6 +17,8 @@
 unit CastlePrecalculatedAnimation
   deprecated 'instead of TCastlePrecalculatedAnimation, use TCastleScene to load animations in any format (X3D, KAnim...) and run them using methods like PlayAnimation';
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, FGL,

--- a/src/x3d/opengl/castlerendererinternaltextureenv.pas
+++ b/src/x3d/opengl/castlerendererinternaltextureenv.pas
@@ -17,6 +17,8 @@
   @exclude Internal unit for CastleRenderer and CastleRendererInternalShader. }
 unit CastleRendererInternalTextureEnv;
 
+{$I castleconf.inc}
+
 interface
 
 type

--- a/src/x3d/x3dcamerautils.pas
+++ b/src/x3d/x3dcamerautils.pas
@@ -18,6 +18,8 @@
     for camera handling.) }
 unit X3DCameraUtils;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleUtils, CastleVectors, CastleBoxes, X3DNodes;

--- a/src/x3d/x3dcastlescript.pas
+++ b/src/x3d/x3dcastlescript.pas
@@ -16,6 +16,8 @@
 { CastleScript utilities for usage as VRML/X3D scripts. }
 unit X3DCastleScript;
 
+{$I castleconf.inc}
+
 interface
 
 uses X3DFields, CastleScript, CastleUtils, CastleClassUtils, X3DTime;

--- a/src/x3d/x3dfields.pas
+++ b/src/x3d/x3dfields.pas
@@ -16,6 +16,8 @@
 { X3D fields (TX3DField and many descendants). }
 unit X3DFields;
 
+{$I castleconf.inc}
+
 interface
 
 uses Classes, SysUtils, DOM, FGL,

--- a/src/x3d/x3dload.pas
+++ b/src/x3d/x3dload.pas
@@ -59,6 +59,8 @@
 }
 unit X3DLoad;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, SysUtils, X3DNodes, X3DLoadInternalMD3,

--- a/src/x3d/x3dloadinternal3ds.pas
+++ b/src/x3d/x3dloadinternal3ds.pas
@@ -17,6 +17,8 @@
 
 unit X3DLoadInternal3DS;
 
+{$I castleconf.inc}
+
 interface
 
 uses X3DNodes;

--- a/src/x3d/x3dloadinternalgeo.pas
+++ b/src/x3d/x3dloadinternalgeo.pas
@@ -18,6 +18,8 @@
   We handle basic geometry, we can open files exported by Blender exporter. }
 unit X3DLoadInternalGEO;
 
+{$I castleconf.inc}
+
 interface
 
 uses X3DNodes;

--- a/src/x3d/x3dloadinternalmd3.pas
+++ b/src/x3d/x3dloadinternalmd3.pas
@@ -17,6 +17,8 @@
   [http://icculus.org/homepages/phaethon/q3a/formats/md3format.html]. }
 unit X3DLoadInternalMD3;
 
+{$I castleconf.inc}
+
 interface
 
 uses SysUtils, Classes, CastleUtils, CastleClassUtils, CastleVectors, X3DNodes,

--- a/src/x3d/x3dloadinternalobj.pas
+++ b/src/x3d/x3dloadinternalobj.pas
@@ -19,6 +19,8 @@
   Texture URL is also read from material file. }
 unit X3DLoadInternalOBJ;
 
+{$I castleconf.inc}
+
 interface
 
 uses X3DNodes;

--- a/src/x3d/x3dloadinternalspine.pas
+++ b/src/x3d/x3dloadinternalspine.pas
@@ -16,6 +16,8 @@
 { Spine 2D animations loader. }
 unit X3DLoadInternalSpine;
 
+{$I castleconf.inc}
+
 interface
 
 uses X3DNodes;

--- a/src/x3d/x3dloadinternalutils.pas
+++ b/src/x3d/x3dloadinternalutils.pas
@@ -16,6 +16,8 @@
 { Utilities for converting other 3D model formats into VRML/X3D. }
 unit X3DLoadInternalUtils;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleVectors, X3DNodes;

--- a/src/x3d/x3dnodesdetailoptions.pas
+++ b/src/x3d/x3dnodesdetailoptions.pas
@@ -16,6 +16,8 @@
 { Parsing command-line options that control the quadric rendering quality. }
 unit X3DNodesDetailOptions;
 
+{$I castleconf.inc}
+
 interface
 
 { Parses @--detail-xxx command-line options, and sets Detail_Xxx variables

--- a/src/x3d/x3dshadowmaps.pas
+++ b/src/x3d/x3dshadowmaps.pas
@@ -16,6 +16,7 @@
 { Shadow maps internal utilities. }
 unit X3DShadowMaps;
 
+{$I castleconf.inc}
 {$modeswitch nestedprocvars}{$H+}
 
 interface

--- a/src/x3d/x3dtime.pas
+++ b/src/x3d/x3dtime.pas
@@ -16,6 +16,8 @@
 { X3D time. }
 unit X3DTime;
 
+{$I castleconf.inc}
+
 interface
 
 uses CastleUtils, CastleTimeUtils, CastleGenericLists;

--- a/src/x3d/x3dtriangles.pas
+++ b/src/x3d/x3dtriangles.pas
@@ -17,6 +17,7 @@
   that resolve collisions with such triangles (TBaseTrianglesOctree). }
 unit X3DTriangles;
 
+{$I castleconf.inc}
 {$I octreeconf.inc}
 
 interface


### PR DESCRIPTION
When checking out some of the FPC bugs you worked around for I also noticed that compiling the engine from the commandline (without using fpmake or Lazarus) requires the mode and the string type to be set. Because of this I decided to add the necessary switches to castleconf.inc and add this include to every unit that doesn't have this yet. This way the units are always compiled the same no matter what default settings are used.