### PR TITLE
fix for split string only numbers in obj parser

### DIFF
--- a/src/base/castlestringutils.pas
+++ b/src/base/castlestringutils.pas
@@ -155,6 +155,7 @@ const
   AllChars = [Low(AnsiChar) .. High(AnsiChar)];
   DefaultWordBorders = AllChars - ['a'..'z', 'A'..'Z', '0'..'9', '_'];
   WhiteSpaces = [' ', #9, #10, #13];
+  OnlyNums = AllChars - ['0'..'9', '.', '-','+','e','E'];
   SimpleAsciiCharacters = [#32 .. #126];
 
 function RandomString: string;

--- a/src/base/castlevectors_float.inc
+++ b/src/base/castlevectors_float.inc
@@ -286,8 +286,8 @@ var
   SPosition: Integer;
 begin
   SPosition := 1;
-  Result.Data[0] := StrToFloat(NextToken(S, SPosition));
-  Result.Data[1] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[0] := StrToFloat(NextToken(S, SPosition, OnlyNums));
+  Result.Data[1] := StrToFloat(NextToken(S, SPosition, OnlyNums));
   if NextToken(S, SPosition) <> '' then
     raise EConvertError.Create('Expected end of data when reading vector from string');
 end;
@@ -297,9 +297,9 @@ var
   SPosition: Integer;
 begin
   SPosition := 1;
-  Result.Data[0] := StrToFloat(NextToken(S, SPosition));
-  Result.Data[1] := StrToFloat(NextToken(S, SPosition));
-  Result.Data[2] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[0] := StrToFloat(NextToken(S, SPosition, OnlyNums));
+  Result.Data[1] := StrToFloat(NextToken(S, SPosition, OnlyNums));
+  Result.Data[2] := StrToFloat(NextToken(S, SPosition, OnlyNums));
   if NextToken(S, SPosition) <> '' then
     raise EConvertError.Create('Expected end of data when reading vector from string');
 
@@ -313,10 +313,10 @@ var
   SPosition: Integer;
 begin
   SPosition := 1;
-  Result.Data[0] := StrToFloat(NextToken(S, SPosition));
-  Result.Data[1] := StrToFloat(NextToken(S, SPosition));
-  Result.Data[2] := StrToFloat(NextToken(S, SPosition));
-  Result.Data[3] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[0] := StrToFloat(NextToken(S, SPosition, OnlyNums));
+  Result.Data[1] := StrToFloat(NextToken(S, SPosition, OnlyNums));
+  Result.Data[2] := StrToFloat(NextToken(S, SPosition, OnlyNums));
+  Result.Data[3] := StrToFloat(NextToken(S, SPosition, OnlyNums));
   if NextToken(s, SPosition) <> '' then
     raise EConvertError.Create('Expected end of data when reading vector from string');
 end;

--- a/src/base/castlevectors_float.inc
+++ b/src/base/castlevectors_float.inc
@@ -96,6 +96,9 @@ function Matrix4Double(const V: TMatrix4): TMatrix4Double;
 function Vector2FromStr(const S: string): TVector2;
 function Vector3FromStr(const S: string): TVector3;
 function Vector4FromStr(const S: string): TVector4;
+
+
+function Vector3FromStrPermissive(const S: string): TVector3;
 { @groupEnd }
 
 { Linear interpolation between two vector values.
@@ -286,13 +289,29 @@ var
   SPosition: Integer;
 begin
   SPosition := 1;
-  Result.Data[0] := StrToFloat(NextToken(S, SPosition, OnlyNums));
-  Result.Data[1] := StrToFloat(NextToken(S, SPosition, OnlyNums));
+  Result.Data[0] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[1] := StrToFloat(NextToken(S, SPosition));
   if NextToken(S, SPosition) <> '' then
     raise EConvertError.Create('Expected end of data when reading vector from string');
 end;
 
 function Vector3FromStr(const s: string): TVector3;
+var
+  SPosition: Integer;
+begin
+  SPosition := 1;
+  Result.Data[0] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[1] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[2] := StrToFloat(NextToken(S, SPosition));
+  if NextToken(S, SPosition) <> '' then
+    raise EConvertError.Create('Expected end of data when reading vector from string');
+
+  { This could also be implemented by DeFormat, but this is faster
+    (which is important for e.g. reading 3D data where this function may be used
+    often) }
+end;
+
+function Vector3FromStrPermissive(const s: string): TVector3;
 var
   SPosition: Integer;
 begin
@@ -313,10 +332,10 @@ var
   SPosition: Integer;
 begin
   SPosition := 1;
-  Result.Data[0] := StrToFloat(NextToken(S, SPosition, OnlyNums));
-  Result.Data[1] := StrToFloat(NextToken(S, SPosition, OnlyNums));
-  Result.Data[2] := StrToFloat(NextToken(S, SPosition, OnlyNums));
-  Result.Data[3] := StrToFloat(NextToken(S, SPosition, OnlyNums));
+  Result.Data[0] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[1] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[2] := StrToFloat(NextToken(S, SPosition));
+  Result.Data[3] := StrToFloat(NextToken(S, SPosition));
   if NextToken(s, SPosition) <> '' then
     raise EConvertError.Create('Expected end of data when reading vector from string');
 end;

--- a/src/x3d/x3dloadinternalobj.pas
+++ b/src/x3d/x3dloadinternalobj.pas
@@ -306,7 +306,7 @@ var
       if SameText(FirstToken, 'xyz') or SameText(FirstToken, 'spectral') then
         { we can't interpret other colors than RGB, so we silently ignore them }
         Result := Vector3(1, 1, 1) else
-        Result := Vector3FromStr(Line);
+        Result := Vector3FromStrPermissive(Line);
     end;
 
     procedure CheckIsMaterial(const AttributeName: string);
@@ -440,10 +440,10 @@ begin
 
       { specialized token line parsing }
       case ArrayPosText(lineTok, ['v', 'vt', 'f', 'vn', 'g', 'mtllib', 'usemtl']) of
-        0: Verts.Add(Vector3FromStr(lineAfterMarker));
+        0: Verts.Add(Vector3FromStrPermissive(lineAfterMarker));
         1: TexCoords.Add(ReadTexCoordFromOBJLine(lineAfterMarker));
         2: ReadFacesFromOBJLine(lineAfterMarker, UsedMaterial);
-        3: Normals.Add(Vector3FromStr(lineAfterMarker));
+        3: Normals.Add(Vector3FromStrPermissive(lineAfterMarker));
         4: {GroupName := LineAfterMarker};
         5: ReadMaterials(LineAfterMarker);
         6: begin
@@ -528,6 +528,8 @@ var
   FacesWithMaterial: TWavefrontMaterial;
   Appearances: TX3DNodeList;
   Shape: TShapeNode;
+  ttt:single;
+    Time: cardinal;
 begin
   BaseUrl := AbsoluteURI(URL);
   Appearances := nil;
@@ -540,11 +542,25 @@ begin
     Coord := TCoordinateNode.Create('ObjCoordinates',BaseUrl);
     TexCoord := TTextureCoordinateNode.Create('ObjTextureCoordinates', BaseUrl);
     Normal := TNormalNode.Create('ObjNormals', BaseUrl);
+	
+	Time:=GetTickCount;
 
     Obj := TObject3DOBJ.Create(URL,
       Coord.FdPoint.Items,
       TexCoord.FdPoint.Items,
       Normal.FdVector.Items);
+	  
+	  
+		   ttt:=GetTickCount-Time;
+		   ttt:=ttt/1000;
+      {
+  writeln(
+  format('obj load time %.2fs',
+       [ttt
+       ]
+       )
+  );
+       }
     try
       Appearances := TX3DNodeList.Create(false);
       Appearances.Count := Obj.Materials.Count;


### PR DESCRIPTION
I have obj file with
	Ka 0 0 0c
in mtl file and obj parser was crashed when parse string '0c' as number