### PR TITLE
Fix $apptype warning on Linux

### DIFF
--- a/examples/2d_dragon_spine_game/code/castle_spine.lpr
+++ b/examples/2d_dragon_spine_game/code/castle_spine.lpr
@@ -16,7 +16,7 @@
 { "Castle Spine" standalone game binary. }
 program castle_spine;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/examples/2d_standard_ui/edit_test/edit_test.lpr
+++ b/examples/2d_standard_ui/edit_test/edit_test.lpr
@@ -13,7 +13,7 @@
   ----------------------------------------------------------------------------
 }
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/examples/2d_standard_ui/show_various_ui_controls/show_various_ui_controls.lpr
+++ b/examples/2d_standard_ui/show_various_ui_controls/show_various_ui_controls.lpr
@@ -17,7 +17,7 @@
   This is the program code for the standalone version. }
 uses CastleWindow, Game;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/examples/2d_standard_ui/timer_test/timer_test.lpr
+++ b/examples/2d_standard_ui/timer_test/timer_test.lpr
@@ -16,7 +16,7 @@
 { Demo of TCastleTimer and TCastleFlashEffect. }
 program timer_test;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 uses Math,
   CastleColors, CastleWindow, CastleControls, CastleFlashEffect;

--- a/examples/2d_standard_ui/zombie_fighter/zombie_fighter.lpr
+++ b/examples/2d_standard_ui/zombie_fighter/zombie_fighter.lpr
@@ -13,7 +13,7 @@
   ----------------------------------------------------------------------------
 }
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/examples/3d_rendering_processing/call_pascal_code_from_3d_model_script.lpr
+++ b/examples/3d_rendering_processing/call_pascal_code_from_3d_model_script.lpr
@@ -33,7 +33,7 @@
 
 program call_pascal_code_from_3d_model_script;
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses CastleUtils, CastleProgress, CastleProgressConsole, CastleLog,
   CastleSceneCore, X3DFields, X3DTime, SysUtils, CastleParameters, CastleStringUtils,

--- a/examples/3d_rendering_processing/custom_3d_object.lpr
+++ b/examples/3d_rendering_processing/custom_3d_object.lpr
@@ -30,7 +30,7 @@
 program custom_3d_object;
 
 {$I castleconf.inc}
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 uses CastleVectors, CastleBoxes, CastleGL, CastleWindow, CastleFrustum,
   CastleClassUtils, CastleUtils, SysUtils, Classes, Castle3D,

--- a/examples/3d_rendering_processing/listen_on_x3d_events.lpr
+++ b/examples/3d_rendering_processing/listen_on_x3d_events.lpr
@@ -29,7 +29,7 @@
 
   Logs TouchSensor clicks on the console. }
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses Classes,SysUtils,
   X3DNodes, X3DFields, X3DTIme, CastleWindow, CastleSceneCore, CastleScene;

--- a/examples/3d_rendering_processing/scene_manager_demos.lpr
+++ b/examples/3d_rendering_processing/scene_manager_demos.lpr
@@ -24,7 +24,7 @@
 }
 program scene_manager_demos;
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses CastleUtils, CastleWindow, CastleVectors, CastleLog, Castle3D,
   CastleSceneCore, CastleScene, X3DFields, X3DNodes, CastleApplicationProperties;

--- a/examples/3d_rendering_processing/view_3d_model_advanced.lpr
+++ b/examples/3d_rendering_processing/view_3d_model_advanced.lpr
@@ -18,7 +18,7 @@
   so look there first. }
 program view_3d_model_advanced;
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses SysUtils, CastleUtils, CastleWindow, CastleProgress, CastleWindowProgress,
   CastleSceneCore, CastleLog, CastleParameters, CastleScene, X3DLoad,

--- a/examples/castlescript/castle_calculator.lpr
+++ b/examples/castlescript/castle_calculator.lpr
@@ -4,7 +4,7 @@
   See [http://castle-engine.sourceforge.net/castle_script.php]
   for expression syntax. }
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 program castle_calculator;
 

--- a/examples/fonts/font_draw_over_image.lpr
+++ b/examples/fonts/font_draw_over_image.lpr
@@ -25,7 +25,7 @@
   See also font_from_texture.lpr demo, that draws text directly on screen,
   and instead of the "PrintStrings" calls it uses TCastleLabel components. }
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 program font_draw_over_image;
 

--- a/examples/fonts/font_from_texture.lpr
+++ b/examples/fonts/font_from_texture.lpr
@@ -24,7 +24,7 @@
     Font data is supplied as a ttf file (see data/DejaVuSans.ttf).
 }
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 program font_from_texture;
 

--- a/examples/fonts/test_font_break.lpr
+++ b/examples/fonts/test_font_break.lpr
@@ -21,7 +21,7 @@
   UIFont with your own font from MyFontFile.ttf.
 }
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 program test_font_break;
 

