### PR TITLE
Utility to convert spritesheets into classic X3D format.

### DIFF
--- a/tools/ss2x3dv/CastleEngineManifest.xml
+++ b/tools/ss2x3dv/CastleEngineManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="ss2x3dv" standalone_source="ss2x3dv.lpr">
+</project>

--- a/tools/ss2x3dv/cocos2dparser.inc
+++ b/tools/ss2x3dv/cocos2dparser.inc
@@ -1,0 +1,119 @@
+procedure Cocos2DParser;
+  procedure ReadQuad(const ASrc: string; out V1, V2, V3, V4: integer);
+  var
+    R: TRegExpr;
+  begin
+    R := TRegExpr.Create;
+    try
+      R.Expression := '{{(\d+),(\d+)},{(\d+),(\d+)}}';
+      if R.Exec(ASrc) and (R.SubExprMatchCount = 4) then
+      begin
+        V1 := StrToInt(R.Match[1]); 
+        V2 := StrToInt(R.Match[2]);
+        V3 := StrToInt(R.Match[3]);
+        V4 := StrToInt(R.Match[4]);
+      end;
+    finally
+      FreeAndNil(R);
+    end;
+  end;
+
+  procedure ReadDual(const ASrc: string; out V1, V2: single);
+  var
+    R: TRegExpr;
+  begin
+    R := TRegExpr.Create;
+    try
+      R.Expression := '{(\d+.*\d*),(\d+.*\d*)}';
+      if R.Exec(ASrc) and (R.SubExprMatchCount = 2) then
+      begin
+        V1 := StrToFloat(R.Match[1]);
+        V2 := StrToFloat(R.Match[2]);
+      end;
+    finally
+      FreeAndNil(R);
+    end;
+  end;
+
+var
+  Doc: TXMLDocument;
+  Dict, N, N2, N3: TDOMNode;
+  AniName,
+  Key: string;
+  Frame: TFrame;
+  X, Y, W, H: integer;
+  AX, AY: single;
+begin
+  ReadXMLFile(Doc, SSFullPath);
+  try
+    Dict := Doc.FindNode('plist').FirstChild;
+    N := Dict.FirstChild;
+    while N <> nil do
+    begin
+      if N.TextContent = 'frames' then
+      begin
+        N := N.NextSibling;   
+        N2 := N.FirstChild;
+        while N2 <> nil do
+        begin
+          if N2.NodeName = 'key' then
+          begin
+            AniName := N2.TextContent;
+          end
+          else
+          if N2.NodeName = 'dict' then
+          begin
+            N3 := N2.FirstChild;
+            AX := 0.5;
+            AY := 0.5;
+            while N3 <> nil do
+            begin
+              if (N3.TextContent = 'frame') or (N3.TextContent = 'textureRect') then
+              begin
+                N3 := N3.NextSibling;
+                ReadQuad(N3.TextContent, X, Y, W, H);
+              end
+              else
+              if N3.TextContent = 'anchor' then
+              begin   
+                N3 := N3.NextSibling;
+                ReadDual(N3.TextContent, AX, AY);
+              end;
+              N3 := N3.NextSibling;
+            end;   
+            Frame.X1 := X;
+            Frame.Y1 := Y;
+            Frame.W := W;
+            Frame.H := H;
+            Frame.X2 := X + W;
+            Frame.Y2 := Y + H;
+            Frame.AX := AX;
+            Frame.AY := AY;
+            KeyParser(AniName, Key);
+            AddFrame(Key, Frame);
+          end;
+          N2 := N2.NextSibling;
+        end;
+      end
+      else
+      if N.TextContent = 'metadata' then
+      begin
+        N := N.NextSibling;
+        N2 := N.FirstChild;
+        while N2 <> nil do
+        begin
+          if (N2.TextContent = 'textureFileName') then
+          begin
+            N2 := N2.NextSibling;
+            Meta.Name := N2.TextContent;   
+            ReadMeta(Meta);
+          end;     
+          N2 := N2.NextSibling;
+        end;
+      end;
+      N := N.NextSibling;
+    end;
+  finally
+    FreeAndNil(Doc);
+  end;
+end; 

