### PR TITLE
Big endian fixes

### DIFF
--- a/fpmake.pp
+++ b/fpmake.pp
@@ -131,6 +131,7 @@ begin
     P.Targets.AddUnit('castleprogress.pas');
     P.Targets.AddUnit('castlerectangles.pas');
     P.Targets.AddUnit('castlestringutils.pas');
+    P.Targets.AddUnit('castlestreamutils.pas');
     P.Targets.AddUnit('castletimeutils.pas');
     P.Targets.AddUnit('castleunicode.pas');
     P.Targets.AddUnit('castleutils.pas');

--- a/packages/castle_base.lpk
+++ b/packages/castle_base.lpk
@@ -36,7 +36,7 @@
     <License Value="GNU GPL >= 2
 (or LGPL >= 2, if compiled with CASTLE_ENGINE_LGPL)"/>
     <Version Major="5" Minor="2"/>
-    <Files Count="349">
+    <Files Count="350">
       <Item1>
         <Filename Value="../src/3d/castle3d.pas"/>
         <UnitName Value="Castle3D"/>
@@ -1441,6 +1441,10 @@
         <Filename Value="../src/x3d/x3dtriangles.pas"/>
         <UnitName Value="X3DTriangles"/>
       </Item349>
+      <Item350>
+        <Filename Value="../src/base/castlestreamutils.pas"/>
+        <UnitName Value="CastleStreamUtils"/>
+      </Item350>
     </Files>
     <RequiredPkgs Count="1">
       <Item1>
@@ -1455,5 +1459,8 @@
       <Version Value="2"/>
       <IgnoreBinaries Value="False"/>
     </PublishOptions>
+    <CustomOptions Items="ExternHelp" Version="2">
+      <_ExternHelp Items="Count"/>
+    </CustomOptions>
   </Package>
 </CONFIG>

--- a/packages/castle_base.lpk
+++ b/packages/castle_base.lpk
@@ -230,1220 +230,1220 @@
         <UnitName Value="CastleShaders"/>
       </Item48>
       <Item49>
-        <Filename Value="../src/base/castlestringutils.pas"/>
-        <UnitName Value="CastleStringUtils"/>
+        <Filename Value="../src/base/castlestreamutils.pas"/>
+        <UnitName Value="CastleStreamUtils"/>
       </Item49>
       <Item50>
-        <Filename Value="../src/base/castletimeutils.pas"/>
-        <UnitName Value="CastleTimeUtils"/>
+        <Filename Value="../src/base/castlestringutils.pas"/>
+        <UnitName Value="CastleStringUtils"/>
       </Item50>
       <Item51>
-        <Filename Value="../src/base/castleunicode.pas"/>
-        <UnitName Value="CastleUnicode"/>
+        <Filename Value="../src/base/castletimeutils.pas"/>
+        <UnitName Value="CastleTimeUtils"/>
       </Item51>
       <Item52>
-        <Filename Value="../src/base/castleutils.pas"/>
-        <UnitName Value="CastleUtils"/>
+        <Filename Value="../src/base/castleunicode.pas"/>
+        <UnitName Value="CastleUnicode"/>
       </Item52>
       <Item53>
-        <Filename Value="../src/base/castleutils_basic_algorithms.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/base/castleutils.pas"/>
+        <UnitName Value="CastleUtils"/>
       </Item53>
       <Item54>
-        <Filename Value="../src/base/castleutils_filenames.inc"/>
+        <Filename Value="../src/base/castleutils_basic_algorithms.inc"/>
         <Type Value="Include"/>
       </Item54>
       <Item55>
-        <Filename Value="../src/base/castleutils_implement_sort.inc"/>
+        <Filename Value="../src/base/castleutils_filenames.inc"/>
         <Type Value="Include"/>
       </Item55>
       <Item56>
-        <Filename Value="../src/base/castleutils_math.inc"/>
+        <Filename Value="../src/base/castleutils_implement_sort.inc"/>
         <Type Value="Include"/>
       </Item56>
       <Item57>
-        <Filename Value="../src/base/castleutils_miscella.inc"/>
+        <Filename Value="../src/base/castleutils_math.inc"/>
         <Type Value="Include"/>
       </Item57>
       <Item58>
-        <Filename Value="../src/base/castleutils_pointers.inc"/>
+        <Filename Value="../src/base/castleutils_miscella.inc"/>
         <Type Value="Include"/>
       </Item58>
       <Item59>
-        <Filename Value="../src/base/castleutils_primitive_lists.inc"/>
+        <Filename Value="../src/base/castleutils_pointers.inc"/>
         <Type Value="Include"/>
       </Item59>
       <Item60>
-        <Filename Value="../src/base/castleutils_program_exit.inc"/>
+        <Filename Value="../src/base/castleutils_primitive_lists.inc"/>
         <Type Value="Include"/>
       </Item60>
       <Item61>
-        <Filename Value="../src/base/castleutils_read_write.inc"/>
+        <Filename Value="../src/base/castleutils_program_exit.inc"/>
         <Type Value="Include"/>
       </Item61>
       <Item62>
-        <Filename Value="../src/base/castlevectors.pas"/>
-        <UnitName Value="CastleVectors"/>
+        <Filename Value="../src/base/castleutils_read_write.inc"/>
+        <Type Value="Include"/>
       </Item62>
       <Item63>
-        <Filename Value="../src/base/castlevectors_dualimplementation.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/base/castlevectors.pas"/>
+        <UnitName Value="CastleVectors"/>
       </Item63>
       <Item64>
-        <Filename Value="../src/base/castlevectors_operators.inc"/>
+        <Filename Value="../src/base/castlevectors_dualimplementation.inc"/>
         <Type Value="Include"/>
       </Item64>
       <Item65>
-        <Filename Value="../src/base/castlevectors_operators_matrix_implementation.inc"/>
+        <Filename Value="../src/base/castlevectors_operators.inc"/>
         <Type Value="Include"/>
       </Item65>
       <Item66>
-        <Filename Value="../src/base/castlevectors_operators_vector_implementation.inc"/>
+        <Filename Value="../src/base/castlevectors_operators_matrix_implementation.inc"/>
         <Type Value="Include"/>
       </Item66>
       <Item67>
-        <Filename Value="../src/base/castlevectors_trysimpleplanexxxintersection.inc"/>
+        <Filename Value="../src/base/castlevectors_operators_vector_implementation.inc"/>
         <Type Value="Include"/>
       </Item67>
       <Item68>
-        <Filename Value="../src/base/castlevectors_vector3fromstr.inc"/>
+        <Filename Value="../src/base/castlevectors_trysimpleplanexxxintersection.inc"/>
         <Type Value="Include"/>
       </Item68>
       <Item69>
-        <Filename Value="../src/base/castlewarnings.pas"/>
-        <UnitName Value="CastleWarnings"/>
+        <Filename Value="../src/base/castlevectors_vector3fromstr.inc"/>
+        <Type Value="Include"/>
       </Item69>
       <Item70>
-        <Filename Value="../src/base/castlexmlcfginternal.pas"/>
-        <UnitName Value="CastleXMLCfgInternal"/>
+        <Filename Value="../src/base/castlewarnings.pas"/>
+        <UnitName Value="CastleWarnings"/>
       </Item70>
       <Item71>
+        <Filename Value="../src/base/castlexmlcfginternal.pas"/>
+        <UnitName Value="CastleXMLCfgInternal"/>
+      </Item71>
+      <Item72>
         <Filename Value="../src/base/castlexmlconfig.pas"/>
         <HasRegisterProc Value="True"/>
         <UnitName Value="CastleXMLConfig"/>
-      </Item71>
-      <Item72>
-        <Filename Value="../src/base/castlexmlutils.pas"/>
-        <UnitName Value="CastleXMLUtils"/>
       </Item72>
       <Item73>
-        <Filename Value="../src/base/castlezlib.pas"/>
-        <UnitName Value="CastleZLib"/>
+        <Filename Value="../src/base/castlexmlutils.pas"/>
+        <UnitName Value="CastleXMLUtils"/>
       </Item73>
       <Item74>
-        <Filename Value="../src/base/castlezstream.pas"/>
-        <UnitName Value="CastleZStream"/>
+        <Filename Value="../src/base/castlezlib.pas"/>
+        <UnitName Value="CastleZLib"/>
       </Item74>
       <Item75>
-        <Filename Value="../src/base/ios/castleiosappglue.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/base/castlezstream.pas"/>
+        <UnitName Value="CastleZStream"/>
       </Item75>
       <Item76>
-        <Filename Value="../src/base/norqcheckbegin.inc"/>
+        <Filename Value="../src/base/ios/castleiosappglue.inc"/>
         <Type Value="Include"/>
       </Item76>
       <Item77>
-        <Filename Value="../src/base/norqcheckend.inc"/>
+        <Filename Value="../src/base/norqcheckbegin.inc"/>
         <Type Value="Include"/>
       </Item77>
       <Item78>
+        <Filename Value="../src/base/norqcheckend.inc"/>
+        <Type Value="Include"/>
+      </Item78>
+      <Item79>
         <Filename Value="../src/base/opengl/castlegles20.pas"/>
         <AddToUsesPkgSection Value="False"/>
         <UnitName Value="CastleGLES20"/>
-      </Item78>
-      <Item79>
-        <Filename Value="../src/base/opengl/castleglversion.pas"/>
-        <UnitName Value="CastleGLVersion"/>
       </Item79>
       <Item80>
-        <Filename Value="../src/base/opengl/openglmac.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/base/opengl/castleglversion.pas"/>
+        <UnitName Value="CastleGLVersion"/>
       </Item80>
       <Item81>
-        <Filename Value="../src/base/unix/castleutils_os_specific_unix.inc"/>
+        <Filename Value="../src/base/opengl/openglmac.inc"/>
         <Type Value="Include"/>
       </Item81>
       <Item82>
-        <Filename Value="../src/base/windows/castleutils_os_specific_windows.inc"/>
+        <Filename Value="../src/base/unix/castleutils_os_specific_unix.inc"/>
         <Type Value="Include"/>
       </Item82>
       <Item83>
-        <Filename Value="../src/castlescript/castlenoise.pas"/>
-        <UnitName Value="CastleNoise"/>
+        <Filename Value="../src/base/windows/castleutils_os_specific_windows.inc"/>
+        <Type Value="Include"/>
       </Item83>
       <Item84>
-        <Filename Value="../src/castlescript/castlescript.pas"/>
-        <UnitName Value="CastleScript"/>
+        <Filename Value="../src/castlescript/castlenoise.pas"/>
+        <UnitName Value="CastleNoise"/>
       </Item84>
       <Item85>
-        <Filename Value="../src/castlescript/castlescriptarrays.pas"/>
-        <UnitName Value="CastleScriptArrays"/>
+        <Filename Value="../src/castlescript/castlescript.pas"/>
+        <UnitName Value="CastleScript"/>
       </Item85>
       <Item86>
-        <Filename Value="../src/castlescript/castlescriptarrays_implement.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/castlescript/castlescriptarrays.pas"/>
+        <UnitName Value="CastleScriptArrays"/>
       </Item86>
       <Item87>
-        <Filename Value="../src/castlescript/castlescriptconfig.pas"/>
-        <UnitName Value="CastleScriptConfig"/>
+        <Filename Value="../src/castlescript/castlescriptarrays_implement.inc"/>
+        <Type Value="Include"/>
       </Item87>
       <Item88>
-        <Filename Value="../src/castlescript/castlescriptcorefunctions.pas"/>
-        <UnitName Value="CastleScriptCoreFunctions"/>
+        <Filename Value="../src/castlescript/castlescriptconfig.pas"/>
+        <UnitName Value="CastleScriptConfig"/>
       </Item88>
       <Item89>
-        <Filename Value="../src/castlescript/castlescriptimages.pas"/>
-        <UnitName Value="CastleScriptImages"/>
+        <Filename Value="../src/castlescript/castlescriptcorefunctions.pas"/>
+        <UnitName Value="CastleScriptCoreFunctions"/>
       </Item89>
       <Item90>
-        <Filename Value="../src/castlescript/castlescriptlexer.pas"/>
-        <UnitName Value="CastleScriptLexer"/>
+        <Filename Value="../src/castlescript/castlescriptimages.pas"/>
+        <UnitName Value="CastleScriptImages"/>
       </Item90>
       <Item91>