--- a/examples/fonts/test_local_characters/test_local_characters.lpr
+++ b/examples/fonts/test_local_characters/test_local_characters.lpr
@@ -1,4 +1,4 @@
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/examples/fps_game/fps_game.lpr
+++ b/examples/fps_game/fps_game.lpr
@@ -16,7 +16,7 @@
 { Example of a fully-working 3D FPS game. }
 program fps_game;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/examples/images_videos/drawing_modes_test.lpr
+++ b/examples/images_videos/drawing_modes_test.lpr
@@ -17,7 +17,7 @@
   with various blending modes. }
 program drawing_modes_test;
 
-{$Apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 uses Classes, SysUtils, TypInfo,
   CastleWindow, CastleImages, CastleFilesUtils, CastleControls, CastleUIControls,

--- a/examples/images_videos/simple_video_editor.lpr
+++ b/examples/images_videos/simple_video_editor.lpr
@@ -21,7 +21,7 @@ program simple_video_editor;
 
 { Console, not GUI, since loading files through ffmpeg will output some
   info on stdout anyway. }
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses CastleUtils, SysUtils, CastleWindow, CastleGLImages, CastleControls,
   CastleVideos, CastleStringUtils, CastleMessages, CastleColors,

--- a/examples/isometric_game/sandbox.lpr
+++ b/examples/isometric_game/sandbox.lpr
@@ -1,6 +1,6 @@
 program SandBox;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 uses
   { standard units }

--- a/examples/joystick/joystick_demo.lpr
+++ b/examples/joystick/joystick_demo.lpr
@@ -18,7 +18,7 @@
 
 program joystick_demo;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 uses SysUtils,
   CastleVectors, CastleWindow, CastleControls, CastleOnScreenMenu,

--- a/examples/mobile/drawing_toy/drawing_toy_standalone.lpr
+++ b/examples/mobile/drawing_toy/drawing_toy_standalone.lpr
@@ -13,7 +13,7 @@
   ----------------------------------------------------------------------------
 }
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { Main program for a standalone version of the game.
   This allows you to compile the same game game (in Game unit)

--- a/examples/mobile/simple_3d_demo/simple_3d_demo_standalone.lpr
+++ b/examples/mobile/simple_3d_demo/simple_3d_demo_standalone.lpr
@@ -13,7 +13,7 @@
   ----------------------------------------------------------------------------
 }
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { Main program for a standalone version of the game.
   This allows you to compile the same game game (in Game unit)

--- a/examples/plugin/cge_3d_viewer/cge_3d_viewer_standalone.lpr
+++ b/examples/plugin/cge_3d_viewer/cge_3d_viewer_standalone.lpr
@@ -1,6 +1,6 @@
 program cge_3d_viewer_standalone;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/examples/portable_game_skeleton/my_fantastic_game_standalone.lpr
+++ b/examples/portable_game_skeleton/my_fantastic_game_standalone.lpr
@@ -1,5 +1,5 @@
 {$mode objfpc}{$H+}
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/examples/space_filling_curve/draw_space_filling_curve.lpr
+++ b/examples/space_filling_curve/draw_space_filling_curve.lpr
@@ -34,7 +34,7 @@
 }
 program draw_space_filling_curve;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 uses SysUtils, CastleWindow, CastleUtils, CastleGLUtils, CastleParameters,
   CastleImages, CastleVectors, Math, CastleSpaceFillingCurves, CastleStringUtils, CastleGLImages,

--- a/examples/tools/stringoper.lpr
+++ b/examples/tools/stringoper.lpr
@@ -23,7 +23,7 @@
   If all Ok, exit code is 0 and result is on stdout. }
 program stringoper;
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses SysUtils, CastleUtils, Classes, CastleStringUtils, CastleFilesUtils,
   CastleParameters;

--- a/examples/window/multi_window.lpr
+++ b/examples/window/multi_window.lpr
@@ -24,7 +24,7 @@
 
 program multi_window;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 uses CastleWindow, SysUtils, CastleUtils, CastleGLUtils, CastleKeysMouse, CastleVectors,
   CastleStringUtils, CastleColors, CastleControls, CastleUIControls;

--- a/examples/window/window_events.lpr
+++ b/examples/window/window_events.lpr
@@ -20,7 +20,7 @@
 
 program window_events;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 uses SysUtils, CastleUtils, CastleGLUtils, CastleNotifications, CastleWindow,
   CastleKeysMouse, CastleStringUtils, CastleColors, Classes, CastleMessages,

--- a/examples/window/window_menu.lpr
+++ b/examples/window/window_menu.lpr
@@ -28,7 +28,7 @@
 }
 program window_menu;
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses SysUtils, CastleVectors, CastleKeysMouse, CastleColors,
   CastleWindow, CastleGLUtils, CastleMessages, CastleStringUtils,

--- a/src/compatibility/generics.collections/examples/tarraydouble/tarrayprojectdouble.lpr
+++ b/src/compatibility/generics.collections/examples/tarraydouble/tarrayprojectdouble.lpr
@@ -5,7 +5,7 @@
 program TArrayProjectDouble;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   SysUtils, Math, Types, Generics.Collections, Generics.Defaults;