--- a/tools/ss2x3dv/data/header.txt
+++ b/tools/ss2x3dv/data/header.txt
@@ -1,2 +1,5 @@
 #X3D V3.3 utf8
 PROFILE Interchange
+
+META "generator" "ss2x3dv, http://castle-engine.sourceforge.net"
+META "source" "%SOURCE%"

--- a/tools/ss2x3dv/data/header.txt
+++ b/tools/ss2x3dv/data/header.txt
@@ -1,0 +1,2 @@
+#X3D V3.3 utf8
+PROFILE Interchange

--- a/tools/ss2x3dv/data/interpolator.txt
+++ b/tools/ss2x3dv/data/interpolator.txt
@@ -1,0 +1,13 @@
+DEF %COORD% CoordinateInterpolator {
+  key [%COORD_KEY%]
+  keyValue [
+%COORD_KEYVALUE%
+  ]
+}
+
+DEF %TEXCOORD% CoordinateInterpolator2D {
+  key [%TEXCOORD_KEY%]
+  keyValue [
+%TEXCOORD_KEYVALUE%
+  ]
+}

--- a/tools/ss2x3dv/data/route.txt
+++ b/tools/ss2x3dv/data/route.txt
@@ -1,0 +1,4 @@
+ROUTE %NAME%.fraction_changed TO %COORD%.set_fraction
+ROUTE %NAME%.fraction_changed TO %TEXCOORD%.set_fraction
+ROUTE %COORD%.value_changed TO coord.point
+ROUTE %TEXCOORD%.value_changed TO tex_coord.point

--- a/tools/ss2x3dv/data/shape.txt
+++ b/tools/ss2x3dv/data/shape.txt
@@ -12,22 +12,24 @@ Transform {
           }
         }
       }
-      geometry QuadSet {
+      geometry TriangleSet {
         solid FALSE
         coord DEF coord Coordinate {
           point [
             -128 -128 0,
             128 -128 0,
             128 128 0,
+            -128 -128 0,
+            128 128 0,
             -128 128 0,
           ]
         }
         texCoord DEF tex_coord TextureCoordinate {
           point [
-            0 0, 1 0, 1 1, 0 1, 
+            0 0, 1 0, 1 1, 0 0, 1 1, 0 1, 
           ]
         }
       }
-    }  
+    } 
   ]
 } 

--- a/tools/ss2x3dv/data/shape.txt
+++ b/tools/ss2x3dv/data/shape.txt
@@ -1,0 +1,33 @@
+Transform {
+  children [
+    Shape {
+      appearance Appearance {
+        texture ImageTexture {
+          url "%ATLAS%"
+          repeatS FALSE
+          repeatT FALSE
+          textureProperties TextureProperties {
+            magnificationFilter "NEAREST_PIXEL"
+            minificationFilter "NEAREST_PIXEL"
+          }
+        }
+      }
+      geometry QuadSet {
+        solid FALSE
+        coord DEF coord Coordinate {
+          point [
+            -128 -128 0,
+            128 -128 0,
+            128 128 0,
+            -128 128 0,
+          ]
+        }
+        texCoord DEF tex_coord TextureCoordinate {
+          point [
+            0 0, 1 0, 1 1, 0 1, 
+          ]
+        }
+      }
+    }  
+  ]
+} 

--- a/tools/ss2x3dv/data/timesensor.txt
+++ b/tools/ss2x3dv/data/timesensor.txt
@@ -1,0 +1,3 @@
+DEF %NAME% TimeSensor {
+  cycleInterval 1
+}

--- a/tools/ss2x3dv/ss2x3dv.lpi
+++ b/tools/ss2x3dv/ss2x3dv.lpi
@@ -34,11 +34,19 @@
         <PackageName Value="castle_base"/>
       </Item1>
     </RequiredPackages>