-        <Filename Value="../src/castlescript/castlescriptparser.pas"/>
-        <UnitName Value="CastleScriptParser"/>
+        <Filename Value="../src/castlescript/castlescriptlexer.pas"/>
+        <UnitName Value="CastleScriptLexer"/>
       </Item91>
       <Item92>
-        <Filename Value="../src/castlescript/castlescriptvectors.pas"/>
-        <UnitName Value="CastleScriptVectors"/>
+        <Filename Value="../src/castlescript/castlescriptparser.pas"/>
+        <UnitName Value="CastleScriptParser"/>
       </Item92>
       <Item93>
-        <Filename Value="../src/castlescript/castlescriptvectors_implement_matrix.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/castlescript/castlescriptvectors.pas"/>
+        <UnitName Value="CastleScriptVectors"/>
       </Item93>
       <Item94>
-        <Filename Value="../src/castlescript/castlescriptvectors_implement_vector.inc"/>
+        <Filename Value="../src/castlescript/castlescriptvectors_implement_matrix.inc"/>
         <Type Value="Include"/>
       </Item94>
       <Item95>
-        <Filename Value="../src/castlescript/opengl/castlecurves.pas"/>
-        <UnitName Value="CastleCurves"/>
+        <Filename Value="../src/castlescript/castlescriptvectors_implement_vector.inc"/>
+        <Type Value="Include"/>
       </Item95>
       <Item96>
-        <Filename Value="../src/fonts/castlefont2pascal.pas"/>
-        <UnitName Value="CastleFont2Pascal"/>
+        <Filename Value="../src/castlescript/opengl/castlecurves.pas"/>
+        <UnitName Value="CastleCurves"/>
       </Item96>
       <Item97>
-        <Filename Value="../src/fonts/castlefreetype.pas"/>
-        <UnitName Value="CastleFreeType"/>
+        <Filename Value="../src/fonts/castlefont2pascal.pas"/>
+        <UnitName Value="CastleFont2Pascal"/>
       </Item97>
       <Item98>
-        <Filename Value="../src/fonts/castlefreetypeh.pas"/>
-        <UnitName Value="CastleFreeTypeH"/>
+        <Filename Value="../src/fonts/castlefreetype.pas"/>
+        <UnitName Value="CastleFreeType"/>
       </Item98>
       <Item99>
-        <Filename Value="../src/fonts/castleftfont.pas"/>
-        <UnitName Value="CastleFtFont"/>
+        <Filename Value="../src/fonts/castlefreetypeh.pas"/>
+        <UnitName Value="CastleFreeTypeH"/>
       </Item99>
       <Item100>
-        <Filename Value="../src/fonts/castletexturefont_dejavusans_10.pas"/>
-        <UnitName Value="CastleTextureFont_DejaVuSans_10"/>
+        <Filename Value="../src/fonts/castleftfont.pas"/>
+        <UnitName Value="CastleFtFont"/>
       </Item100>
       <Item101>
-        <Filename Value="../src/fonts/castletexturefont_dejavusansmono_18.pas"/>
-        <UnitName Value="CastleTextureFont_DejaVuSansMono_18"/>
+        <Filename Value="../src/fonts/castletexturefont_dejavusans_10.pas"/>
+        <UnitName Value="CastleTextureFont_DejaVuSans_10"/>
       </Item101>
       <Item102>
-        <Filename Value="../src/fonts/castletexturefont_dejavusansmonobold_15.pas"/>
-        <UnitName Value="CastleTextureFont_DejaVuSansMonoBold_15"/>
+        <Filename Value="../src/fonts/castletexturefont_dejavusansmono_18.pas"/>
+        <UnitName Value="CastleTextureFont_DejaVuSansMono_18"/>
       </Item102>
       <Item103>
-        <Filename Value="../src/fonts/castletexturefont_djvmono_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvMono_20"/>
+        <Filename Value="../src/fonts/castletexturefont_dejavusansmonobold_15.pas"/>
+        <UnitName Value="CastleTextureFont_DejaVuSansMonoBold_15"/>
       </Item103>
       <Item104>
-        <Filename Value="../src/fonts/castletexturefont_djvmonob_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvMonoB_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvmono_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvMono_20"/>
       </Item104>
       <Item105>
-        <Filename Value="../src/fonts/castletexturefont_djvmonobo_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvMonoBO_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvmonob_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvMonoB_20"/>
       </Item105>
       <Item106>
-        <Filename Value="../src/fonts/castletexturefont_djvmonoo_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvMonoO_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvmonobo_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvMonoBO_20"/>
       </Item106>
       <Item107>
-        <Filename Value="../src/fonts/castletexturefont_djvsans_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvSans_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvmonoo_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvMonoO_20"/>
       </Item107>
       <Item108>
-        <Filename Value="../src/fonts/castletexturefont_djvsansb_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvSansB_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvsans_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvSans_20"/>
       </Item108>
       <Item109>
-        <Filename Value="../src/fonts/castletexturefont_djvsansbo_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvSansBO_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvsansb_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvSansB_20"/>
       </Item109>
       <Item110>
-        <Filename Value="../src/fonts/castletexturefont_djvsanso_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvSansO_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvsansbo_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvSansBO_20"/>
       </Item110>
       <Item111>
-        <Filename Value="../src/fonts/castletexturefont_djvserif_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvSerif_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvsanso_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvSansO_20"/>
       </Item111>
       <Item112>
-        <Filename Value="../src/fonts/castletexturefont_djvserifb_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvSerifB_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvserif_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvSerif_20"/>
       </Item112>
       <Item113>
-        <Filename Value="../src/fonts/castletexturefont_djvserifbi_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvSerifBI_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvserifb_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvSerifB_20"/>
       </Item113>
       <Item114>
-        <Filename Value="../src/fonts/castletexturefont_djvserifi_20.pas"/>
-        <UnitName Value="CastleTextureFont_DjvSerifI_20"/>
+        <Filename Value="../src/fonts/castletexturefont_djvserifbi_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvSerifBI_20"/>
       </Item114>
       <Item115>
-        <Filename Value="../src/fonts/castletexturefontdata.pas"/>
-        <UnitName Value="CastleTextureFontData"/>
+        <Filename Value="../src/fonts/castletexturefont_djvserifi_20.pas"/>
+        <UnitName Value="CastleTextureFont_DjvSerifI_20"/>
       </Item115>
       <Item116>
-        <Filename Value="../src/fonts/opengl/castlefonts.pas"/>
-        <UnitName Value="CastleFonts"/>
+        <Filename Value="../src/fonts/castletexturefontdata.pas"/>
+        <UnitName Value="CastleTextureFontData"/>
       </Item116>
       <Item117>
+        <Filename Value="../src/fonts/opengl/castlefonts.pas"/>
+        <UnitName Value="CastleFonts"/>
+      </Item117>
+      <Item118>
         <Filename Value="../src/fonts/windows/castlewindowsfonts.pas"/>
         <AddToUsesPkgSection Value="False"/>
         <UnitName Value="CastleWindowsFonts"/>
-      </Item117>
-      <Item118>
-        <Filename Value="../src/game/castle2dscenemanager.pas"/>
-        <UnitName Value="Castle2DSceneManager"/>
       </Item118>
       <Item119>
-        <Filename Value="../src/game/castlecreatures.pas"/>
-        <UnitName Value="CastleCreatures"/>
+        <Filename Value="../src/game/castle2dscenemanager.pas"/>
+        <UnitName Value="Castle2DSceneManager"/>
       </Item119>
       <Item120>
-        <Filename Value="../src/game/castlegamenotifications.pas"/>
-        <UnitName Value="CastleGameNotifications"/>
+        <Filename Value="../src/game/castlecreatures.pas"/>
+        <UnitName Value="CastleCreatures"/>
       </Item120>
       <Item121>
-        <Filename Value="../src/game/castleitems.pas"/>
-        <UnitName Value="CastleItems"/>
+        <Filename Value="../src/game/castlegamenotifications.pas"/>
+        <UnitName Value="CastleGameNotifications"/>
       </Item121>
       <Item122>
-        <Filename Value="../src/game/castlelevels.pas"/>
-        <UnitName Value="CastleLevels"/>
+        <Filename Value="../src/game/castleitems.pas"/>
+        <UnitName Value="CastleItems"/>
       </Item122>
       <Item123>
-        <Filename Value="../src/game/castleplayer.pas"/>
-        <UnitName Value="CastlePlayer"/>
+        <Filename Value="../src/game/castlelevels.pas"/>
+        <UnitName Value="CastleLevels"/>
       </Item123>
       <Item124>
-        <Filename Value="../src/game/castleresources.pas"/>
-        <UnitName Value="CastleResources"/>
+        <Filename Value="../src/game/castleplayer.pas"/>
+        <UnitName Value="CastlePlayer"/>
       </Item124>
       <Item125>
+        <Filename Value="../src/game/castleresources.pas"/>
+        <UnitName Value="CastleResources"/>
+      </Item125>
+      <Item126>
         <Filename Value="../src/game/castlescenemanager.pas"/>
         <HasRegisterProc Value="True"/>
         <UnitName Value="CastleSceneManager"/>
-      </Item125>
-      <Item126>
-        <Filename Value="../src/images/castlecompositeimage.pas"/>
-        <UnitName Value="CastleCompositeImage"/>
       </Item126>
       <Item127>
-        <Filename Value="../src/images/castlefpwritepng.pas"/>
-        <UnitName Value="CastleFPWritePNG"/>
+        <Filename Value="../src/images/castlecompositeimage.pas"/>
+        <UnitName Value="CastleCompositeImage"/>
       </Item127>
       <Item128>
-        <Filename Value="../src/images/castleimages.pas"/>
-        <UnitName Value="CastleImages"/>
+        <Filename Value="../src/images/castlefpwritepng.pas"/>
+        <UnitName Value="CastleFPWritePNG"/>
       </Item128>
       <Item129>
-        <Filename Value="../src/images/castleimages_draw.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/images/castleimages.pas"/>
+        <UnitName Value="CastleImages"/>
       </Item129>
       <Item130>
-        <Filename Value="../src/images/castleimages_file_formats.inc"/>
+        <Filename Value="../src/images/castleimages_draw.inc"/>
         <Type Value="Include"/>
       </Item130>
       <Item131>
-        <Filename Value="../src/images/castlepng.pas"/>
-        <UnitName Value="CastlePng"/>
+        <Filename Value="../src/images/castleimages_file_formats.inc"/>
+        <Type Value="Include"/>
       </Item131>
       <Item132>
-        <Filename Value="../src/images/castlepng_dynamic.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/images/castlepng.pas"/>
+        <UnitName Value="CastlePng"/>
       </Item132>
       <Item133>
-        <Filename Value="../src/images/castlepng_static.inc"/>
+        <Filename Value="../src/images/castlepng_dynamic.inc"/>
         <Type Value="Include"/>
       </Item133>
       <Item134>
-        <Filename Value="../src/images/castletextureimages.pas"/>
-        <UnitName Value="CastleTextureImages"/>
+        <Filename Value="../src/images/castlepng_static.inc"/>
+        <Type Value="Include"/>
       </Item134>
       <Item135>
-        <Filename Value="../src/images/castlevideos.pas"/>
-        <UnitName Value="CastleVideos"/>
+        <Filename Value="../src/images/castletextureimages.pas"/>
+        <UnitName Value="CastleTextureImages"/>
       </Item135>
       <Item136>
-        <Filename Value="../src/images/images_bmp.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/images/castlevideos.pas"/>
+        <UnitName Value="CastleVideos"/>
       </Item136>
       <Item137>
-        <Filename Value="../src/images/images_composite.inc"/>
+        <Filename Value="../src/images/images_bmp.inc"/>
         <Type Value="Include"/>
       </Item137>
       <Item138>
-        <Filename Value="../src/images/images_external_tool.inc"/>
+        <Filename Value="../src/images/images_composite.inc"/>
         <Type Value="Include"/>
       </Item138>
       <Item139>
-        <Filename Value="../src/images/images_fpimage.inc"/>
+        <Filename Value="../src/images/images_external_tool.inc"/>
         <Type Value="Include"/>
       </Item139>
       <Item140>
-        <Filename Value="../src/images/images_ipl.inc"/>
+        <Filename Value="../src/images/images_fpimage.inc"/>
         <Type Value="Include"/>
       </Item140>
       <Item141>
-        <Filename Value="../src/images/images_modulatergb_implement.inc"/>
+        <Filename Value="../src/images/images_ipl.inc"/>
         <Type Value="Include"/>
       </Item141>
       <Item142>
