### PR TITLE
Support for two extra mouse buttons

### DIFF
--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -1,5 +1,6 @@
 {
-  Copyright 2001-2016 Michalis Kamburelis.
+  Copyright 2001-2016 Michalis Kamburelis,
+  2017 Tomasz Wojtyś.
 
   This file is part of "Castle Game Engine".
 
@@ -250,7 +251,7 @@ type
   TCharactersBooleans = array [Char] of Boolean;
   PCharactersBooleans = ^TCharactersBooleans;
 
-  TMouseButton = (mbLeft, mbMiddle, mbRight);
+  TMouseButton = (mbLeft, mbMiddle, mbRight, mbExtra1, mbExtra2);
   TMouseButtons = set of TMouseButton;
 
   { Look of the mouse cursor.
@@ -290,7 +291,8 @@ type
     mcHand);
 
 const
-  MouseButtonStr: array [TMouseButton] of string = ('left', 'middle', 'right');
+  MouseButtonStr: array [TMouseButton] of string = ('left', 'middle', 'right',
+                                                    'extra1', 'extra2');
 
 type
   { Modifier keys are keys that, when pressed, modify the meaning of

--- a/src/window/gtk/castlewindow_gtk.inc
+++ b/src/window/gtk/castlewindow_gtk.inc
@@ -353,6 +353,8 @@ begin
   1: mb := mbLeft;
   2: mb := mbMiddle;
   3: mb := mbRight;
+  8: mb := mbExtra1;
+  9: mb := mbExtra2;
   else Exit(false);
  end;
  Result := true;


### PR DESCRIPTION
I've added support for mouses with more than three buttons. Tested only in GTK window backend.
TMouseButton definition is compatible now with the one in the Controls unit.