-    <Units Count="1">
+    <Units Count="3">
       <Unit0>
         <Filename Value="ss2x3dv.lpr"/>
         <IsPartOfProject Value="True"/>
       </Unit0>
+      <Unit1>
+        <Filename Value="starlingparser.inc"/>
+        <IsPartOfProject Value="True"/>
+      </Unit1>
+      <Unit2>
+        <Filename Value="cocos2dparser.inc"/>
+        <IsPartOfProject Value="True"/>
+      </Unit2>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/tools/ss2x3dv/ss2x3dv.lpi
+++ b/tools/ss2x3dv/ss2x3dv.lpi
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="10"/>
+    <PathDelim Value="\"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <MainUnit Value="0"/>
+      <Title Value="ss2x3dv"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+      <XPManifest>
+        <TextName Value="CompanyName.ProductName.AppName"/>
+        <TextDesc Value="Your application description."/>
+      </XPManifest>
+    </General>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RunParams>
+      <local>
+        <FormatVersion Value="1"/>
+      </local>
+    </RunParams>
+    <RequiredPackages Count="1">
+      <Item1>
+        <PackageName Value="castle_base"/>
+      </Item1>
+    </RequiredPackages>
+    <Units Count="1">
+      <Unit0>
+        <Filename Value="ss2x3dv.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="\"/>
+    <Target>
+      <Filename Value="ss2x3dv"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions Count="3">
+      <Item1>
+        <Name Value="EAbort"/>
+      </Item1>
+      <Item2>
+        <Name Value="ECodetoolError"/>
+      </Item2>
+      <Item3>
+        <Name Value="EFOpenError"/>
+      </Item3>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/tools/ss2x3dv/ss2x3dv.lpr
+++ b/tools/ss2x3dv/ss2x3dv.lpr
@@ -40,7 +40,7 @@ type
   end;
 
   TFrameList = specialize TGenericStructList<TFrame>;
-  TAnimation = specialize TFPGMap<string, TFrameList>;
+  TAnimations = specialize TFPGMap<string, TFrameList>;
 
 var
   SSFullPath,
@@ -52,7 +52,7 @@ var
   TpRoute,
   TpTimeSensor,
   TpInterpolator: string;