-        <Filename Value="../src/images/images_png.inc"/>
+        <Filename Value="../src/images/images_modulatergb_implement.inc"/>
         <Type Value="Include"/>
       </Item142>
       <Item143>
-        <Filename Value="../src/images/images_ppm.inc"/>
+        <Filename Value="../src/images/images_png.inc"/>
         <Type Value="Include"/>
       </Item143>
       <Item144>
-        <Filename Value="../src/images/images_rgbe_fileformat.inc"/>
+        <Filename Value="../src/images/images_ppm.inc"/>
         <Type Value="Include"/>
       </Item144>
       <Item145>
-        <Filename Value="../src/images/images_s3tc_flip_vertical.inc"/>
+        <Filename Value="../src/images/images_rgbe_fileformat.inc"/>
         <Type Value="Include"/>
       </Item145>
       <Item146>
-        <Filename Value="../src/images/images_transformrgb_implement.inc"/>
+        <Filename Value="../src/images/images_s3tc_flip_vertical.inc"/>
         <Type Value="Include"/>
       </Item146>
       <Item147>
-        <Filename Value="../src/images/opengl/castleglimages.pas"/>
-        <UnitName Value="CastleGLImages"/>
+        <Filename Value="../src/images/images_transformrgb_implement.inc"/>
+        <Type Value="Include"/>
       </Item147>
       <Item148>
-        <Filename Value="../src/images/opengl/castleglimages_filter.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/images/opengl/castleglimages.pas"/>
+        <UnitName Value="CastleGLImages"/>
       </Item148>
       <Item149>
-        <Filename Value="../src/images/opengl/castleglimages_load_2d.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_filter.inc"/>
         <Type Value="Include"/>
       </Item149>
       <Item150>
-        <Filename Value="../src/images/opengl/castleglimages_load_3d.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_load_2d.inc"/>
         <Type Value="Include"/>
       </Item150>
       <Item151>
-        <Filename Value="../src/images/opengl/castleglimages_load_cubemap.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_load_3d.inc"/>
         <Type Value="Include"/>
       </Item151>
       <Item152>
-        <Filename Value="../src/images/opengl/castleglimages_packing.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_load_cubemap.inc"/>
         <Type Value="Include"/>
       </Item152>
       <Item153>
-        <Filename Value="../src/images/opengl/castleglimages_rendertotexture.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_packing.inc"/>
         <Type Value="Include"/>
       </Item153>
       <Item154>
-        <Filename Value="../src/images/opengl/castleglimages_savescreen.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_rendertotexture.inc"/>
         <Type Value="Include"/>
       </Item154>
       <Item155>
-        <Filename Value="../src/images/opengl/castleglimages_sprite.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_savescreen.inc"/>
         <Type Value="Include"/>
       </Item155>
       <Item156>
-        <Filename Value="../src/images/opengl/castleglimages_texturememoryprofiler.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_sprite.inc"/>
         <Type Value="Include"/>
       </Item156>
       <Item157>
-        <Filename Value="../src/images/opengl/castleglimages_tglimage.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_texturememoryprofiler.inc"/>
         <Type Value="Include"/>
       </Item157>
       <Item158>
-        <Filename Value="../src/images/opengl/castleglimages_video.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_tglimage.inc"/>
         <Type Value="Include"/>
       </Item158>
       <Item159>
-        <Filename Value="../src/images/opengl/castleglimages_wrap.inc"/>
+        <Filename Value="../src/images/opengl/castleglimages_video.inc"/>
         <Type Value="Include"/>
       </Item159>
       <Item160>
-        <Filename Value="../src/images/opengl/castleglshaders.pas"/>
-        <UnitName Value="CastleGLShaders"/>
+        <Filename Value="../src/images/opengl/castleglimages_wrap.inc"/>
+        <Type Value="Include"/>
       </Item160>
       <Item161>
-        <Filename Value="../src/images/opengl/castleglutils.pas"/>
-        <UnitName Value="CastleGLUtils"/>
+        <Filename Value="../src/images/opengl/castleglshaders.pas"/>
+        <UnitName Value="CastleGLShaders"/>
       </Item161>
       <Item162>
-        <Filename Value="../src/images/opengl/castleglutils_mipmaps.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/images/opengl/castleglutils.pas"/>
+        <UnitName Value="CastleGLUtils"/>
       </Item162>
       <Item163>
-        <Filename Value="../src/images/opengl/castlescreeneffects.pas"/>
-        <UnitName Value="CastleScreenEffects"/>
+        <Filename Value="../src/images/opengl/castleglutils_mipmaps.inc"/>
+        <Type Value="Include"/>
       </Item163>
       <Item164>
-        <Filename Value="../src/images/opengl/glsl/image.fs.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/images/opengl/castlescreeneffects.pas"/>
+        <UnitName Value="CastleScreenEffects"/>
       </Item164>
       <Item165>
-        <Filename Value="../src/images/opengl/glsl/image.vs.inc"/>
+        <Filename Value="../src/images/opengl/glsl/image.fs.inc"/>
         <Type Value="Include"/>
       </Item165>
       <Item166>
-        <Filename Value="../src/images/opengl/glsl/rectangle.fs.inc"/>
+        <Filename Value="../src/images/opengl/glsl/image.vs.inc"/>
         <Type Value="Include"/>
       </Item166>
       <Item167>
-        <Filename Value="../src/images/opengl/glsl/rectangle.vs.inc"/>
+        <Filename Value="../src/images/opengl/glsl/rectangle.fs.inc"/>
         <Type Value="Include"/>
       </Item167>
       <Item168>
-        <Filename Value="../src/net/castledatauri.pas"/>
-        <UnitName Value="CastleDataURI"/>
+        <Filename Value="../src/images/opengl/glsl/rectangle.vs.inc"/>
+        <Type Value="Include"/>
       </Item168>
       <Item169>
-        <Filename Value="../src/net/castledownload.pas"/>
-        <UnitName Value="CastleDownload"/>
+        <Filename Value="../src/net/castledatauri.pas"/>
+        <UnitName Value="CastleDataURI"/>
       </Item169>
       <Item170>
-        <Filename Value="../src/net/castleuriutils.pas"/>
-        <UnitName Value="CastleURIUtils"/>
+        <Filename Value="../src/net/castledownload.pas"/>
+        <UnitName Value="CastleDownload"/>
       </Item170>
       <Item171>
-        <Filename Value="../src/services/castleads.pas"/>
-        <UnitName Value="CastleAds"/>
+        <Filename Value="../src/net/castleuriutils.pas"/>
+        <UnitName Value="CastleURIUtils"/>
       </Item171>
       <Item172>
-        <Filename Value="../src/services/castleanalytics.pas"/>
-        <UnitName Value="CastleAnalytics"/>
+        <Filename Value="../src/services/castleads.pas"/>
+        <UnitName Value="CastleAds"/>
       </Item172>
       <Item173>
-        <Filename Value="../src/services/castlegiftiz.pas"/>
-        <UnitName Value="CastleGiftiz"/>
+        <Filename Value="../src/services/castleanalytics.pas"/>
+        <UnitName Value="CastleAnalytics"/>
       </Item173>
       <Item174>
-        <Filename Value="../src/services/castlegoogleplaygames.pas"/>
-        <UnitName Value="CastleGooglePlayGames"/>
+        <Filename Value="../src/services/castlegiftiz.pas"/>
+        <UnitName Value="CastleGiftiz"/>
       </Item174>
       <Item175>
-        <Filename Value="../src/services/castleinapppurchases.pas"/>
-        <UnitName Value="CastleInAppPurchases"/>
+        <Filename Value="../src/services/castlegoogleplaygames.pas"/>
+        <UnitName Value="CastleGooglePlayGames"/>
       </Item175>
       <Item176>
-        <Filename Value="../src/services/castlemessaging.pas"/>
-        <UnitName Value="CastleMessaging"/>
+        <Filename Value="../src/services/castleinapppurchases.pas"/>
+        <UnitName Value="CastleInAppPurchases"/>
       </Item176>
       <Item177>
-        <Filename Value="../src/services/castleopendocument.pas"/>
-        <UnitName Value="CastleOpenDocument"/>
+        <Filename Value="../src/services/castlemessaging.pas"/>
+        <UnitName Value="CastleMessaging"/>
       </Item177>
       <Item178>
-        <Filename Value="../src/ui/castleinputs.pas"/>
-        <UnitName Value="CastleInputs"/>
+        <Filename Value="../src/services/castleopendocument.pas"/>
+        <UnitName Value="CastleOpenDocument"/>
       </Item178>
       <Item179>
-        <Filename Value="../src/ui/castlekeysmouse.pas"/>
-        <UnitName Value="CastleKeysMouse"/>
+        <Filename Value="../src/ui/castleinputs.pas"/>
+        <UnitName Value="CastleInputs"/>
       </Item179>
       <Item180>
-        <Filename Value="../src/ui/castleuicontrols.pas"/>
-        <UnitName Value="CastleUIControls"/>
+        <Filename Value="../src/ui/castlekeysmouse.pas"/>
+        <UnitName Value="CastleKeysMouse"/>
       </Item180>
       <Item181>
+        <Filename Value="../src/ui/castleuicontrols.pas"/>
+        <UnitName Value="CastleUIControls"/>
+      </Item181>
+      <Item182>
         <Filename Value="../src/ui/opengl/castlecontrols.pas"/>
         <HasRegisterProc Value="True"/>
         <UnitName Value="CastleControls"/>
-      </Item181>
-      <Item182>
-        <Filename Value="../src/ui/opengl/castlecontrolsimages.pas"/>
-        <UnitName Value="CastleControlsImages"/>
       </Item182>
       <Item183>
-        <Filename Value="../src/ui/opengl/castleflasheffect.pas"/>
-        <UnitName Value="CastleFlashEffect"/>
+        <Filename Value="../src/ui/opengl/castlecontrolsimages.pas"/>
+        <UnitName Value="CastleControlsImages"/>
       </Item183>
       <Item184>
-        <Filename Value="../src/ui/opengl/castleglcontainer.pas"/>
-        <UnitName Value="CastleGLContainer"/>
+        <Filename Value="../src/ui/opengl/castleflasheffect.pas"/>
+        <UnitName Value="CastleFlashEffect"/>
       </Item184>
       <Item185>
-        <Filename Value="../src/ui/opengl/castleinspectorcontrol.pas"/>
-        <UnitName Value="CastleInspectorControl"/>
+        <Filename Value="../src/ui/opengl/castleglcontainer.pas"/>
+        <UnitName Value="CastleGLContainer"/>
       </Item185>
       <Item186>
-        <Filename Value="../src/ui/opengl/castlenotifications.pas"/>
-        <UnitName Value="CastleNotifications"/>
+        <Filename Value="../src/ui/opengl/castleinspectorcontrol.pas"/>
+        <UnitName Value="CastleInspectorControl"/>
       </Item186>
       <Item187>
+        <Filename Value="../src/ui/opengl/castlenotifications.pas"/>
+        <UnitName Value="CastleNotifications"/>
+      </Item187>
+      <Item188>
         <Filename Value="../src/ui/opengl/castleonscreenmenu.pas"/>
         <HasRegisterProc Value="True"/>
         <UnitName Value="CastleOnScreenMenu"/>
-      </Item187>
-      <Item188>
-        <Filename Value="../src/ui/pk3dconnexion.pas"/>
-        <UnitName Value="pk3DConnexion"/>
       </Item188>
       <Item189>
-        <Filename Value="../src/x3d/arraysgenerator_x3d_geometry3d.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/ui/pk3dconnexion.pas"/>
+        <UnitName Value="pk3DConnexion"/>
       </Item189>
       <Item190>
-        <Filename Value="../src/x3d/arraysgenerator_x3d_rendering.inc"/>
+        <Filename Value="../src/x3d/arraysgenerator_x3d_geometry3d.inc"/>
         <Type Value="Include"/>
       </Item190>
       <Item191>
-        <Filename Value="../src/x3d/castlearraysgenerator.pas"/>
-        <UnitName Value="CastleArraysGenerator"/>
+        <Filename Value="../src/x3d/arraysgenerator_x3d_rendering.inc"/>
+        <Type Value="Include"/>
       </Item191>
       <Item192>
-        <Filename Value="../src/x3d/castleinternalnodeinterpolator.pas"/>
-        <UnitName Value="CastleInternalNodeInterpolator"/>
+        <Filename Value="../src/x3d/castlearraysgenerator.pas"/>
+        <UnitName Value="CastleArraysGenerator"/>
       </Item192>
       <Item193>
