### PR TITLE
Re-implementation of dmBlendSmart and dmMultiply

### DIFF
--- a/src/images/castleimages.pas
+++ b/src/images/castleimages.pas
@@ -246,11 +246,16 @@ destination.alpha := destination.alpha; // never changed by this drawing mode
     dmBlend,
 
     { An advanced blending mode capable of blending 2 images with alpha channel.
-      Based on https://en.wikipedia.org/wiki/Alpha_compositing formula for alpha-blending.
-      This one is much less efficient than dmBlend and should be used only in case
-      several layers of semi-transparent images should overlay one another and it
-      matters to accurately account for both images alpha channel. }
+    Based on https://en.wikipedia.org/wiki/Alpha_compositing formula for alpha-blending.
+    This one is much less efficient than dmBlend and should be used only in case
+    several layers of semi-transparent images should overlay one another and it
+    matters to accurately account for both images alpha channel. Implemented for
+    all @link(TRGBAlphaImage) and @link(TGrayscaleAlphaImage) combinations.
+    }
     dmBlendSmart,
+    { Simple implementation of 'multiply' filter. I.e. bytes of one image are just
+    multiplied by bytes of another image.}
+    dmMultiply,
 
     { Additive drawing mode, where the image contents of source image
       are added to the existing destination image. That is,

--- a/src/images/castleimages_draw.inc
+++ b/src/images/castleimages_draw.inc
@@ -136,6 +136,25 @@ begin
   Result := W;
 end;
 
+function MultiplyBytes(const Dest, Source: Byte): Byte; {$ifdef SUPPORTS_INLINE} inline; {$endif}
+var
+  W: Word;
+begin
+  W := Dest * Word(Source) div 255;
+  if W > 255 then W := 255;
+  Result := W;
+end;
+
+function MultiplyBytesOpaque(const Dest, Source, Opacity: Byte): Byte; {$ifdef SUPPORTS_INLINE} inline; {$endif}
+var
+  W: Word;
+begin
+  W := Dest * (255 - Opacity) div 255 + Dest * Word(Source) div 255 * Opacity div 255;
+  if W > 255 then W := 255;
+  Result := W;
+end;
+
+
 { Drawing when TRGBAlphaImage is a destination ------------------------------- }
 
 procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
@@ -161,6 +180,22 @@ procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
             Inc(PDest);
           end;
         end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],PSource^[0]);