-  Animations: TAnimation;
+  Animations: TAnimations;
   Meta: TMeta;
 
 { Parse a string with XXX_YYY format, XXX is the name of the frame and YYY is
@@ -239,7 +239,7 @@ begin
   end;
   X3DV := TStringList.Create;
   try
-    X3DV.Add(TpHeader);
+    X3DV.Add(StringReplace(TpHeader, '%SOURCE%', SSName + SSExt, [rfReplaceAll]));
     X3DV.Add('');
     X3DV.Add(StringReplace(TpShape, '%ATLAS%', Meta.Name, [rfReplaceAll]));  
     X3DV.Add('');
@@ -317,7 +317,7 @@ begin
 end;
 
 begin
-  Animations := TAnimation.Create;
+  Animations := TAnimations.Create;
   try
     try
       LoadTemplates;

--- a/tools/ss2x3dv/ss2x3dv.lpr
+++ b/tools/ss2x3dv/ss2x3dv.lpr
@@ -1,0 +1,336 @@
+{
+  Copyright 2017 Trung Le (kagamma).
+
+  This file is part of "Castle Game Engine".
+
+  "Castle Game Engine" is free software; see the file COPYING.txt,
+  included in this distribution, for details about the copyright.
+
+  "Castle Game Engine" is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+  ----------------------------------------------------------------------------
+}
+
+{ Convert spritesheets to classic X3D files. }
+
+program ss2x3dv;
+
+{$APPTYPE CONSOLE}
+
+uses
+  Classes, SysUtils, strutils,
+  FPimage, FPReadPNG, FPReadJPEG,
+  DOM, XMLRead,
+  RegExpr,
+  FGL, CastleGenericLists;
+
+type
+  TMeta = record
+    Name: string;       { Image name }
+    W, H: integer;      { Image size }
+  end;
+
+  TFrame = record
+    X1, Y1,             { Texture coords }
+    X2, Y2,
+    W, H,               { Frame size }
+    AX, AY: single;     { Anchor }
+  end;
+
+  TFrameList = specialize TGenericStructList<TFrame>;
+  TAnimation = specialize TFPGMap<string, TFrameList>;
+
+var
+  SSFullPath,
+  SSPath,
+  SSExt,
+  SSName: string;
+  TpHeader,
+  TpShape,
+  TpRoute,
+  TpTimeSensor,
+  TpInterpolator: string;
+  Animations: TAnimation;
+  Meta: TMeta;
+
+{ Parse a string with XXX_YYY format, XXX is the name of the frame and YYY is
+  frame number. Here we only need XXX part so that it can be used as animation
+  name (key). }
+procedure KeyParser(const AName: string; out AKey: string);
+var
+  R: TRegExpr;
+begin
+  R := TRegExpr.Create;
+  try
+    R.Expression := '(.*)_(.*)';
+    if R.Exec(AName) and (R.SubExprMatchCount = 2) then
+    begin
+      AKey := R.Match[1];
+    end;
+  finally
+    FreeAndNil(R);
+  end;
+end;
+
+{ Add a frame to frame list, it will try to find frame list based on key,
+  in case there's no key in dictionary, a new frame list with that key will
+  be created. }
+procedure AddFrame(const AKey: string; const AFrame: TFrame);
+var
+  List: TFrameList;
+  i: integer;
+begin
+  if Animations.Find(AKey, i) then
+  begin
+    List := Animations.Data[i];
+  end
+  else
+  begin
+    List := TFrameList.Create;
+    Animations.Add(AKey, List);
+  end;
+  List.Add(AFrame);
+end;
+
+{ Read texture altas's width and height. }
+procedure ReadMeta(var AMeta: TMeta);
+var
+  Image: TFPCustomImage;
+  Reader: TFPCustomImageReader;
+begin
+  Image := TFPMemoryImage.Create(0, 0);
+  case LowerCase(ExtractFileExt(AMeta.Name)) of
+    '.png':
+      Reader := TFPReaderPNG.Create;           
+    '.jpg', '.jpeg':
+      Reader := TFPReaderJPEG.Create;
+    else
+      begin
+        Writeln('Error: Unsupported image format.');
+        Halt;
+      end;
+  end;
+  try
+    Image.LoadFromFile(AMeta.Name, Reader);
+    AMeta.W := Image.Width;
+    AMeta.H := Image.Height;
+  finally
+    FreeAndNil(Image);
+    FreeAndNil(Reader);
+  end;
+end;
+
+{ Load classic X3D templates. }
+procedure LoadTemplates;
+
+  function ReadFile(const AName: string): string;
+  var
+    FS: TFileStream;
+    SS: TStringStream;
+  begin
+    Result := '';
+    FS := TFileStream.Create(AName, fmOpenRead);
+    SS := TStringStream.Create;
+    try
+      FS.Position := 0;
+      SS.CopyFrom(FS, FS.Size);
+      Result := SS.DataString;
+    finally
+      FreeAndNil(FS);
+      FreeAndNil(SS);
+    end;
+  end;
+
+begin
+  TpHeader := ReadFile('data/header.txt');
+  TpShape := ReadFile('data/shape.txt');
+  TpTimeSensor := ReadFile('data/timesensor.txt');
+  TpInterpolator := ReadFile('data/interpolator.txt');
+  TpRoute := ReadFile('data/route.txt');
+end;
+
+procedure ParamHandle;
+begin
+  case ParamCount of
+    0:
+      begin
+        Writeln(
+            'ss2x3dv: Convert spritesheet files into classic X3D files.' + #10#13 +
+            '         Support file formats: Starling (.xml), Cocos2D (.plist).'+ #10#13 +
+            '         Please make sure frame keys follow XXX_YYY naming convention:'+ #10#13 +
+            '         - XXX: Frame name, start with a letter, will be used as animation name.'+ #10#13 +
+            '         - YYY: Frame number.'+ #10#13 +
+            'Usage: ss2x3dv <spritesheet>'
+        );
+        Halt;
+      end;
+    else
+      begin
+        SSFullPath := ParamStr(1);
+        if not FileExists(SSFullPath) then
+        begin
+          Writeln('Error: File not exists.');
+          Halt;
+        end;
+        SSPath := ExtractFilePath(SSFullPath);
+        SSExt := ExtractFileExt(SSFullPath);
+        SSName := StringReplace(
+            StringReplace(SSFullPath, SSPath, '', []), SSExt, '', []);
+      end;
+  end;
+end;
+
+{$I starlingparser.inc}
+{$I cocos2dparser.inc}
+
+procedure Parse;
+begin
+  case LowerCase(SSExt) of
+    '.xml':
+      begin
+        StarlingParser;
+      end;               
+    '.plist':
+      begin
+        Cocos2DParser;
+      end;
+  end;
+end;      
+
+procedure Convert;
+var
+  i, j: integer;
+  List: TFrameList;
+  Frame: TFrame;
+  X3DV: TStringList;
+  S,
+  Interpolators,
+  Routes,
+  TimeSensors,
+  NameStr,
+  CoordStr,
+  TexCoordStr,
+  OldKeyStr,
+  KeyStr,
+  OldCoordKeyValueStr,
+  CoordKeyValueStr,
+  OldTexCoordKeyValueStr,
+  TexCoordKeyValueStr: string;
+begin   
+  Interpolators := '';
+  Routes := '';
+  TimeSensors := '';
+  for j := 0 to Animations.Count-1 do
+  begin
+    List := Animations.Data[j];
+    List.Add(List[0]);
+    { Convert sprite texture coordinates to X3D format. }
+    for i := 0 to List.Count-1 do
+    begin
+      Frame := List[i];
+      Frame.X1 := 1 / Meta.W * Frame.X1;
+      Frame.Y1 := 1 - 1 / Meta.H * Frame.Y1;
+      Frame.X2 := 1 / Meta.W * Frame.X2;
+      Frame.Y2 := 1 - 1 / Meta.H * Frame.Y2;
+      List[i] := Frame;
+    end;
+  end;
+  X3DV := TStringList.Create;
+  try
+    X3DV.Add(TpHeader);
+    X3DV.Add('');
+    X3DV.Add(StringReplace(TpShape, '%ATLAS%', Meta.Name, [rfReplaceAll]));  
+    X3DV.Add('');
+    for j := 0 to Animations.Count-1 do
+    begin
+      List := Animations.Data[j];
+      NameStr := StringReplace(
+          ExtractFileName(Animations.Keys[j]),
+          ExtractFilePath(Animations.Keys[j]), '', []);
+      CoordStr := NameStr + '_Coord';
+      TexCoordStr := NameStr + '_TexCoord'; 
+      KeyStr := '';
+      OldKeyStr := '';
+      { Generate list of keys. }
+      for i := 0 to List.Count-1 do
+      begin
+        KeyStr += OldKeyStr + FloatToStr(1/(List.Count - 1) * i) + ' ';
+        OldKeyStr := FloatToStr(1/(List.Count - 1) * (i+1) - 0.0000001) + ' ';
+      end;
+      CoordKeyValueStr := '';
+      TexCoordKeyValueStr := '';
+      OldCoordKeyValueStr := '';
+      OldTexCoordKeyValueStr := '';  
+      { Generate list of coord/texcoord key values. }
+      for i := 0 to List.Count-1 do
+      begin
+        Frame := List[i];
+        S := Format('%.1f %.1f 0, %.1f %.1f 0, %.1f %.1f 0, %.1f %.1f 0, ' + #10,
+            [-Frame.W * (  Frame.AX),  Frame.H * (  Frame.AY),
+              Frame.W * (1-Frame.AX),  Frame.H * (  Frame.AY),
+              Frame.W * (1-Frame.AX), -Frame.H * (1-Frame.AY),
+             -Frame.W * (  Frame.AX), -Frame.H * (1-Frame.AY)]);
+        CoordKeyValueStr += OldCoordKeyValueStr + S;
+        OldCoordKeyValueStr := S;
+        S := Format('%.4f %.4f, %.4f %.4f, %.4f %.4f, %.4f %.4f, ' + #10,
+            [Frame.X1, Frame.Y1,
+             Frame.X2, Frame.Y1,
+             Frame.X2, Frame.Y2,
+             Frame.X1, Frame.Y2]);
+        TexCoordKeyValueStr += OldTexCoordKeyValueStr + S;
+        OldTexCoordKeyValueStr := S;
+      end;
+      SetLength(KeyStr, Length(KeyStr)-1);
+      SetLength(CoordKeyValueStr, Length(CoordKeyValueStr)-1);
+      SetLength(TexCoordKeyValueStr, Length(TexCoordKeyValueStr)-1);
+      TimeSensors := TimeSensors + StringsReplace(
+          TpTimeSensor,
+          ['%NAME%'],
+          [NameStr],
+          [rfReplaceAll]) + #10#10;     
+      Interpolators := Interpolators + StringsReplace(
+          TpInterpolator,
+          ['%NAME%',
+           '%COORD%', '%COORD_KEY%', '%COORD_KEYVALUE%',
+           '%TEXCOORD%', '%TEXCOORD_KEY%', '%TEXCOORD_KEYVALUE%'],
+          [NameStr,
+           CoordStr, KeyStr, CoordKeyValueStr,
+           TexCoordStr, KeyStr, TexCoordKeyValueStr],
+          [rfReplaceAll]) + #10#10;
+      Routes := Routes + StringsReplace(
+          TpRoute,
+          ['%NAME%',
+           '%COORD%',
+           '%TEXCOORD%'],
+          [NameStr,
+           CoordStr,
+           TexCoordStr],
+          [rfReplaceAll]) + #10;
+    end;
+    X3DV.Text := X3DV.Text + TimeSensors + Interpolators + Routes;
+    X3DV.SaveToFile(SSName + '.x3dv');
+  finally
+    FreeAndNil(X3DV);
+  end;
+end;
+
+begin
+  Animations := TAnimation.Create;
+  try
+    try
+      LoadTemplates;
+      ParamHandle;
+      Parse;
+      Convert;
+    except
+      on E: Exception do
+        Writeln(E.ClassName, ': ', E.Message);
+    end;
+  finally
+    FreeAndNil(Animations);
+  end;
+end.
+
+

--- a/tools/ss2x3dv/ss2x3dv.lpr
+++ b/tools/ss2x3dv/ss2x3dv.lpr
@@ -267,16 +267,24 @@ begin
       for i := 0 to List.Count-1 do
       begin
         Frame := List[i];
-        S := Format('%.1f %.1f 0, %.1f %.1f 0, %.1f %.1f 0, %.1f %.1f 0, ' + #10,
+        S := Format(
+            '%.1f %.1f 0, %.1f %.1f 0, %.1f %.1f 0, ' +
+            '%.1f %.1f 0, %.1f %.1f 0, %.1f %.1f 0, ' + #10,
             [-Frame.W * (  Frame.AX),  Frame.H * (  Frame.AY),
               Frame.W * (1-Frame.AX),  Frame.H * (  Frame.AY),
+              Frame.W * (1-Frame.AX), -Frame.H * (1-Frame.AY), 
+             -Frame.W * (  Frame.AX),  Frame.H * (  Frame.AY),
               Frame.W * (1-Frame.AX), -Frame.H * (1-Frame.AY),
              -Frame.W * (  Frame.AX), -Frame.H * (1-Frame.AY)]);
         CoordKeyValueStr += OldCoordKeyValueStr + S;
         OldCoordKeyValueStr := S;
-        S := Format('%.4f %.4f, %.4f %.4f, %.4f %.4f, %.4f %.4f, ' + #10,
+        S := Format(
+            '%.4f %.4f, %.4f %.4f, %.4f %.4f, ' +
+            '%.4f %.4f, %.4f %.4f, %.4f %.4f, ' + #10,
             [Frame.X1, Frame.Y1,
              Frame.X2, Frame.Y1,
+             Frame.X2, Frame.Y2,
+             Frame.X1, Frame.Y1,
              Frame.X2, Frame.Y2,
              Frame.X1, Frame.Y2]);
         TexCoordKeyValueStr += OldTexCoordKeyValueStr + S;

--- a/tools/ss2x3dv/ss2x3dv_compile.sh
+++ b/tools/ss2x3dv/ss2x3dv_compile.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -eu
+
+# Call this script from this directory,
+# or from base castle_game_engine directory.
+# Or just do "make" in base castle_game_engine directory.
+
+# Allow calling this script from it's dir.
+if [ -f ss2x3dv.lpr ]; then cd ../../; fi
+
+fpc -dRELEASE @castle-fpc.cfg tools/ss2x3dv/ss2x3dv.lpr

--- a/tools/ss2x3dv/starlingparser.inc
+++ b/tools/ss2x3dv/starlingparser.inc
@@ -1,0 +1,35 @@
+procedure StarlingParser;
+var
+  Doc: TXMLDocument;
+  Atlas, N: TDOMNode;
+  AniName,
+  Key: string;
+  Frame: TFrame;
+begin
+  ReadXMLFile(Doc, SSFullPath);
+  try
+    Atlas := Doc.FindNode('TextureAtlas');
+    Meta.Name := Atlas.Attributes.GetNamedItem('imagePath').NodeValue;
+    ReadMeta(Meta);
+    N := Atlas.FirstChild;
+    while N <> nil do
+    begin
+      if N.NodeName <> 'SubTexture' then
+        continue;
+      AniName := N.Attributes.GetNamedItem('name').NodeValue;
+      Frame.X1 := StrToFloat(N.Attributes.GetNamedItem('x').NodeValue);
+      Frame.Y1 := StrToFloat(N.Attributes.GetNamedItem('y').NodeValue);
+      Frame.W := StrToFloat(N.Attributes.GetNamedItem('width').NodeValue);
+      Frame.H := StrToFloat(N.Attributes.GetNamedItem('height').NodeValue);
+      Frame.X2 := Frame.X1 + Frame.W;
+      Frame.Y2 := Frame.Y1 + Frame.H;
+      Frame.AX := 0.5;
+      Frame.AY := 0.5;
+      KeyParser(AniName, Key);
+      AddFrame(Key, Frame);
+      N := N.NextSibling;
+    end;
+  finally
+    FreeAndNil(Doc);
+  end;
+end; 


### PR DESCRIPTION
I have created a simple utility allows to convert spritesheets into ready-to-use classic X3D format.

Support file format:
- Starling (.xml), Fully supported.
- Cocos2D (.plist). Covered most of important stuff, rare features like rotate, polygon sprites are not supported (yet!) but it can be added easily :).

Notes:
- By default anchor will be placed at the center of the sprite if the tool didn't found it in spritesheet.
- Frames must be named after the following format: XXX_YYY. XXX stands for frame name, which will be used as animation name. YYY is frame number. Example: slime_01.png, slime_02.png, ect.
- The tool is test on Windows only, but it should be able to compile on other OSes, as no platform-dependent code is used.

Demo clip from a previous development version but still applied to this version: https://www.youtube.com/watch?v=2JDiwQttgSo