-        <Filename Value="../src/x3d/castleinternalnormals.pas"/>
-        <UnitName Value="CastleInternalNormals"/>
+        <Filename Value="../src/x3d/castleinternalnodeinterpolator.pas"/>
+        <UnitName Value="CastleInternalNodeInterpolator"/>
       </Item193>
       <Item194>
-        <Filename Value="../src/x3d/castlematerialproperties.pas"/>
-        <UnitName Value="CastleMaterialProperties"/>
+        <Filename Value="../src/x3d/castleinternalnormals.pas"/>
+        <UnitName Value="CastleInternalNormals"/>
       </Item194>
       <Item195>
-        <Filename Value="../src/x3d/castleraytracer.pas"/>
-        <UnitName Value="CastleRayTracer"/>
+        <Filename Value="../src/x3d/castlematerialproperties.pas"/>
+        <UnitName Value="CastleMaterialProperties"/>
       </Item195>
       <Item196>
-        <Filename Value="../src/x3d/castlerenderingcamera.pas"/>
-        <UnitName Value="CastleRenderingCamera"/>
+        <Filename Value="../src/x3d/castleraytracer.pas"/>
+        <UnitName Value="CastleRayTracer"/>
       </Item196>
       <Item197>
-        <Filename Value="../src/x3d/castlescenecore.pas"/>
-        <UnitName Value="CastleSceneCore"/>
+        <Filename Value="../src/x3d/castlerenderingcamera.pas"/>
+        <UnitName Value="CastleRenderingCamera"/>
       </Item197>
       <Item198>
-        <Filename Value="../src/x3d/castleshapeinternalshadowvolumes.pas"/>
-        <UnitName Value="CastleShapeInternalShadowVolumes"/>
+        <Filename Value="../src/x3d/castlescenecore.pas"/>
+        <UnitName Value="CastleSceneCore"/>
       </Item198>
       <Item199>
-        <Filename Value="../src/x3d/castleshapeoctree.pas"/>
-        <UnitName Value="CastleShapeOctree"/>
+        <Filename Value="../src/x3d/castleshapeinternalshadowvolumes.pas"/>
+        <UnitName Value="CastleShapeInternalShadowVolumes"/>
       </Item199>
       <Item200>
-        <Filename Value="../src/x3d/castleshapes.pas"/>
-        <UnitName Value="CastleShapes"/>
+        <Filename Value="../src/x3d/castleshapeoctree.pas"/>
+        <UnitName Value="CastleShapeOctree"/>
       </Item200>
       <Item201>
-        <Filename Value="../src/x3d/castleterrain.pas"/>
-        <UnitName Value="CastleTerrain"/>
+        <Filename Value="../src/x3d/castleshapes.pas"/>
+        <UnitName Value="CastleShapes"/>
       </Item201>
       <Item202>
-        <Filename Value="../src/x3d/castletriangleoctree.pas"/>
-        <UnitName Value="CastleTriangleOctree"/>
+        <Filename Value="../src/x3d/castleterrain.pas"/>
+        <UnitName Value="CastleTerrain"/>
       </Item202>
       <Item203>
-        <Filename Value="../src/x3d/octreeconf.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/x3d/castletriangleoctree.pas"/>
+        <UnitName Value="CastleTriangleOctree"/>
       </Item203>
       <Item204>
-        <Filename Value="../src/x3d/opengl/castlebackground.pas"/>
-        <UnitName Value="CastleBackground"/>
+        <Filename Value="../src/x3d/octreeconf.inc"/>
+        <Type Value="Include"/>
       </Item204>
       <Item205>
-        <Filename Value="../src/x3d/opengl/castleglcubemaps.pas"/>
-        <UnitName Value="CastleGLCubeMaps"/>
+        <Filename Value="../src/x3d/opengl/castlebackground.pas"/>
+        <UnitName Value="CastleBackground"/>
       </Item205>
       <Item206>
+        <Filename Value="../src/x3d/opengl/castleglcubemaps.pas"/>
+        <UnitName Value="CastleGLCubeMaps"/>
+      </Item206>
+      <Item207>
         <Filename Value="../src/x3d/opengl/castleprecalculatedanimation.pas"/>
         <HasRegisterProc Value="True"/>
         <UnitName Value="CastlePrecalculatedAnimation"/>
-      </Item206>
-      <Item207>
-        <Filename Value="../src/x3d/opengl/castlerenderer.pas"/>
-        <UnitName Value="CastleRenderer"/>
       </Item207>
       <Item208>
-        <Filename Value="../src/x3d/opengl/castlerenderer_bumpmapping.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/x3d/opengl/castlerenderer.pas"/>
+        <UnitName Value="CastleRenderer"/>
       </Item208>
       <Item209>
-        <Filename Value="../src/x3d/opengl/castlerenderer_glsl.inc"/>
+        <Filename Value="../src/x3d/opengl/castlerenderer_bumpmapping.inc"/>
         <Type Value="Include"/>
       </Item209>
       <Item210>
-        <Filename Value="../src/x3d/opengl/castlerenderer_materials.inc"/>
+        <Filename Value="../src/x3d/opengl/castlerenderer_glsl.inc"/>
         <Type Value="Include"/>
       </Item210>
       <Item211>
-        <Filename Value="../src/x3d/opengl/castlerenderer_meshrenderer.inc"/>
+        <Filename Value="../src/x3d/opengl/castlerenderer_materials.inc"/>
         <Type Value="Include"/>
       </Item211>
       <Item212>
-        <Filename Value="../src/x3d/opengl/castlerenderer_resource.inc"/>
+        <Filename Value="../src/x3d/opengl/castlerenderer_meshrenderer.inc"/>
         <Type Value="Include"/>
       </Item212>
       <Item213>
-        <Filename Value="../src/x3d/opengl/castlerenderer_texture.inc"/>
+        <Filename Value="../src/x3d/opengl/castlerenderer_resource.inc"/>
         <Type Value="Include"/>
       </Item213>
       <Item214>
-        <Filename Value="../src/x3d/opengl/castlerendererinternallights.pas"/>
-        <UnitName Value="CastleRendererInternalLights"/>
+        <Filename Value="../src/x3d/opengl/castlerenderer_texture.inc"/>
+        <Type Value="Include"/>
       </Item214>
       <Item215>
-        <Filename Value="../src/x3d/opengl/castlerendererinternalshader.pas"/>
-        <UnitName Value="CastleRendererInternalShader"/>
+        <Filename Value="../src/x3d/opengl/castlerendererinternallights.pas"/>
+        <UnitName Value="CastleRendererInternalLights"/>
       </Item215>
       <Item216>
-        <Filename Value="../src/x3d/opengl/castlerendererinternaltextureenv.pas"/>
-        <UnitName Value="CastleRendererInternalTextureEnv"/>
+        <Filename Value="../src/x3d/opengl/castlerendererinternalshader.pas"/>
+        <UnitName Value="CastleRendererInternalShader"/>
       </Item216>
       <Item217>
+        <Filename Value="../src/x3d/opengl/castlerendererinternaltextureenv.pas"/>
+        <UnitName Value="CastleRendererInternalTextureEnv"/>
+      </Item217>
+      <Item218>
         <Filename Value="../src/x3d/opengl/castlescene.pas"/>
         <HasRegisterProc Value="True"/>
         <UnitName Value="CastleScene"/>
-      </Item217>
-      <Item218>
-        <Filename Value="../src/x3d/opengl/castlesceneinternalblending.pas"/>
-        <UnitName Value="CastleSceneInternalBlending"/>
       </Item218>
       <Item219>
-        <Filename Value="../src/x3d/opengl/castlesceneinternalocclusion.pas"/>
-        <UnitName Value="CastleSceneInternalOcclusion"/>
+        <Filename Value="../src/x3d/opengl/castlesceneinternalblending.pas"/>
+        <UnitName Value="CastleSceneInternalBlending"/>
       </Item219>
       <Item220>
-        <Filename Value="../src/x3d/opengl/castlesceneinternalshape.pas"/>
-        <UnitName Value="CastleSceneInternalShape"/>
+        <Filename Value="../src/x3d/opengl/castlesceneinternalocclusion.pas"/>
+        <UnitName Value="CastleSceneInternalOcclusion"/>
       </Item220>
       <Item221>
-        <Filename Value="../src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas"/>
-        <UnitName Value="CastleShapeInternalRenderShadowVolumes"/>
+        <Filename Value="../src/x3d/opengl/castlesceneinternalshape.pas"/>
+        <UnitName Value="CastleSceneInternalShape"/>
       </Item221>
       <Item222>
-        <Filename Value="../src/x3d/opengl/glsl/fallback.fs.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas"/>
+        <UnitName Value="CastleShapeInternalRenderShadowVolumes"/>
       </Item222>
       <Item223>
-        <Filename Value="../src/x3d/opengl/glsl/fallback.vs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/fallback.fs.inc"/>
         <Type Value="Include"/>
       </Item223>
       <Item224>
-        <Filename Value="../src/x3d/opengl/glsl/screen_effect.vs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/fallback.vs.inc"/>
         <Type Value="Include"/>
       </Item224>
       <Item225>
-        <Filename Value="../src/x3d/opengl/glsl/screen_effect_library.glsl.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/screen_effect.vs.inc"/>
         <Type Value="Include"/>
       </Item225>
       <Item226>
-        <Filename Value="../src/x3d/opengl/glsl/shadow_map_common.fs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/screen_effect_library.glsl.inc"/>
         <Type Value="Include"/>
       </Item226>
       <Item227>
-        <Filename Value="../src/x3d/opengl/glsl/ssao.glsl.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/shadow_map_common.fs.inc"/>
         <Type Value="Include"/>
       </Item227>
       <Item228>
-        <Filename Value="../src/x3d/opengl/glsl/template.fs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/ssao.glsl.inc"/>
         <Type Value="Include"/>
       </Item228>
       <Item229>
-        <Filename Value="../src/x3d/opengl/glsl/template.gs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/template.fs.inc"/>
         <Type Value="Include"/>
       </Item229>
       <Item230>
-        <Filename Value="../src/x3d/opengl/glsl/template.vs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/template.gs.inc"/>
         <Type Value="Include"/>
       </Item230>
       <Item231>
-        <Filename Value="../src/x3d/opengl/glsl/template_add_light.glsl.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/template.vs.inc"/>
         <Type Value="Include"/>
       </Item231>
       <Item232>
-        <Filename Value="../src/x3d/opengl/glsl/template_mobile.fs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/template_add_light.glsl.inc"/>
         <Type Value="Include"/>
       </Item232>
       <Item233>
-        <Filename Value="../src/x3d/opengl/glsl/template_mobile.vs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/template_mobile.fs.inc"/>
         <Type Value="Include"/>
       </Item233>
       <Item234>
-        <Filename Value="../src/x3d/opengl/glsl/template_mobile_add_light.glsl.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/template_mobile.vs.inc"/>
         <Type Value="Include"/>
       </Item234>
       <Item235>
-        <Filename Value="../src/x3d/opengl/glsl/variance_shadow_map_common.fs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/template_mobile_add_light.glsl.inc"/>
         <Type Value="Include"/>
       </Item235>
       <Item236>
-        <Filename Value="../src/x3d/opengl/glsl/variance_shadow_map_generate.fs.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/variance_shadow_map_common.fs.inc"/>
         <Type Value="Include"/>
       </Item236>
       <Item237>
-        <Filename Value="../src/x3d/teapot/teapot.inc"/>
+        <Filename Value="../src/x3d/opengl/glsl/variance_shadow_map_generate.fs.inc"/>
         <Type Value="Include"/>
       </Item237>
       <Item238>
-        <Filename Value="../src/x3d/triangle_raysegment_nonleaf.inc"/>
+        <Filename Value="../src/x3d/teapot/teapot.inc"/>
         <Type Value="Include"/>
       </Item238>
       <Item239>
-        <Filename Value="../src/x3d/triangleoctree_raysegmentcollisions.inc"/>
+        <Filename Value="../src/x3d/triangle_raysegment_nonleaf.inc"/>
         <Type Value="Include"/>
       </Item239>
       <Item240>
-        <Filename Value="../src/x3d/x3d_cadgeometry.inc"/>
+        <Filename Value="../src/x3d/triangleoctree_raysegmentcollisions.inc"/>
         <Type Value="Include"/>
       </Item240>
       <Item241>
