### PR TITLE
Reliable showing/hiding of Android keyboard

### DIFF
--- a/src/ui/opengl/castlecontrols_edit.inc
+++ b/src/ui/opengl/castlecontrols_edit.inc
@@ -381,7 +381,7 @@ begin
   inherited;
 
   if FAutoOnScreenKeyboard then
-    Messaging.Send(['change-keyboard-state', BoolToStr(Value)])
+    Messaging.Send(['change-keyboard-state', TMessaging.BoolToStr(Value)])
 end;
 
 {$endif read_implementation}

--- a/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/ServiceAbstract.java
+++ b/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/ServiceAbstract.java
@@ -58,10 +58,10 @@ public abstract class ServiceAbstract
 
     protected static boolean stringToBoolean(String value)
     {
-        if (value.equals("true")) {
+        if (value.equals("-1") || (value.equals("1") || value.equals("True") || value.equals("true")) {
             return true;
         } else
-        if (value.equals("false")) {
+        if (value.equals("0") || value.equals("False") || value.equals("false")) {
             return false;
         } else {
             logWarning(CATEGORY, "Invalid boolean value in message: " + value);

--- a/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/ServiceAbstract.java
+++ b/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/ServiceAbstract.java
@@ -58,10 +58,10 @@ public abstract class ServiceAbstract
 
     protected static boolean stringToBoolean(String value)
     {
-        if (value.equals("-1") || (value.equals("1") || value.equals("True") || value.equals("true")) {
+        if (value.equals("true")) {
             return true;
         } else
-        if (value.equals("0") || value.equals("False") || value.equals("false")) {
+        if (value.equals("false")) {
             return false;
         } else {
             logWarning(CATEGORY, "Invalid boolean value in message: " + value);

--- a/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/ServiceMiscellaneous.java
+++ b/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/ServiceMiscellaneous.java
@@ -85,9 +85,9 @@ public class ServiceMiscellaneous extends ServiceAbstract
     private void changeKeyboardState(Boolean keyboardState)
     {
         if (keyboardState)
-            im.toggleSoftInput(0, InputMethodManager.SHOW_IMPLICIT);
+            im.showSoftInput(getActivity().getWindow().getDecorView(), InputMethodManager.SHOW_FORCED);
         else
-            im.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0);
+            im.hideSoftInputFromWindow(getActivity().getWindow().getDecorView().getWindowToken(), 0);
     }
 
     @Override


### PR DESCRIPTION
I was able to change the toggle approach for the Android software keyboard with working `showSoftInput` and `hideSoftInput`, which makes it much less buggy in practical use.
Next to your suggestion to get the view via `getActivity().getWindow().getDecorView()`, it was necessary to use `InputMethodManager.SHOW_FORCED`.
Besides that, I had to extend the `stringToBoolean` function because the FreePascal `BoolToStr` used in CastleEdit wasn't compatible (anymore?). It returns `true` as `-1` and `false` as `0`. (When used in "string mode" it returns `True` and `False`, so this should cover most cases.)