### PR TITLE
Detection of CodeTyphon FPC with generics compatibility.

### DIFF
--- a/tools/build-tool/code/toolcompile.pas
+++ b/tools/build-tool/code/toolcompile.pas
@@ -57,6 +57,7 @@ uses SysUtils, Process,
 type
   TFPCVersion = object
     Major, Minor, Release: Integer;
+    IsCodeTyphon: Boolean;
     function AtLeast(const AMajor, AMinor, ARelease: Integer): boolean;
   end;
 
@@ -80,6 +81,8 @@ begin
   MyRunCommandIndir(GetCurrentDir, FpcExe, ['-iV'], FpcOutput, FpcExitStatus);
   if FpcExitStatus <> 0 then
     raise Exception.Create('Failed to query FPC version');
+
+  Result.IsCodeTyphon := Pos('codetyphon', LowerCase(FpcExe)) > 0;
 
   { parse output into 3 numbers }
   FpcOutput := Trim(FpcOutput);
@@ -415,7 +418,7 @@ begin
         AddEnginePath('physics');
         AddEnginePath('physics/kraft');
 
-        if not FPCVer.AtLeast(3, 1, 1) then
+        if not FPCVer.AtLeast(3, 1, 1) or FPCVer.IsCodeTyphon then
           AddEnginePath('compatibility/generics.collections/src');
 
         { Do not add castle-fpc.cfg.


### PR DESCRIPTION
CodeTyphon has its own FPC version with small modifications. One thing is its own Generics.Collection in a seperate package. That is why the build tool could not find the units. With a detection if CodeTyphon is installed, now, in this case, it will load the compatibility units like in FPC versions below 3.1.1.
Nicely the detection is very easy because on every supported platform the path to the modified FPC version contains the string "codetyphon".