-        <Filename Value="../src/x3d/x3d_core.inc"/>
+        <Filename Value="../src/x3d/x3d_cadgeometry.inc"/>
         <Type Value="Include"/>
       </Item241>
       <Item242>
-        <Filename Value="../src/x3d/x3d_cubemaptexturing.inc"/>
+        <Filename Value="../src/x3d/x3d_core.inc"/>
         <Type Value="Include"/>
       </Item242>
       <Item243>
-        <Filename Value="../src/x3d/x3d_dis.inc"/>
+        <Filename Value="../src/x3d/x3d_cubemaptexturing.inc"/>
         <Type Value="Include"/>
       </Item243>
       <Item244>
-        <Filename Value="../src/x3d/x3d_environmentaleffects.inc"/>
+        <Filename Value="../src/x3d/x3d_dis.inc"/>
         <Type Value="Include"/>
       </Item244>
       <Item245>
-        <Filename Value="../src/x3d/x3d_environmentalsensor.inc"/>
+        <Filename Value="../src/x3d/x3d_environmentaleffects.inc"/>
         <Type Value="Include"/>
       </Item245>
       <Item246>
-        <Filename Value="../src/x3d/x3d_eventutilities.inc"/>
+        <Filename Value="../src/x3d/x3d_environmentalsensor.inc"/>
         <Type Value="Include"/>
       </Item246>
       <Item247>
-        <Filename Value="../src/x3d/x3d_followers.inc"/>
+        <Filename Value="../src/x3d/x3d_eventutilities.inc"/>
         <Type Value="Include"/>
       </Item247>
       <Item248>
-        <Filename Value="../src/x3d/x3d_geometry2d.inc"/>
+        <Filename Value="../src/x3d/x3d_followers.inc"/>
         <Type Value="Include"/>
       </Item248>
       <Item249>
-        <Filename Value="../src/x3d/x3d_geometry3d.inc"/>
+        <Filename Value="../src/x3d/x3d_geometry2d.inc"/>
         <Type Value="Include"/>
       </Item249>
       <Item250>
-        <Filename Value="../src/x3d/x3d_geospatial.inc"/>
+        <Filename Value="../src/x3d/x3d_geometry3d.inc"/>
         <Type Value="Include"/>
       </Item250>
       <Item251>
-        <Filename Value="../src/x3d/x3d_grouping.inc"/>
+        <Filename Value="../src/x3d/x3d_geospatial.inc"/>
         <Type Value="Include"/>
       </Item251>
       <Item252>
-        <Filename Value="../src/x3d/x3d_h-anim.inc"/>
+        <Filename Value="../src/x3d/x3d_grouping.inc"/>
         <Type Value="Include"/>
       </Item252>
       <Item253>
-        <Filename Value="../src/x3d/x3d_interpolation.inc"/>
+        <Filename Value="../src/x3d/x3d_h-anim.inc"/>
         <Type Value="Include"/>
       </Item253>
       <Item254>
-        <Filename Value="../src/x3d/x3d_interpolation_cubic_bezier.inc"/>
+        <Filename Value="../src/x3d/x3d_interpolation.inc"/>
         <Type Value="Include"/>
       </Item254>
       <Item255>
-        <Filename Value="../src/x3d/x3d_keydevicesensor.inc"/>
+        <Filename Value="../src/x3d/x3d_interpolation_cubic_bezier.inc"/>
         <Type Value="Include"/>
       </Item255>
       <Item256>
-        <Filename Value="../src/x3d/x3d_layering.inc"/>
+        <Filename Value="../src/x3d/x3d_keydevicesensor.inc"/>
         <Type Value="Include"/>
       </Item256>
       <Item257>
-        <Filename Value="../src/x3d/x3d_layout.inc"/>
+        <Filename Value="../src/x3d/x3d_layering.inc"/>
         <Type Value="Include"/>
       </Item257>
       <Item258>
-        <Filename Value="../src/x3d/x3d_lighting.inc"/>
+        <Filename Value="../src/x3d/x3d_layout.inc"/>
         <Type Value="Include"/>
       </Item258>
       <Item259>
-        <Filename Value="../src/x3d/x3d_navigation.inc"/>
+        <Filename Value="../src/x3d/x3d_lighting.inc"/>
         <Type Value="Include"/>
       </Item259>
       <Item260>
-        <Filename Value="../src/x3d/x3d_networking.inc"/>
+        <Filename Value="../src/x3d/x3d_navigation.inc"/>
         <Type Value="Include"/>
       </Item260>
       <Item261>
-        <Filename Value="../src/x3d/x3d_nurbs.inc"/>
+        <Filename Value="../src/x3d/x3d_networking.inc"/>
         <Type Value="Include"/>
       </Item261>
       <Item262>
-        <Filename Value="../src/x3d/x3d_particlesystems.inc"/>
+        <Filename Value="../src/x3d/x3d_nurbs.inc"/>
         <Type Value="Include"/>
       </Item262>
       <Item263>
-        <Filename Value="../src/x3d/x3d_picking.inc"/>
+        <Filename Value="../src/x3d/x3d_particlesystems.inc"/>
         <Type Value="Include"/>
       </Item263>
       <Item264>
-        <Filename Value="../src/x3d/x3d_pointingdevicesensor.inc"/>
+        <Filename Value="../src/x3d/x3d_picking.inc"/>
         <Type Value="Include"/>
       </Item264>
       <Item265>
-        <Filename Value="../src/x3d/x3d_rendering.inc"/>
+        <Filename Value="../src/x3d/x3d_pointingdevicesensor.inc"/>
         <Type Value="Include"/>
       </Item265>
       <Item266>
-        <Filename Value="../src/x3d/x3d_rigidbodyphysics.inc"/>
+        <Filename Value="../src/x3d/x3d_rendering.inc"/>
         <Type Value="Include"/>
       </Item266>
       <Item267>
-        <Filename Value="../src/x3d/x3d_scripting.inc"/>
+        <Filename Value="../src/x3d/x3d_rigidbodyphysics.inc"/>
         <Type Value="Include"/>
       </Item267>
       <Item268>
-        <Filename Value="../src/x3d/x3d_shaders.inc"/>
+        <Filename Value="../src/x3d/x3d_scripting.inc"/>
         <Type Value="Include"/>
       </Item268>
       <Item269>
-        <Filename Value="../src/x3d/x3d_shape.inc"/>
+        <Filename Value="../src/x3d/x3d_shaders.inc"/>
         <Type Value="Include"/>
       </Item269>
       <Item270>
-        <Filename Value="../src/x3d/x3d_sound.inc"/>
+        <Filename Value="../src/x3d/x3d_shape.inc"/>
         <Type Value="Include"/>
       </Item270>
       <Item271>
-        <Filename Value="../src/x3d/x3d_text.inc"/>
+        <Filename Value="../src/x3d/x3d_sound.inc"/>
         <Type Value="Include"/>
       </Item271>
       <Item272>
-        <Filename Value="../src/x3d/x3d_texturing.inc"/>
+        <Filename Value="../src/x3d/x3d_text.inc"/>
         <Type Value="Include"/>
       </Item272>
       <Item273>
-        <Filename Value="../src/x3d/x3d_texturing3d.inc"/>
+        <Filename Value="../src/x3d/x3d_texturing.inc"/>
         <Type Value="Include"/>
       </Item273>
       <Item274>
-        <Filename Value="../src/x3d/x3d_time.inc"/>
+        <Filename Value="../src/x3d/x3d_texturing3d.inc"/>
         <Type Value="Include"/>
       </Item274>
       <Item275>
-        <Filename Value="../src/x3d/x3dcamerautils.pas"/>
-        <UnitName Value="X3DCameraUtils"/>
+        <Filename Value="../src/x3d/x3d_time.inc"/>
+        <Type Value="Include"/>
       </Item275>
       <Item276>
-        <Filename Value="../src/x3d/x3dcastlescript.pas"/>
-        <UnitName Value="X3DCastleScript"/>
+        <Filename Value="../src/x3d/x3dcamerautils.pas"/>
+        <UnitName Value="X3DCameraUtils"/>
       </Item276>
       <Item277>
-        <Filename Value="../src/x3d/x3devents.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/x3d/x3dcastlescript.pas"/>
+        <UnitName Value="X3DCastleScript"/>
       </Item277>
       <Item278>
-        <Filename Value="../src/x3d/x3devents_descendants.inc"/>
+        <Filename Value="../src/x3d/x3devents.inc"/>
         <Type Value="Include"/>
       </Item278>
       <Item279>
-        <Filename Value="../src/x3d/x3dfields.pas"/>
-        <UnitName Value="X3DFields"/>
+        <Filename Value="../src/x3d/x3devents_descendants.inc"/>
+        <Type Value="Include"/>
       </Item279>
       <Item280>
-        <Filename Value="../src/x3d/x3dlexer.pas"/>
-        <UnitName Value="X3DLexer"/>
+        <Filename Value="../src/x3d/x3dfields.pas"/>
+        <UnitName Value="X3DFields"/>
       </Item280>
       <Item281>
-        <Filename Value="../src/x3d/x3dload.pas"/>
-        <UnitName Value="X3DLoad"/>
+        <Filename Value="../src/x3d/x3dlexer.pas"/>
+        <UnitName Value="X3DLexer"/>
       </Item281>
       <Item282>
-        <Filename Value="../src/x3d/x3dloadinternal3ds.pas"/>
-        <UnitName Value="X3DLoadInternal3DS"/>
+        <Filename Value="../src/x3d/x3dload.pas"/>
+        <UnitName Value="X3DLoad"/>
       </Item282>
       <Item283>
-        <Filename Value="../src/x3d/x3dloadinternalcollada.pas"/>
-        <UnitName Value="X3DLoadInternalCollada"/>
+        <Filename Value="../src/x3d/x3dloadinternal3ds.pas"/>
+        <UnitName Value="X3DLoadInternal3DS"/>
       </Item283>
       <Item284>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_cameras.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada.pas"/>
+        <UnitName Value="X3DLoadInternalCollada"/>
       </Item284>
       <Item285>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_controllers.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_cameras.inc"/>
         <Type Value="Include"/>
       </Item285>
       <Item286>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_effects.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_controllers.inc"/>
         <Type Value="Include"/>
       </Item286>
       <Item287>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_geometries.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_effects.inc"/>
         <Type Value="Include"/>
       </Item287>
       <Item288>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_images.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_geometries.inc"/>
         <Type Value="Include"/>
       </Item288>
       <Item289>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_indexes.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_images.inc"/>
         <Type Value="Include"/>
       </Item289>
       <Item290>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_integerparser.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_indexes.inc"/>
         <Type Value="Include"/>
       </Item290>
       <Item291>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_librarynodes.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_integerparser.inc"/>
         <Type Value="Include"/>
       </Item291>
       <Item292>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_lights.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_librarynodes.inc"/>
         <Type Value="Include"/>
       </Item292>
       <Item293>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_materials.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_lights.inc"/>
         <Type Value="Include"/>
       </Item293>
       <Item294>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_materialsmap.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_materials.inc"/>
         <Type Value="Include"/>
       </Item294>
       <Item295>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_matrix.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_materialsmap.inc"/>
         <Type Value="Include"/>
       </Item295>
       <Item296>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_node.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_matrix.inc"/>
         <Type Value="Include"/>
       </Item296>
       <Item297>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_primitives.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_node.inc"/>
         <Type Value="Include"/>
       </Item297>
       <Item298>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_read_helpers.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_primitives.inc"/>
         <Type Value="Include"/>
       </Item298>
       <Item299>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_scenes.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_read_helpers.inc"/>
         <Type Value="Include"/>
       </Item299>
       <Item300>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_source.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_scenes.inc"/>
         <Type Value="Include"/>
       </Item300>
       <Item301>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_sources.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_source.inc"/>
         <Type Value="Include"/>
       </Item301>
       <Item302>
-        <Filename Value="../src/x3d/x3dloadinternalcollada_stringtexturenodemap.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_sources.inc"/>
         <Type Value="Include"/>
       </Item302>
       <Item303>
-        <Filename Value="../src/x3d/x3dloadinternalgeo.pas"/>
-        <UnitName Value="X3DLoadInternalGEO"/>
+        <Filename Value="../src/x3d/x3dloadinternalcollada_stringtexturenodemap.inc"/>
+        <Type Value="Include"/>
       </Item303>
       <Item304>
