### PR TITLE
Removed CastleUIState and CastleDialogStates from alternate_castle_window.

### DIFF
--- a/packages/alternative_castle_window_based_on_lcl.lpk
+++ b/packages/alternative_castle_window_based_on_lcl.lpk
@@ -44,7 +44,7 @@ This package cannot be installed under Lazarus, it's only for being used in othe
 This is the same license as used by Lazarus LCL and FPC RTL.
 See https://castle-engine.io/license.php for details."/>
     <Version Major="6" Minor="5"/>
-    <Files Count="14">
+    <Files Count="12">
       <Item1>
         <Filename Value="../src/base/castleconf.inc"/>
         <Type Value="Include"/>
@@ -94,14 +94,6 @@ See https://castle-engine.io/license.php for details."/>
         <AddToUsesPkgSection Value="False"/>
         <UnitName Value="CastleInternalXlib"/>
       </Item12>
-      <Item13>
-        <Filename Value="../src/window/castleuistate.pas"/>
-        <UnitName Value="CastleUIState"/>
-      </Item13>
-      <Item14>
-        <Filename Value="../src/window/castledialogstates.pas"/>
-        <UnitName Value="CastleDialogStates"/>
-      </Item14>
     </Files>
     <RequiredPkgs Count="3">
       <Item1>


### PR DESCRIPTION
In ce1b411b882c5660237051aa66162ad85706998c CastleDialogStates and CastleUIState were moved to ui/opengl into the castle_base.lpk. You forgot to remove if from alternative_castle_window_based_on_lcl.lpk.