+              PDest^[1] := MultiplyBytes(PDest^[1],PSource^[1]);
+              PDest^[2] := MultiplyBytes(PDest^[2],PSource^[2]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
+          end;
+        end;
       dmAdd:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
@@ -175,7 +210,7 @@ procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
             Inc(PDest);
           end;
         end;
-      else raise EImageDrawError.Create('Blend mode not implemented (TRGBAlphaImage.DrawFromCore)');
+      else raise EImageDrawError.CreateFmt(SErrBlendModeNotImplemented, [Source.ClassName, ClassName]);
     end;
   end;
 
@@ -187,7 +222,6 @@ procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
 
     //variables for smart-blending mode
     alpha1,alpha2,alpha1d,alphaSum:single;
-    j: integer;
   begin
     case Mode of
       dmBlend:
@@ -211,7 +245,7 @@ procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
           PDest := PixelPtr(X, DestY);
           for DestX := X to X + SourceWidth - 1 do
           begin
-            //get single alpha
+            //get alpha in 0..1 range
             alpha1 := PDest^[3]/255;
             alpha2 := PSource^[3]/255;
             //calculate alpha-sums according to https://en.wikipedia.org/wiki/Alpha_compositing
@@ -220,12 +254,30 @@ procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
             // if alpha sum >0 then do the pixel colors and alpha summation according to the formula
             if alphaSum > 0 then
             begin
-              for j := 0 to 2 do
-                PDest^[j] := Round((PDest^[j]*alpha1d + PSource^[j]*alpha2)/alphaSum);
+              PDest^[0] := Round((PDest^[0]*alpha1d + PSource^[0]*alpha2)/alphaSum);
+              PDest^[1] := Round((PDest^[1]*alpha1d + PSource^[1]*alpha2)/alphaSum);
+              PDest^[2] := Round((PDest^[2]*alpha1d + PSource^[2]*alpha2)/alphaSum);
               PDest^[3] := Round(255*alphaSum);
             end;
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],PSource^[0]);
+              PDest^[1] := MultiplyBytes(PDest^[1],PSource^[1]);
+              PDest^[2] := MultiplyBytes(PDest^[2],PSource^[2]);
+              PDest^[3] := MultiplyBytes(PDest^[3],PSource^[3]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -269,6 +321,9 @@ procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
     PSource: PVector2Byte;
     PDest: PVector4Byte;
     DestX, DestY: Integer;
+
+    //variables for smart-blending mode
+    alpha1,alpha2,alpha1d,alphaSum:single;
   begin
     case Mode of
       dmBlend:
@@ -283,6 +338,48 @@ procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
             PDest^[2] := BlendBytes(PDest^[2], PSource^[0], PSource^[1]);
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmBlendSmart:
+        for DestY := Y to Y + SourceHeight - 1 do
+        begin
+          PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+          PDest := PixelPtr(X, DestY);
+          for DestX := X to X + SourceWidth - 1 do
+          begin
+            //get alpha in 0..1 range
+            alpha1 := PDest^[3]/255;
+            alpha2 := PSource^[1]/255;
+            //calculate alpha-sums according to https://en.wikipedia.org/wiki/Alpha_compositing
+            alpha1d := alpha1*(1-alpha2);
+            alphasum := alpha1+(1-alpha1)*alpha2;
+            // if alpha sum >0 then do the pixel colors and alpha summation according to the formula
+            if alphaSum > 0 then
+            begin
+              PDest^[0] := Round((PDest^[0]*alpha1d + PSource^[0]*alpha2)/alphaSum);
+              PDest^[1] := Round((PDest^[1]*alpha1d + PSource^[0]*alpha2)/alphaSum);
+              PDest^[2] := Round((PDest^[2]*alpha1d + PSource^[0]*alpha2)/alphaSum);
+              PDest^[3] := Round(255*alphaSum);
+            end;
+            Inc(PSource);
+            Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],PSource^[0]);
+              PDest^[1] := MultiplyBytes(PDest^[1],PSource^[0]);
+              PDest^[2] := MultiplyBytes(PDest^[2],PSource^[0]);
+              PDest^[3] := MultiplyBytes(PDest^[3],PSource^[1]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -340,6 +437,22 @@ procedure TRGBAlphaImage.DrawFromCore(Source: TCastleImage;
             PDest^[2] := PSource^;
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],PSource^);
+              PDest^[1] := MultiplyBytes(PDest^[1],PSource^);
+              PDest^[2] := MultiplyBytes(PDest^[2],PSource^);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -386,6 +499,22 @@ procedure TRGBImage.DrawFromCore(Source: TCastleImage;
   begin
     case Mode of
       { dmBlend is handled by inherited }
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],PSource^[0]);
+              PDest^[1] := MultiplyBytes(PDest^[1],PSource^[1]);
+              PDest^[2] := MultiplyBytes(PDest^[2],PSource^[2]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
+          end;
+        end;
       dmAdd:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
@@ -411,7 +540,7 @@ procedure TRGBImage.DrawFromCore(Source: TCastleImage;
     DestX, DestY: Integer;
   begin
     case Mode of
-      dmBlend:
+      dmBlend,dmBlendSmart:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
           PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
@@ -423,6 +552,22 @@ procedure TRGBImage.DrawFromCore(Source: TCastleImage;
             PDest^[2] := BlendBytes(PDest^[2], PSource^[2], PSource^[3]);
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytesOpaque(PDest^[0],PSource^[0],PSource^[3]);
+              PDest^[1] := MultiplyBytesOpaque(PDest^[1],PSource^[1],PSource^[3]);
+              PDest^[2] := MultiplyBytesOpaque(PDest^[2],PSource^[2],PSource^[3]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -468,7 +613,7 @@ procedure TRGBImage.DrawFromCore(Source: TCastleImage;
     DestX, DestY: Integer;
   begin
     case Mode of
-      dmBlend:
+      dmBlend,dmBlendSmart:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
           PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
@@ -480,6 +625,22 @@ procedure TRGBImage.DrawFromCore(Source: TCastleImage;
             PDest^[2] := BlendBytes(PDest^[2], PSource^[0], PSource^[1]);
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytesOpaque(PDest^[0],PSource^[0],PSource^[1]);
+              PDest^[1] := MultiplyBytesOpaque(PDest^[1],PSource^[0],PSource^[1]);
+              PDest^[2] := MultiplyBytesOpaque(PDest^[2],PSource^[0],PSource^[1]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -539,6 +700,22 @@ procedure TRGBImage.DrawFromCore(Source: TCastleImage;
             Inc(PDest);
           end;
         end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],PSource^);
+              PDest^[1] := MultiplyBytes(PDest^[1],PSource^);
+              PDest^[2] := MultiplyBytes(PDest^[2],PSource^);
+              Inc(PSource);
+              Inc(PDest);
+            end;
+          end;
+        end;
       dmAdd:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
@@ -558,7 +735,7 @@ procedure TRGBImage.DrawFromCore(Source: TCastleImage;
   end;
 
 begin
-  if (Source is TRGBImage) and (Mode = dmAdd) then
+  if (Source is TRGBImage) and ((Mode = dmAdd) or (Mode = dmMultiply)) then
     SourceRGB(TRGBImage(Source)) else
   if Source is TRGBAlphaImage then
     SourceRGBAlpha(TRGBAlphaImage(Source)) else
@@ -582,7 +759,7 @@ procedure TGrayscaleImage.DrawFromCore(Source: TCastleImage;
     DestX, DestY: Integer;
   begin
     case Mode of
-      dmBlend:
+      dmBlend,dmBlendSmart:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
           PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
@@ -592,6 +769,20 @@ procedure TGrayscaleImage.DrawFromCore(Source: TCastleImage;
             PDest^ := BlendBytes(PDest^, GrayscaleValue(PSource^), PSource^[3]);
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^ := MultiplyBytesOpaque(PDest^,GrayscaleValue(PSource^),PSource^[3]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -633,7 +824,7 @@ procedure TGrayscaleImage.DrawFromCore(Source: TCastleImage;
     DestX, DestY: Integer;
   begin
     case Mode of
-      dmBlend:
+      dmBlend,dmBlendSmart:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
           PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
@@ -643,6 +834,20 @@ procedure TGrayscaleImage.DrawFromCore(Source: TCastleImage;
             PDest^ := BlendBytes(PDest^, PSource^[0], PSource^[1]);
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^ := MultiplyBytesOpaque(PDest^,PSource^[0],PSource^[1]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -685,6 +890,20 @@ procedure TGrayscaleImage.DrawFromCore(Source: TCastleImage;
   begin
     case Mode of
       { dmBlend handled by inherited }
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^ := MultiplyBytes(PDest^,PSource^);
+              Inc(PSource);
+              Inc(PDest);
+            end;
+          end;
+        end;
       dmAdd:
         {if Source.PremultipliedAlpha then
         begin
@@ -736,6 +955,20 @@ procedure TGrayscaleImage.DrawFromCore(Source: TCastleImage;
             Inc(PDest);
           end;
         end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^ := MultiplyBytes(PDest^,GrayscaleValue(PSource^));
+              Inc(PSource);
+              Inc(PDest);
+            end;
+          end;
+        end;
       dmAdd:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
@@ -755,7 +988,7 @@ procedure TGrayscaleImage.DrawFromCore(Source: TCastleImage;
 begin
   if Source is TRGBAlphaImage then
     SourceRGBAlpha(TRGBAlphaImage(Source)) else
-  if (Source is TGrayscaleImage) and (Mode = dmAdd) then
+  if (Source is TGrayscaleImage) and ((Mode = dmAdd) or (Mode = dmMultiply)) then
     SourceGrayscale(TGrayscaleImage(Source)) else
   if Source is TGrayscaleAlphaImage then
     SourceGrayscaleAlpha(TGrayscaleAlphaImage(Source)) else
@@ -789,6 +1022,20 @@ procedure TGrayscaleAlphaImage.DrawFromCore(Source: TCastleImage;
             Inc(PDest);
           end;
         end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],GrayscaleValue(PSource^));
+              Inc(PSource);
+              Inc(PDest);
+            end;
+          end;
+        end;
       dmAdd:
         for DestY := Y to Y + SourceHeight - 1 do
         begin
@@ -810,6 +1057,9 @@ procedure TGrayscaleAlphaImage.DrawFromCore(Source: TCastleImage;
     PSource: PVector4Byte;
     PDest: PVector2Byte;
     DestX, DestY: Integer;
+
+    //variables for smart-blending mode
+    alpha1,alpha2,alpha1d,alphaSum:single;
   begin
     case Mode of
       dmBlend:
@@ -822,6 +1072,44 @@ procedure TGrayscaleAlphaImage.DrawFromCore(Source: TCastleImage;
             PDest^[0] := BlendBytes(PDest^[0], GrayscaleValue(PSource^), PSource^[3]);
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmBlendSmart:
+        for DestY := Y to Y + SourceHeight - 1 do
+        begin
+          PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+          PDest := PixelPtr(X, DestY);
+          for DestX := X to X + SourceWidth - 1 do
+          begin
+            //get alpha in 0..1 range
+            alpha1 := PDest^[1]/255;
+            alpha2 := PSource^[3]/255;
+            //calculate alpha-sums according to https://en.wikipedia.org/wiki/Alpha_compositing
+            alpha1d := alpha1*(1-alpha2);
+            alphasum := alpha1+(1-alpha1)*alpha2;
+            // if alpha sum >0 then do the pixel colors and alpha summation according to the formula
+            if alphaSum > 0 then
+            begin
+              PDest^[0] := Round((PDest^[0]*alpha1d + GrayscaleValue(PSource^)*alpha2)/alphaSum);
+              PDest^[1] := Round(255*alphaSum);
+            end;
+            Inc(PSource);
+            Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],GrayscaleValue(PSource^));
+              PDest^[1] := MultiplyBytes(PDest^[1],PSource^[3]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -861,6 +1149,9 @@ procedure TGrayscaleAlphaImage.DrawFromCore(Source: TCastleImage;
     PSource: PVector2Byte;
     PDest: PVector2Byte;
     DestX, DestY: Integer;
+
+    //variables for smart-blending mode
+    alpha1,alpha2,alpha1d,alphaSum:single;
   begin
     case Mode of
       dmBlend:
@@ -873,6 +1164,44 @@ procedure TGrayscaleAlphaImage.DrawFromCore(Source: TCastleImage;
             PDest^[0] := BlendBytes(PDest^[0], PSource^[0], PSource^[1]);
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmBlendSmart:
+        for DestY := Y to Y + SourceHeight - 1 do
+        begin
+          PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+          PDest := PixelPtr(X, DestY);
+          for DestX := X to X + SourceWidth - 1 do
+          begin
+            //get alpha in 0..1 range
+            alpha1 := PDest^[1]/255;
+            alpha2 := PSource^[1]/255;
+            //calculate alpha-sums according to https://en.wikipedia.org/wiki/Alpha_compositing
+            alpha1d := alpha1*(1-alpha2);
+            alphasum := alpha1+(1-alpha1)*alpha2;
+            // if alpha sum >0 then do the pixel colors and alpha summation according to the formula
+            if alphaSum > 0 then
+            begin
+              PDest^[0] := Round((PDest^[0]*alpha1d + PSource^[0]*alpha2)/alphaSum);
+              PDest^[1] := Round(255*alphaSum);
+            end;
+            Inc(PSource);
+            Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],PSource^[0]);
+              PDest^[1] := MultiplyBytes(PDest^[1],PSource^[1]);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:
@@ -924,6 +1253,20 @@ procedure TGrayscaleAlphaImage.DrawFromCore(Source: TCastleImage;
             PDest^[0] := PSource^;
             Inc(PSource);
             Inc(PDest);
+          end;
+        end;
+      dmMultiply:
+        begin
+          for DestY := Y to Y + SourceHeight - 1 do
+          begin
+            PSource := Source.PixelPtr(SourceX, SourceY + DestY - Y);
+            PDest := PixelPtr(X, DestY);
+            for DestX := X to X + SourceWidth - 1 do
+            begin
+              PDest^[0] := MultiplyBytes(PDest^[0],PSource^);
+              Inc(PSource);
+              Inc(PDest);
+            end;
           end;
         end;
       dmAdd:


### PR DESCRIPTION
Hi, Michalis!

I've decided to make the pull request from the scratch because I'm not so confident in my understanding of git and I'm afraid to mess something up :) Yesterday I was struggling 4 hours just to finally "discard my fork" and re-fork it again :)

Finally I've re-implemented and extended dmBlendSmart and dmMultiply modes for all applicable image types. I've also extended dmBlendSmart=dmBlend for no-alpha destination as it produces expected results.
Practically there is no sense in dmBlendSmart for no-alpha source, as it'll just replace the original image part and it's better to have an exception here because in this case the user is doing something that'll result in an unexpected result. However, it still might be extended in this sense to no-alpha / no-alpha blending.
I've also changed dmMultiply logic for drawing alpha images over non-alpha images to account for transparency because basic dmMultiply algorithm provided mathematically correct but visually ugly result.
Plus I've made an additional test utility for testing blending modes and images combination - requires manual blend mode specification in the code. I'm not sure if it's good for anything, but I'll attach it here.
However, I saw there are separate tests for CGE in castle-engine\tests. I think I should also make a test there similar to other tests in testcastleimagesdraw.pas. Looks relatively complex and will take me some time to understand the logic and the purpose of the test.

There seems to be a minor typo in castleimages_draw.inc in procedure TRGBAlphaImage.DrawFromCore > procedure SourceRGB
	else raise EImageDrawError.Create('Blend mode not implemented (TRGBAlphaImage.DrawFromCore)');
should be
	else raise EImageDrawError.CreateFmt(SErrBlendModeNotImplemented, [Source.ClassName, ClassName]);
as in all other sources/destination combinations, right? (I've fixed it in the commit)

Practically all 16 sourceXXXXX procedures and each blend mode are so similar... But I've been struggling for 4 hours and found no way to unify them without dropping efficiency and merging 2 or 3 of those won't give any result worth the effort... However, maybe at least sorting them would be a good idea? E.g. to make strictly that RGBAlpha comes first, then GrayscaleAlpha (as it also uses alpha-logic), then non-transparent RGB and Grayscale - both in DrawFromCore order and sourceXXXXX order. No serious profit, but might provide a little better code readability.
This doesn't seem to be difficult and I can hardly mess up something here, so I can do it, if you're ok with the order. Or maybe other ideas?
[DrawModeTest.zip](https://github.com/castle-engine/castle-engine/files/340839/DrawModeTest.zip)