-        <Filename Value="../src/x3d/x3dloadinternalmd3.pas"/>
-        <UnitName Value="X3DLoadInternalMD3"/>
+        <Filename Value="../src/x3d/x3dloadinternalgeo.pas"/>
+        <UnitName Value="X3DLoadInternalGEO"/>
       </Item304>
       <Item305>
-        <Filename Value="../src/x3d/x3dloadinternalobj.pas"/>
-        <UnitName Value="X3DLoadInternalOBJ"/>
+        <Filename Value="../src/x3d/x3dloadinternalmd3.pas"/>
+        <UnitName Value="X3DLoadInternalMD3"/>
       </Item305>
       <Item306>
-        <Filename Value="../src/x3d/x3dloadinternalspine.pas"/>
-        <UnitName Value="X3DLoadInternalSpine"/>
+        <Filename Value="../src/x3d/x3dloadinternalobj.pas"/>
+        <UnitName Value="X3DLoadInternalOBJ"/>
       </Item306>
       <Item307>
-        <Filename Value="../src/x3d/x3dloadinternalspine_animations.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine.pas"/>
+        <UnitName Value="X3DLoadInternalSpine"/>
       </Item307>
       <Item308>
-        <Filename Value="../src/x3d/x3dloadinternalspine_atlas.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_animations.inc"/>
         <Type Value="Include"/>
       </Item308>
       <Item309>
-        <Filename Value="../src/x3d/x3dloadinternalspine_attachments.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_atlas.inc"/>
         <Type Value="Include"/>
       </Item309>
       <Item310>
-        <Filename Value="../src/x3d/x3dloadinternalspine_bones.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_attachments.inc"/>
         <Type Value="Include"/>
       </Item310>
       <Item311>
-        <Filename Value="../src/x3d/x3dloadinternalspine_bonetimelines.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_bones.inc"/>
         <Type Value="Include"/>
       </Item311>
       <Item312>
-        <Filename Value="../src/x3d/x3dloadinternalspine_drawordertimelines.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_bonetimelines.inc"/>
         <Type Value="Include"/>
       </Item312>
       <Item313>
-        <Filename Value="../src/x3d/x3dloadinternalspine_json.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_drawordertimelines.inc"/>
         <Type Value="Include"/>
       </Item313>
       <Item314>
-        <Filename Value="../src/x3d/x3dloadinternalspine_simpletextureloader.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_json.inc"/>
         <Type Value="Include"/>
       </Item314>
       <Item315>
-        <Filename Value="../src/x3d/x3dloadinternalspine_skeleton.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_simpletextureloader.inc"/>
         <Type Value="Include"/>
       </Item315>
       <Item316>
-        <Filename Value="../src/x3d/x3dloadinternalspine_skins.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_skeleton.inc"/>
         <Type Value="Include"/>
       </Item316>
       <Item317>
-        <Filename Value="../src/x3d/x3dloadinternalspine_slots.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_skins.inc"/>
         <Type Value="Include"/>
       </Item317>
       <Item318>
-        <Filename Value="../src/x3d/x3dloadinternalspine_slottimelines.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_slots.inc"/>
         <Type Value="Include"/>
       </Item318>
       <Item319>
-        <Filename Value="../src/x3d/x3dloadinternalspine_textureloader.inc"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_slottimelines.inc"/>
         <Type Value="Include"/>
       </Item319>
       <Item320>
-        <Filename Value="../src/x3d/x3dloadinternalutils.pas"/>
-        <UnitName Value="X3DLoadInternalUtils"/>
+        <Filename Value="../src/x3d/x3dloadinternalspine_textureloader.inc"/>
+        <Type Value="Include"/>
       </Item320>
       <Item321>
-        <Filename Value="../src/x3d/x3dnodes.pas"/>
-        <UnitName Value="X3DNodes"/>
+        <Filename Value="../src/x3d/x3dloadinternalutils.pas"/>
+        <UnitName Value="X3DLoadInternalUtils"/>
       </Item321>
       <Item322>
-        <Filename Value="../src/x3d/x3dnodes_1.inc"/>
-        <Type Value="Include"/>
+        <Filename Value="../src/x3d/x3dnodes.pas"/>
+        <UnitName Value="X3DNodes"/>
       </Item322>
       <Item323>
-        <Filename Value="../src/x3d/x3dnodes_97_hanim.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_1.inc"/>
         <Type Value="Include"/>
       </Item323>
       <Item324>
-        <Filename Value="../src/x3d/x3dnodes_97_nurbs.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_97_hanim.inc"/>
         <Type Value="Include"/>
       </Item324>
       <Item325>
-        <Filename Value="../src/x3d/x3dnodes_avalon.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_97_nurbs.inc"/>
         <Type Value="Include"/>
       </Item325>
       <Item326>
-        <Filename Value="../src/x3d/x3dnodes_bitmanagement.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_avalon.inc"/>
         <Type Value="Include"/>
       </Item326>
       <Item327>
-        <Filename Value="../src/x3d/x3dnodes_boundingboxes.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_bitmanagement.inc"/>
         <Type Value="Include"/>
       </Item327>
       <Item328>
-        <Filename Value="../src/x3d/x3dnodes_box.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_boundingboxes.inc"/>
         <Type Value="Include"/>
       </Item328>
       <Item329>
-        <Filename Value="../src/x3d/x3dnodes_castle.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_box.inc"/>
         <Type Value="Include"/>
       </Item329>
       <Item330>
-        <Filename Value="../src/x3d/x3dnodes_cone_cylinder.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_castle.inc"/>
         <Type Value="Include"/>
       </Item330>
       <Item331>
-        <Filename Value="../src/x3d/x3dnodes_coordpolygons.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_cone_cylinder.inc"/>
         <Type Value="Include"/>
       </Item331>
       <Item332>
-        <Filename Value="../src/x3d/x3dnodes_elevationgrid.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_coordpolygons.inc"/>
         <Type Value="Include"/>
       </Item332>
       <Item333>
-        <Filename Value="../src/x3d/x3dnodes_encoding_classic.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_elevationgrid.inc"/>
         <Type Value="Include"/>
       </Item333>
       <Item334>
-        <Filename Value="../src/x3d/x3dnodes_encoding_xml.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_encoding_classic.inc"/>
         <Type Value="Include"/>
       </Item334>
       <Item335>
-        <Filename Value="../src/x3d/x3dnodes_eventsengine.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_encoding_xml.inc"/>
         <Type Value="Include"/>
       </Item335>
       <Item336>
-        <Filename Value="../src/x3d/x3dnodes_extrusion.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_eventsengine.inc"/>
         <Type Value="Include"/>
       </Item336>
       <Item337>
-        <Filename Value="../src/x3d/x3dnodes_generatedtextures.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_extrusion.inc"/>
         <Type Value="Include"/>
       </Item337>
       <Item338>
-        <Filename Value="../src/x3d/x3dnodes_inventor.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_generatedtextures.inc"/>
         <Type Value="Include"/>
       </Item338>
       <Item339>
-        <Filename Value="../src/x3d/x3dnodes_lightcontribution.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_inventor.inc"/>
         <Type Value="Include"/>
       </Item339>
       <Item340>
-        <Filename Value="../src/x3d/x3dnodes_load.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_lightcontribution.inc"/>
         <Type Value="Include"/>
       </Item340>
       <Item341>
-        <Filename Value="../src/x3d/x3dnodes_node.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_load.inc"/>
         <Type Value="Include"/>
       </Item341>
       <Item342>
-        <Filename Value="../src/x3d/x3dnodes_node_helpers.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_node.inc"/>
         <Type Value="Include"/>
       </Item342>
       <Item343>
-        <Filename Value="../src/x3d/x3dnodes_save.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_node_helpers.inc"/>
         <Type Value="Include"/>
       </Item343>
       <Item344>
-        <Filename Value="../src/x3d/x3dnodes_sphere.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_save.inc"/>
         <Type Value="Include"/>
       </Item344>
       <Item345>
-        <Filename Value="../src/x3d/x3dnodes_verticesandtrianglescounting.inc"/>
+        <Filename Value="../src/x3d/x3dnodes_sphere.inc"/>
         <Type Value="Include"/>
       </Item345>
       <Item346>
-        <Filename Value="../src/x3d/x3dnodesdetailoptions.pas"/>
-        <UnitName Value="X3DNodesDetailOptions"/>
+        <Filename Value="../src/x3d/x3dnodes_verticesandtrianglescounting.inc"/>
+        <Type Value="Include"/>
       </Item346>
       <Item347>
-        <Filename Value="../src/x3d/x3dshadowmaps.pas"/>
-        <UnitName Value="X3DShadowMaps"/>
+        <Filename Value="../src/x3d/x3dnodesdetailoptions.pas"/>
+        <UnitName Value="X3DNodesDetailOptions"/>
       </Item347>
       <Item348>
-        <Filename Value="../src/x3d/x3dtime.pas"/>
-        <UnitName Value="X3DTime"/>
+        <Filename Value="../src/x3d/x3dshadowmaps.pas"/>
+        <UnitName Value="X3DShadowMaps"/>
       </Item348>
       <Item349>
-        <Filename Value="../src/x3d/x3dtriangles.pas"/>
-        <UnitName Value="X3DTriangles"/>
+        <Filename Value="../src/x3d/x3dtime.pas"/>
+        <UnitName Value="X3DTime"/>
       </Item349>
       <Item350>
-        <Filename Value="../src/base/castlestreamutils.pas"/>
-        <UnitName Value="CastleStreamUtils"/>
+        <Filename Value="../src/x3d/x3dtriangles.pas"/>
+        <UnitName Value="X3DTriangles"/>
       </Item350>
     </Files>
     <RequiredPkgs Count="1">

--- a/src/base/castleclassutils.pas
+++ b/src/base/castleclassutils.pas
@@ -1218,11 +1218,15 @@ begin
 end;
 
 function TSimplePeekCharStream.PeekChar: Integer;
+var
+  C: Char;
 begin
   if not IsPeekedChar then
   begin
-    if SourceStream.Read(PeekedChar, 1) = 0 then
-      PeekedChar := -1;
+    if SourceStream.Read(C, 1) = 0 then
+      PeekedChar := -1
+    else
+      PeekedChar := Ord(C);
     IsPeekedChar := true;
   end;
   Result := PeekedChar;

--- a/src/base/castlestreamutils.pas
+++ b/src/base/castlestreamutils.pas
@@ -32,60 +32,60 @@ type
       Byte order.
 
       @groupBegin }
-    function ReadLE(out Value: Word): Boolean; overload;
-    function ReadLE(out Value: LongWord): Boolean; overload;
-    function ReadLE(out Value: QWord): Boolean; overload;
-    function ReadLE(out Value: SmallInt): Boolean; overload;
-    function ReadLE(out Value: LongInt): Boolean; overload;
-    function ReadLE(out Value: Int64): Boolean; overload;
-    function ReadLE(out Value: Single): Boolean; overload;
-    function ReadLE(out Value: Double): Boolean; overload;
-    function ReadLE(out Value: TVector2Single): Boolean; overload;
-    function ReadLE(out Value: TVector2Double): Boolean; overload;
-    function ReadLE(out Value: TVector3Single): Boolean; overload;
-    function ReadLE(out Value: TVector3Double): Boolean; overload;
-    function ReadLE(out Value: TVector4Single): Boolean; overload;
-    function ReadLE(out Value: TVector4Double): Boolean; overload;
+    procedure ReadLE(out Value: Word); overload;
+    procedure ReadLE(out Value: LongWord); overload;
+    procedure ReadLE(out Value: QWord); overload;
+    procedure ReadLE(out Value: SmallInt); overload;
+    procedure ReadLE(out Value: LongInt); overload;
+    procedure ReadLE(out Value: Int64); overload;
+    procedure ReadLE(out Value: Single); overload;
+    procedure ReadLE(out Value: Double); overload;
+    procedure ReadLE(out Value: TVector2Single); overload;
+    procedure ReadLE(out Value: TVector2Double); overload;
+    procedure ReadLE(out Value: TVector3Single); overload;
+    procedure ReadLE(out Value: TVector3Double); overload;
+    procedure ReadLE(out Value: TVector4Single); overload;
+    procedure ReadLE(out Value: TVector4Double); overload;
     { @groupEnd }
 
     { Reads a big endian value from the stream and converts it to native
       Byte order.
 
       @groupBegin }
