### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.inc linguist-language=Pascal


### PR DESCRIPTION
*.inc files are treated by GitHub as C++ files so the file change this to Pascal. It's only for statistics.