--- a/src/compatibility/generics.collections/examples/tarraysingle/tarrayprojectsingle.lpr
+++ b/src/compatibility/generics.collections/examples/tarraysingle/tarrayprojectsingle.lpr
@@ -5,7 +5,7 @@
 program TArrayProjectSingle;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   SysUtils, Math, Types, Generics.Collections, Generics.Defaults;

--- a/src/compatibility/generics.collections/examples/tcomparer/tcomparerproject.lpr
+++ b/src/compatibility/generics.collections/examples/tcomparer/tcomparerproject.lpr
@@ -4,7 +4,7 @@
 program TComparerProject;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   SysUtils, Generics.Collections, Generics.Defaults;

--- a/src/compatibility/generics.collections/examples/thashmap/thashmapproject.lpr
+++ b/src/compatibility/generics.collections/examples/thashmap/thashmapproject.lpr
@@ -5,7 +5,7 @@
 program THashMapProject;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   SysUtils, Generics.Collections, Generics.Defaults;

--- a/src/compatibility/generics.collections/examples/thashmapcaseinsensitive/thashmapcaseinsensitive.lpr
+++ b/src/compatibility/generics.collections/examples/thashmapcaseinsensitive/thashmapcaseinsensitive.lpr
@@ -4,7 +4,7 @@
 program THashMapCaseInsensitive;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   Generics.Collections, Generics.Defaults;

--- a/src/compatibility/generics.collections/examples/thashmapextendedequalitycomparer/thashmapextendedequalitycomparer.lpr
+++ b/src/compatibility/generics.collections/examples/thashmapextendedequalitycomparer/thashmapextendedequalitycomparer.lpr
@@ -4,7 +4,7 @@
 program THashMapExtendedEqualityComparer;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   SysUtils, Generics.Collections, Generics.Defaults;

--- a/src/compatibility/generics.collections/examples/tobjectlist/tobjectlistproject.lpr
+++ b/src/compatibility/generics.collections/examples/tobjectlist/tobjectlistproject.lpr
@@ -5,7 +5,7 @@
 program TObjectListProject;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   SysUtils, Generics.Collections, Generics.Defaults, DateUtils;

--- a/src/compatibility/generics.collections/examples/tqueue/tqueueproject.lpr
+++ b/src/compatibility/generics.collections/examples/tqueue/tqueueproject.lpr
@@ -5,7 +5,7 @@
 program TQueueProject;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   SysUtils, Generics.Collections;

--- a/src/compatibility/generics.collections/examples/tstack/tstackproject.lpr
+++ b/src/compatibility/generics.collections/examples/tstack/tstackproject.lpr
@@ -4,7 +4,7 @@
 program TStackProject;
 
 {$MODE DELPHI}
-{$APPTYPE CONSOLE}
+{$IFDEF WINDOWS}{$APPTYPE CONSOLE}{$ENDIF}
 
 uses
   SysUtils,

--- a/tools/build-tool/data/standalone/program_template.lpr
+++ b/tools/build-tool/data/standalone/program_template.lpr
@@ -17,7 +17,7 @@
 { Program to run the game on desktop (standalone) platforms. }
 program ${NAME_PASCAL}_standalone;
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 
 { This adds icons and version info for Windows,
   automatically created by "castle-engine compile".

--- a/tools/castle-curves/castle-curves.lpr
+++ b/tools/castle-curves/castle-curves.lpr
@@ -16,7 +16,7 @@
 { Create and edit curves.
   Docs are at https://github.com/castle-engine/castle-engine/wiki/Curves-tool }
 
-{$apptype GUI}
+{$ifdef Windows}{$apptype GUI}{$endif}
 {$I castleconf.inc}
 
 uses SysUtils, Classes, Math,

--- a/tools/sprite-sheet-to-x3d/sprite-sheet-to-x3d.lpr
+++ b/tools/sprite-sheet-to-x3d/sprite-sheet-to-x3d.lpr
@@ -15,7 +15,7 @@
 
 { Convert spritesheets to classic X3D files. }
 
-{$APPTYPE CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses Classes, SysUtils, strutils, DOM, RegExpr, Generics.Collections,
   CastleParameters, CastleImages, CastleStringUtils,

--- a/tools/texture-font-to-pascal/texture-font-to-pascal.lpr
+++ b/tools/texture-font-to-pascal/texture-font-to-pascal.lpr
@@ -15,7 +15,7 @@
 
 { Convert ttf fonts to Pascal units, to embed fonts inside source code. }
 
-{$apptype CONSOLE}
+{$ifdef Windows}{$apptype CONSOLE}{$endif}
 
 uses Classes, SysUtils,
   CastleFont2Pascal, CastleUtils, CastleClassUtils, CastleLog,


### PR DESCRIPTION
Hi, Michalis!
As $Apptype directive is Windows-specific, there's a warning issued on Linux. I've seemed to fixed everything here, thou trivial, the amount of corrections is large (42 files), so it'd be good if you could look it through before merging.
E.g. tools/build-tool/data/standalone/program_template.lpr might correspond to windows-only apps and therefore the check would be unnecessary.
Pay attention that I've also modified files in generics.collections/examples (I'm not sure why are they located in src folder, thou).