-    function ReadBE(out Value: Word): Boolean; overload;
-    function ReadBE(out Value: LongWord): Boolean; overload;
-    function ReadBE(out Value: QWord): Boolean; overload;
-    function ReadBE(out Value: SmallInt): Boolean; overload;
-    function ReadBE(out Value: LongInt): Boolean; overload;
-    function ReadBE(out Value: Int64): Boolean; overload;
-    function ReadBE(out Value: Single): Boolean; overload;
-    function ReadBE(out Value: Double): Boolean; overload;
+    procedure ReadBE(out Value: Word); overload;
+    procedure ReadBE(out Value: LongWord); overload;
+    procedure ReadBE(out Value: QWord); overload;
+    procedure ReadBE(out Value: SmallInt); overload;
+    procedure ReadBE(out Value: LongInt); overload;
+    procedure ReadBE(out Value: Int64); overload;
+    procedure ReadBE(out Value: Single); overload;
+    procedure ReadBE(out Value: Double); overload;
     { @groupEnd }
 
     { Writes a value in native Byte order as little endian value to the stream.
 
       @groupBegin }
-    function WriteLE(const Value: Word): Boolean; overload;
-    function WriteLE(const Value: LongWord): Boolean; overload;
-    function WriteLE(const Value: QWord): Boolean; overload;
-    function WriteLE(const Value: SmallInt): Boolean; overload;
-    function WriteLE(const Value: LongInt): Boolean; overload;
-    function WriteLE(const Value: Int64): Boolean; overload;
-    function WriteLE(const Value: Single): Boolean; overload;
-    function WriteLE(const Value: Double): Boolean; overload;
+    procedure WriteLE(const Value: Word); overload;
+    procedure WriteLE(const Value: LongWord); overload;
+    procedure WriteLE(const Value: QWord); overload;
+    procedure WriteLE(const Value: SmallInt); overload;
+    procedure WriteLE(const Value: LongInt); overload;
+    procedure WriteLE(const Value: Int64); overload;
+    procedure WriteLE(const Value: Single); overload;
+    procedure WriteLE(const Value: Double); overload;
     { @groupEnd }
 
     { Writes a value in native Byte order as big endian value to the stream.
 
       @groupBegin }
-    function WriteBE(const Value: Word): Boolean; overload;
-    function WriteBE(const Value: LongWord): Boolean; overload;
-    function WriteBE(const Value: QWord): Boolean; overload;
-    function WriteBE(const Value: SmallInt): Boolean; overload;
-    function WriteBE(const Value: LongInt): Boolean; overload;
-    function WriteBE(const Value: Int64): Boolean; overload;
-    function WriteBE(const Value: Single): Boolean; overload;
-    function WriteBE(const Value: Double): Boolean; overload;
+    procedure WriteBE(const Value: Word); overload;
+    procedure WriteBE(const Value: LongWord); overload;
+    procedure WriteBE(const Value: QWord); overload;
+    procedure WriteBE(const Value: SmallInt); overload;
+    procedure WriteBE(const Value: LongInt); overload;
+    procedure WriteBE(const Value: Int64); overload;
+    procedure WriteBE(const Value: Single); overload;
+    procedure WriteBE(const Value: Double); overload;
     { @groupEnd }
   end;
 
@@ -96,340 +96,264 @@ uses
 
 { TStreamHelper -------------------------------------------------------------- }
 
-function TStreamHelper.ReadLE(out Value: Word): Boolean;
+procedure TStreamHelper.ReadLE(out Value: Word);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: LongWord): Boolean;
+procedure TStreamHelper.ReadLE(out Value: LongWord);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: QWord): Boolean;
+procedure TStreamHelper.ReadLE(out Value: QWord);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: SmallInt): Boolean;
+procedure TStreamHelper.ReadLE(out Value: SmallInt);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: LongInt): Boolean;
+procedure TStreamHelper.ReadLE(out Value: LongInt);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: Int64): Boolean;
+procedure TStreamHelper.ReadLE(out Value: Int64);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: Single): Boolean;
+procedure TStreamHelper.ReadLE(out Value: Single);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: Double): Boolean;
+procedure TStreamHelper.ReadLE(out Value: Double);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: TVector2Single): Boolean;
+procedure TStreamHelper.ReadLE(out Value: TVector2Single);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: TVector2Double): Boolean;
+procedure TStreamHelper.ReadLE(out Value: TVector2Double);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: TVector3Single): Boolean;
+procedure TStreamHelper.ReadLE(out Value: TVector3Single);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: TVector3Double): Boolean;
+procedure TStreamHelper.ReadLE(out Value: TVector3Double);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: TVector4Single): Boolean;
+procedure TStreamHelper.ReadLE(out Value: TVector4Single);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadLE(out Value: TVector4Double): Boolean;
+procedure TStreamHelper.ReadLE(out Value: TVector4Double);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := LEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadBE(out Value: Word): Boolean;
+procedure TStreamHelper.ReadBE(out Value: Word);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := BEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadBE(out Value: LongWord): Boolean;
+procedure TStreamHelper.ReadBE(out Value: LongWord);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := BEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadBE(out Value: QWord): Boolean;
+procedure TStreamHelper.ReadBE(out Value: QWord);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := BEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadBE(out Value: SmallInt): Boolean;
+procedure TStreamHelper.ReadBE(out Value: SmallInt);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := BEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadBE(out Value: LongInt): Boolean;
+procedure TStreamHelper.ReadBE(out Value: LongInt);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := BEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadBE(out Value: Int64): Boolean;
+procedure TStreamHelper.ReadBE(out Value: Int64);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := BEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadBE(out Value: Single): Boolean;
+procedure TStreamHelper.ReadBE(out Value: Single);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := BEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.ReadBE(out Value: Double): Boolean;
+procedure TStreamHelper.ReadBE(out Value: Double);
 begin
-  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
-    Exit(False);
+  ReadBuffer(Value, SizeOf(Value));
   Value := BEtoN(Value);
-  Result := True;
 end;
 
-function TStreamHelper.WriteLE(const Value: Word): Boolean;
+procedure TStreamHelper.WriteLE(const Value: Word);
 var
   tmp: Word;
 begin
   tmp := NToLE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteLE(const Value: LongWord): Boolean;
+procedure TStreamHelper.WriteLE(const Value: LongWord);
 var
   tmp: LongWord;
 begin
   tmp := NToLE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteLE(const Value: QWord): Boolean;
+procedure TStreamHelper.WriteLE(const Value: QWord);
 var
   tmp: QWord;
 begin
   tmp := NToLE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteLE(const Value: SmallInt): Boolean;
+procedure TStreamHelper.WriteLE(const Value: SmallInt);
 var
   tmp: SmallInt;
 begin
   tmp := NToLE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteLE(const Value: LongInt): Boolean;
+procedure TStreamHelper.WriteLE(const Value: LongInt);
 var
   tmp: LongInt;
 begin
   tmp := NToLE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteLE(const Value: Int64): Boolean;
+procedure TStreamHelper.WriteLE(const Value: Int64);
 var
   tmp: Int64;
 begin
   tmp := NToLE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(Value) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteLE(const Value: Single): Boolean;
+procedure TStreamHelper.WriteLE(const Value: Single);
 var
   tmp: Single;
 begin
   tmp := NToLE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteLE(const Value: Double): Boolean;
+procedure TStreamHelper.WriteLE(const Value: Double);
 var
   tmp: Double;
 begin
   tmp := NToLE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteBE(const Value: Word): Boolean;
+procedure TStreamHelper.WriteBE(const Value: Word);
 var
   tmp: Word;
 begin
   tmp := NToBE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteBE(const Value: LongWord): Boolean;
+procedure TStreamHelper.WriteBE(const Value: LongWord);
 var
   tmp: LongWord;
 begin
   tmp := NToBE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteBE(const Value: QWord): Boolean;
+procedure TStreamHelper.WriteBE(const Value: QWord);
 var
   tmp: QWord;
 begin
   tmp := NToBE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteBE(const Value: SmallInt): Boolean;
+procedure TStreamHelper.WriteBE(const Value: SmallInt);
 var
   tmp: SmallInt;
 begin
   tmp := NToBE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteBE(const Value: LongInt): Boolean;
+procedure TStreamHelper.WriteBE(const Value: LongInt);
 var
   tmp: LongInt;
 begin
   tmp := NToBE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteBE(const Value: Int64): Boolean;
+procedure TStreamHelper.WriteBE(const Value: Int64);
 var
   tmp: Int64;
 begin
   tmp := NToBE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteBE(const Value: Single): Boolean;
+procedure TStreamHelper.WriteBE(const Value: Single);
 var
   tmp: Single;
 begin
   tmp := NToBE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
-function TStreamHelper.WriteBE(const Value: Double): Boolean;
+procedure TStreamHelper.WriteBE(const Value: Double);
 var
   tmp: Double;
 begin
   tmp := NToBE(Value);
-  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
-    Exit(False);
-  Result := True;
+  WriteBuffer(tmp, SizeOf(tmp));
 end;
 
 end.

--- a/src/base/castlestreamutils.pas
+++ b/src/base/castlestreamutils.pas
@@ -1,0 +1,436 @@
+{
+  Copyright 2015 Sven Barth.
+
+  This file is part of "Castle Game Engine".
+
+  "Castle Game Engine" is free software; see the file COPYING.txt,
+  included in this distribution, for details about the copyright.
+
+  "Castle Game Engine" is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+  ----------------------------------------------------------------------------
+}
+
+{ TStream utilities and helpers }
+unit CastleStreamUtils;
+
+{$I castleconf.inc}
+
+interface
+
+uses
+  Classes, CastleVectors;
+
+type
+  { Helper class for streams that allows to correct read and write either little
+    or big endian values. }
+  TStreamHelper = class helper for TStream
+  public
+    { Reads a little endian value from the stream and converts it to native
+      Byte order.
+
+      @groupBegin }
+    function ReadLE(out Value: Word): Boolean; overload;
+    function ReadLE(out Value: LongWord): Boolean; overload;
+    function ReadLE(out Value: QWord): Boolean; overload;
+    function ReadLE(out Value: SmallInt): Boolean; overload;
+    function ReadLE(out Value: LongInt): Boolean; overload;
+    function ReadLE(out Value: Int64): Boolean; overload;
+    function ReadLE(out Value: Single): Boolean; overload;
+    function ReadLE(out Value: Double): Boolean; overload;
+    function ReadLE(out Value: TVector2Single): Boolean; overload;
+    function ReadLE(out Value: TVector2Double): Boolean; overload;
+    function ReadLE(out Value: TVector3Single): Boolean; overload;
+    function ReadLE(out Value: TVector3Double): Boolean; overload;
+    function ReadLE(out Value: TVector4Single): Boolean; overload;
+    function ReadLE(out Value: TVector4Double): Boolean; overload;
+    { @groupEnd }
+
+    { Reads a big endian value from the stream and converts it to native
+      Byte order.
+
+      @groupBegin }
+    function ReadBE(out Value: Word): Boolean; overload;
+    function ReadBE(out Value: LongWord): Boolean; overload;
+    function ReadBE(out Value: QWord): Boolean; overload;
+    function ReadBE(out Value: SmallInt): Boolean; overload;
+    function ReadBE(out Value: LongInt): Boolean; overload;
+    function ReadBE(out Value: Int64): Boolean; overload;
+    function ReadBE(out Value: Single): Boolean; overload;
+    function ReadBE(out Value: Double): Boolean; overload;
+    { @groupEnd }
+
+    { Writes a value in native Byte order as little endian value to the stream.
+
+      @groupBegin }
+    function WriteLE(const Value: Word): Boolean; overload;
+    function WriteLE(const Value: LongWord): Boolean; overload;
+    function WriteLE(const Value: QWord): Boolean; overload;
+    function WriteLE(const Value: SmallInt): Boolean; overload;
+    function WriteLE(const Value: LongInt): Boolean; overload;
+    function WriteLE(const Value: Int64): Boolean; overload;
+    function WriteLE(const Value: Single): Boolean; overload;
+    function WriteLE(const Value: Double): Boolean; overload;
+    { @groupEnd }
+
+    { Writes a value in native Byte order as big endian value to the stream.
+
+      @groupBegin }
+    function WriteBE(const Value: Word): Boolean; overload;
+    function WriteBE(const Value: LongWord): Boolean; overload;
+    function WriteBE(const Value: QWord): Boolean; overload;
+    function WriteBE(const Value: SmallInt): Boolean; overload;
+    function WriteBE(const Value: LongInt): Boolean; overload;
+    function WriteBE(const Value: Int64): Boolean; overload;
+    function WriteBE(const Value: Single): Boolean; overload;
+    function WriteBE(const Value: Double): Boolean; overload;
+    { @groupEnd }
+  end;
+
+implementation
+
+uses
+  CastleUtils;
+
+{ TStreamHelper -------------------------------------------------------------- }
+
+function TStreamHelper.ReadLE(out Value: Word): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: LongWord): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: QWord): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: SmallInt): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: LongInt): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: Int64): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: Single): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: Double): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: TVector2Single): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: TVector2Double): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: TVector3Single): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: TVector3Double): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: TVector4Single): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadLE(out Value: TVector4Double): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := LEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadBE(out Value: Word): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := BEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadBE(out Value: LongWord): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := BEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadBE(out Value: QWord): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := BEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadBE(out Value: SmallInt): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := BEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadBE(out Value: LongInt): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := BEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadBE(out Value: Int64): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := BEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadBE(out Value: Single): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := BEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.ReadBE(out Value: Double): Boolean;
+begin
+  if Read(Value, SizeOf(Value)) <> SizeOf(Value) then
+    Exit(False);
+  Value := BEtoN(Value);
+  Result := True;
+end;
+
+function TStreamHelper.WriteLE(const Value: Word): Boolean;
+var
+  tmp: Word;
+begin
+  tmp := NToLE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteLE(const Value: LongWord): Boolean;
+var
+  tmp: LongWord;
+begin
+  tmp := NToLE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteLE(const Value: QWord): Boolean;
+var
+  tmp: QWord;
+begin
+  tmp := NToLE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteLE(const Value: SmallInt): Boolean;
+var
+  tmp: SmallInt;
+begin
+  tmp := NToLE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteLE(const Value: LongInt): Boolean;
+var
+  tmp: LongInt;
+begin
+  tmp := NToLE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteLE(const Value: Int64): Boolean;
+var
+  tmp: Int64;
+begin
+  tmp := NToLE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(Value) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteLE(const Value: Single): Boolean;
+var
+  tmp: Single;
+begin
+  tmp := NToLE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteLE(const Value: Double): Boolean;
+var
+  tmp: Double;
+begin
+  tmp := NToLE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteBE(const Value: Word): Boolean;
+var
+  tmp: Word;
+begin
+  tmp := NToBE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteBE(const Value: LongWord): Boolean;
+var
+  tmp: LongWord;
+begin
+  tmp := NToBE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteBE(const Value: QWord): Boolean;
+var
+  tmp: QWord;
+begin
+  tmp := NToBE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteBE(const Value: SmallInt): Boolean;
+var
+  tmp: SmallInt;
+begin
+  tmp := NToBE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteBE(const Value: LongInt): Boolean;
+var
+  tmp: LongInt;
+begin
+  tmp := NToBE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteBE(const Value: Int64): Boolean;
+var
+  tmp: Int64;
+begin
+  tmp := NToBE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteBE(const Value: Single): Boolean;
+var
+  tmp: Single;
+begin
+  tmp := NToBE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+function TStreamHelper.WriteBE(const Value: Double): Boolean;
+var
+  tmp: Double;
+begin
+  tmp := NToBE(Value);
+  if Write(tmp, SizeOf(tmp)) <> SizeOf(tmp) then
+    Exit(False);
+  Result := True;
+end;
+
+end.
+

--- a/src/base/castleutils_math.inc
+++ b/src/base/castleutils_math.inc
@@ -360,6 +360,27 @@ function IntSqrt(const Value: Cardinal): Cardinal;
   http://www.khronos.org/opengles/sdk/docs/manglsl/xhtml/smoothstep.xml }
 function SmoothStep(const Edge0, Edge1, X: Single): Single;
 
+{ Utility functions to control the endianess of Single and Double values; no
+  support for Extended though as such values have yet to be encountered when
+  read from a file
+
+  @groupBegin }
+function SwapEndian(const Value: Single): Single; overload;
+function SwapEndian(const Value: Double): Double; overload;
+
+function NtoLE(const Value: Single): Single; overload;
+function NtoLE(const Value: Double): Double; overload;
+
+function NtoBE(const Value: Single): Single; overload;
+function NtoBE(const Value: Double): Double; overload;
+
+function LEtoN(const Value: Single): Single; overload;
+function LEtoN(const Value: Double): Double; overload;
+
+function BEtoN(const Value: Single): Single; overload;
+function BEtoN(const Value: Double): Double; overload;
+{ @groupEnd }
+
 {$endif read_interface}
 
 {$ifdef read_implementation}
@@ -1023,6 +1044,88 @@ function SmoothStep(const Edge0, Edge1, X: Single): Single;
 begin
   Result := Clamped((X - Edge0) / (Edge1 - Edge0), 0.0, 1.0);
   Result := Result * Result * (3.0 - 2.0 * Result);
+end;
+
+function SwapEndian(const Value: Single): Single;
+begin
+  PLongWord(@Result)^ := SwapEndian(PLongWord(@Value)^);
+end;
+
+function SwapEndian(const Value: Double): Double;
+begin
+  PQWord(@Result)^ := SwapEndian(PQWord(@Value)^);
+end;
+
+function NtoLE(const Value: Single): Single;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(Value);
+{$else ENDIAN_BIG}
+  Result := Value;
+{$endif ENDIAN_BIG}
+end;
+
+function NtoLE(const Value: Double): Double;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(Value);
+{$else ENDIAN_BIG}
+  Result := Value;
+{$endif ENDIAN_BIG}
+end;
+
+function NtoBE(const Value: Single): Single;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := Value;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(Value);
+{$endif ENDIAN_BIG}
+end;
+
+function NtoBE(const Value: Double): Double;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := Value;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(Value);
+{$endif ENDIAN_BIG}
+end;
+
+function LEtoN(const Value: Single): Single;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(Value);
+{$else ENDIAN_BIG}
+  Result := Value;
+{$endif ENDIAN_BIG}
+end;
+
+function LEtoN(const Value: Double): Double;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(Value);
+{$else ENDIAN_BIG}
+  Result := Value;
+{$endif ENDIAN_BIG}
+end;
+
+function BEtoN(const Value: Single): Single;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := Value;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(Value);
+{$endif ENDIAN_BIG}
+end;
+
+function BEtoN(const Value: Double): Double;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := Value;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(Value);
+{$endif ENDIAN_BIG}
 end;
 
 {$endif read_implementation}

--- a/src/base/castlevectors.pas
+++ b/src/base/castlevectors.pas
@@ -651,6 +651,43 @@ operator := (const V: TVector2Single): TVector2_Single;
 operator := (const V: TVector3Single): TVector3_Single;
 operator := (const V: TVector4Single): TVector4_Single;
 
+{ Endianess utility functions for vectors  ----------------------------------- }
+
+function SwapEndian(const V: TVector2Single): TVector2Single; overload;
+function SwapEndian(const V: TVector2Double): TVector2Double; overload;
+function SwapEndian(const V: TVector3Single): TVector3Single; overload;
+function SwapEndian(const V: TVector3Double): TVector3Double; overload;
+function SwapEndian(const V: TVector4Single): TVector4Single; overload;
+function SwapEndian(const V: TVector4Double): TVector4Double; overload;
+
+function LEtoN(const V: TVector2Single): TVector2Single; overload;
+function LEtoN(const V: TVector2Double): TVector2Double; overload;
+function LEtoN(const V: TVector3Single): TVector3Single; overload;
+function LEtoN(const V: TVector3Double): TVector3Double; overload;
+function LEtoN(const V: TVector4Single): TVector4Single; overload;
+function LEtoN(const V: TVector4Double): TVector4Double; overload;
+
+function BEtoN(const V: TVector2Single): TVector2Single; overload;
+function BEtoN(const V: TVector2Double): TVector2Double; overload;
+function BEtoN(const V: TVector3Single): TVector3Single; overload;
+function BEtoN(const V: TVector3Double): TVector3Double; overload;
+function BEtoN(const V: TVector4Single): TVector4Single; overload;
+function BEtoN(const V: TVector4Double): TVector4Double; overload;
+
+function NtoLE(const V: TVector2Single): TVector2Single; overload;
+function NtoLE(const V: TVector2Double): TVector2Double; overload;
+function NtoLE(const V: TVector3Single): TVector3Single; overload;
+function NtoLE(const V: TVector3Double): TVector3Double; overload;
+function NtoLE(const V: TVector4Single): TVector4Single; overload;
+function NtoLE(const V: TVector4Double): TVector4Double; overload;
+
+function NtoBE(const V: TVector2Single): TVector2Single; overload;
+function NtoBE(const V: TVector2Double): TVector2Double; overload;
+function NtoBE(const V: TVector3Single): TVector3Single; overload;
+function NtoBE(const V: TVector3Double): TVector3Double; overload;
+function NtoBE(const V: TVector4Single): TVector4Single; overload;
+function NtoBE(const V: TVector4Double): TVector4Double; overload;
+
 { Simple vectors operations  ------------------------------------------------- }
 
 { }

--- a/src/base/castlevectors_dualimplementation.inc
+++ b/src/base/castlevectors_dualimplementation.inc
@@ -226,6 +226,135 @@ begin
   V1[2] *= V2[2];
 end;
 
+function SwapEndian(const V: TVector2): TVector2;
+begin
+  Result[0] := SwapEndian(V[0]);
+  Result[1] := SwapEndian(V[1]);
+end;
+
+function SwapEndian(const V: TVector3): TVector3;
+begin
+  Result[0] := SwapEndian(V[0]);
+  Result[1] := SwapEndian(V[1]);
+  Result[2] := SwapEndian(V[2]);
+end;
+
+function SwapEndian(const V: TVector4): TVector4;
+begin
+  Result[0] := SwapEndian(V[0]);
+  Result[1] := SwapEndian(V[1]);
+  Result[2] := SwapEndian(V[2]);
+  Result[3] := SwapEndian(V[3]);
+end;
+
+function NtoLE(const V: TVector2): TVector2;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$else ENDIAN_BIG}
+  Result := V;
+{$endif ENDIAN_BIG}
+end;
+
+function NtoLE(const V: TVector3): TVector3;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$else ENDIAN_BIG}
+  Result := V;
+{$endif ENDIAN_BIG}
+end;
+
+function NtoLE(const V: TVector4): TVector4;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$else ENDIAN_BIG}
+  Result := V;
+{$endif ENDIAN_BIG}
+end;
+
+function NtoBE(const V: TVector2): TVector2;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := V;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$endif ENDIAN_BIG}
+end;
+
+function NtoBE(const V: TVector3): TVector3;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := V;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$endif ENDIAN_BIG}
+end;
+
+function NtoBE(const V: TVector4): TVector4;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := V;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$endif ENDIAN_BIG}
+end;
+
+function LEtoN(const V: TVector2): TVector2;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$else ENDIAN_BIG}
+  Result := V;
+{$endif ENDIAN_BIG}
+end;
+
+function LEtoN(const V: TVector3): TVector3;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$else ENDIAN_BIG}
+  Result := V;
+{$endif ENDIAN_BIG}
+end;
+
+function LEtoN(const V: TVector4): TVector4;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$else ENDIAN_BIG}
+  Result := V;
+{$endif ENDIAN_BIG}
+end;
+
+function BEtoN(const V: TVector2): TVector2;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := V;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$endif ENDIAN_BIG}
+end;
+
+function BEtoN(const V: TVector3): TVector3;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := V;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$endif ENDIAN_BIG}
+end;
+
+function BEtoN(const V: TVector4): TVector4;
+begin
+{$ifdef ENDIAN_BIG}
+  Result := V;
+{$else ENDIAN_BIG}
+  Result := SwapEndian(V);
+{$endif ENDIAN_BIG}
+end;
+
 procedure SwapValues(var V1, V2: TVector2);
 var
   Tmp: TVector2;


### PR DESCRIPTION
These changes fix some problems when using the engine on big endian systems.
First of there was a bug in TSimplePeekCharStream that affected the X3D reader and secondly at least the 3DS loader misbehaved. For this I've added a TStream helper that deals with reading (and writing) values in the correct endianess and this helper should be used in the future for reading (and writing) binary data. I've already corrected the 3DS loader and I'll adjust more as I get along with testing everything on my big endian machines (one PowerPC and one M68k), though I don't know how long that will take, so merging this already would be good.