### PR TITLE
KraftRigidBody lifetime fix and expose some methods (WIP)

### DIFF
--- a/examples/physics/physics_2d_collisions/gameinitialize.pas
+++ b/examples/physics/physics_2d_collisions/gameinitialize.pas
@@ -77,11 +77,14 @@ begin
 
   RBody := TRigidBody.Create(Plane);
   RBody.Dynamic := true;
-  RBody.Animated := true;
   RBody.Setup2D;
   RBody.OnCollisionEnter := @CollisionEnter;
+  RBody.LinearVelocityDamp := 0;
+  RBody.MaximalLinearVelocity := 200;
+  RBody.AngularVelocityDamp := 0;
   Collider := TBoxCollider.Create(RBody);
   Collider.Size := LocalBoundingBox.Size * 5;
+  Collider.Restitution := 0.4;
 
   RigidBody := RBody;
 end;
@@ -201,6 +204,7 @@ begin
   Status.Caption := Format(
     'FPS: %s' + NL +
     'Scene Manager Objects: %d' + NL +
+    'Linear velocity: %f' + NL +
     'Use AWSD to change plane velocity.' + NL +
     NL+
     'Current Plane Colisions (from TRigidBody.GetCollidingTransforms):' + NL +
@@ -210,6 +214,7 @@ begin
     '  %s', [
      Container.Fps.ToString,
      SceneManager.Items.Count,
+     Plane.RigidBody.LinearVelocity.Length,
      CollisionsListTXT,
      Plane.LastCollisionEnter
    ]);

--- a/examples/physics/physics_2d_game_sopwith/gameinitialize.pas
+++ b/examples/physics/physics_2d_game_sopwith/gameinitialize.pas
@@ -239,7 +239,7 @@ procedure WindowUpdate(Container: TUIContainer);
 
     RigidBody := TRigidBody.Create(Transform);
     RigidBody.Setup2D;
-    RigidBody.InitialLinearVelocity := Vector3(100, 0, 0);
+    RigidBody.LinearVelocity := Vector3(100, 0, 0);
 
     Collider := TSphereCollider.Create(RigidBody);
     Collider.Radius := MissileScene.BoundingBox.Size.X / 2;

--- a/examples/physics/physics_3d_demo/gameinitialize.pas
+++ b/examples/physics/physics_3d_demo/gameinitialize.pas
@@ -170,7 +170,7 @@ procedure WindowPress(Container: TUIContainer; const Event: TInputPressRelease);
 
     SceneManager.Items.Add(Scene);
 
-    RigidBody.InitialLinearVelocity := CameraDir * 4.0;
+    RigidBody.LinearVelocity := CameraDir * 4.0;
     Scene.RigidBody := RigidBody;
   end;
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -136,18 +136,12 @@
 
     procedure SetAngularVelocity(const AVelocity: TVector3);
     function GetAngularVelocity: TVector3;
-
     procedure SetAngularVelocityDamp(const AValue: Single);
-    function GetAngularVelocityDamp: Single;
-
     procedure SetMaximalAngularVelocity(const AValue: Single);
 
     procedure SetLinearVelocity(const LVelocity: TVector3);
     function GetLinearVelocity: TVector3;
-
     procedure SetLinearVelocityDamp(const AValue: Single);
-    function GetLinearVelocityDamp: Single;
-
     procedure SetMaximalLinearVelocity(const AValue: Single);
 
     procedure SetExists(const Value: Boolean);
@@ -170,11 +164,11 @@
     function GetCollidingTransforms: TCastleTransformList;
 
     property AngularVelocity: TVector3 read GetAngularVelocity write SetAngularVelocity;
-    property AngularVelocityDamp: Single read GetAngularVelocityDamp write SetAngularVelocityDamp;
+    property AngularVelocityDamp: Single read FAngularVelocityDamp write SetAngularVelocityDamp;
     property MaximalAngularVelocity: Single read FMaximalAngularVelocity write SetMaximalAngularVelocity;
 
     property LinearVelocity: TVector3 read GetLinearVelocity write SetLinearVelocity;
-    property LinearVelocityDamp: Single read GetLinearVelocityDamp write SetLinearVelocityDamp;
+    property LinearVelocityDamp: Single read FLinearVelocityDamp write SetLinearVelocityDamp;
     property MaximalLinearVelocity: Single read FMaximalLinearVelocity write SetMaximalLinearVelocity;
 
     { Occurs when TRigidBody starts colliding with another TRigidBody.
@@ -563,28 +557,12 @@ begin
   end;
 end;
 
-function TRigidBody.GetAngularVelocityDamp: Single;
-begin
-  if FKraftBody <> nil then
-    Result := FKraftBody.AngularVelocityDamp
-  else
-    Result := FAngularVelocityDamp;
-end;
-
 procedure TRigidBody.SetMaximalAngularVelocity(const AValue: Single);
 begin
   FMaximalAngularVelocity := AValue;
   { Kraft uses max velocity for delta time which is physics update frequency. }
   if FKraftBody <> nil then
     FKraftBody.MaximalAngularVelocity := AValue / FTransform.World.FKraftEngine.WorldFrequency;
-end;
-
-function TRigidBody.GetLinearVelocityDamp: Single;
-begin
-  if FKraftBody <> nil then
-    Result := FKraftBody.LinearVelocityDamp
-  else
-    Result := FLinearVelocityDamp;
 end;
 
 procedure TRigidBody.SetMaximalLinearVelocity(const AValue: Single);
@@ -615,9 +593,7 @@ begin
     Exit;
 
   FLinearVelocity := VectorFromKraft(FKraftBody.LinearVelocity);
-  FLinearVelocityDamp := FKraftBody.LinearVelocityDamp;
   FAngularVelocity := VectorFromKraft(FKraftBody.AngularVelocity);
-  FAngularVelocityDamp := FKraftBody.AngularVelocityDamp;
 end;
 
 procedure TRigidBody.Update(const Transform: TCastleTransform; const SecondsPassed: Single);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -135,12 +135,10 @@
     procedure SynchronizeFromKraft;
 
     procedure SetAngularVelocity(const AVelocity: TVector3);
-    function GetAngularVelocity: TVector3;
     procedure SetAngularVelocityDamp(const AValue: Single);
     procedure SetMaximalAngularVelocity(const AValue: Single);
 
     procedure SetLinearVelocity(const LVelocity: TVector3);
-    function GetLinearVelocity: TVector3;
     procedure SetLinearVelocityDamp(const AValue: Single);
     procedure SetMaximalLinearVelocity(const AValue: Single);
 
@@ -163,11 +161,11 @@
     { Transformations that we collide with currently. }
     function GetCollidingTransforms: TCastleTransformList;
 
-    property AngularVelocity: TVector3 read GetAngularVelocity write SetAngularVelocity;
+    property AngularVelocity: TVector3 read FAngularVelocity write SetAngularVelocity;
     property AngularVelocityDamp: Single read FAngularVelocityDamp write SetAngularVelocityDamp;
     property MaximalAngularVelocity: Single read FMaximalAngularVelocity write SetMaximalAngularVelocity;
 
-    property LinearVelocity: TVector3 read GetLinearVelocity write SetLinearVelocity;
+    property LinearVelocity: TVector3 read FLinearVelocity write SetLinearVelocity;
     property LinearVelocityDamp: Single read FLinearVelocityDamp write SetLinearVelocityDamp;
     property MaximalLinearVelocity: Single read FMaximalLinearVelocity write SetMaximalLinearVelocity;
 
@@ -529,7 +527,6 @@ begin
 
   Assert(not ((Transform.World.FKraftEngine = nil) and (FKraftBody <> nil)), 'KraftBody should not live longer than KraftEngine!');
 
-  SynchronizeFromKraft;
   FreeAndNil(FKraftBody);
 
   { Collider.FKraftShape is owned by FKraftBody, it was automatically freed already }
@@ -637,8 +634,10 @@ begin
 
   UpdateCollides(Transform);
   if Dynamic then
-    TransformationFromKraft
-  else
+  begin
+    TransformationFromKraft;
+    SynchronizeFromKraft; // I think its only required for dynamic bodies.
+  end else
   if Animated then
   begin
     // TODO: check "if TransformChanged then" or such, don't do this every frame
@@ -677,14 +676,6 @@ begin
   end;
 end;
 
-function TRigidBody.GetLinearVelocity: TVector3;
-begin
-  if FKraftBody <> nil then
-    Result := VectorFromKraft(FKraftBody.LinearVelocity)
-  else
-    Result := FLinearVelocity;
-end;
-
 procedure TRigidBody.SetAngularVelocity(const AVelocity: TVector3);
 begin
   FAngularVelocity := AVelocity;
@@ -694,14 +685,6 @@ begin
     if not AVelocity.IsPerfectlyZero then
       FKraftBody.SetToAwake;
   end;
-end;
-
-function TRigidBody.GetAngularVelocity: TVector3;
-begin
-  if FKraftBody <> nil then
-    Result := VectorFromKraft(FKraftBody.AngularVelocity)
-  else
-    Result := FAngularVelocity;
 end;
 
 procedure TRigidBody.SetExists(const Value: Boolean);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -120,8 +120,10 @@
     FLockRotation: T3DCoords;
     FAngularVelocity: TVector3;
     FAngularVelocityDamp: Single;
+    FMaximalAngularVelocity: Single;
     FLinearVelocity: TVector3;
     FLinearVelocityDamp: Single;
+    FMaximalLinearVelocity: Single;
     FTransform: TCastleTransform;
     FCollisionList: TCastleTransformList;
     FOnCollisionEnter: TOnCollision;
@@ -138,11 +140,15 @@
     procedure SetAngularVelocityDamp(const AValue: Single);
     function GetAngularVelocityDamp: Single;
 
+    procedure SetMaximalAngularVelocity(const AValue: Single);
+
     procedure SetLinearVelocity(const LVelocity: TVector3);
     function GetLinearVelocity: TVector3;
 
     procedure SetLinearVelocityDamp(const AValue: Single);
     function GetLinearVelocityDamp: Single;
+
+    procedure SetMaximalLinearVelocity(const AValue: Single);
 
     procedure SetExists(const Value: Boolean);
   public
@@ -165,9 +171,11 @@
 
     property AngularVelocity: TVector3 read GetAngularVelocity write SetAngularVelocity;
     property AngularVelocityDamp: Single read GetAngularVelocityDamp write SetAngularVelocityDamp;
+    property MaximalAngularVelocity: Single read FMaximalAngularVelocity write SetMaximalAngularVelocity;
 
     property LinearVelocity: TVector3 read GetLinearVelocity write SetLinearVelocity;
     property LinearVelocityDamp: Single read GetLinearVelocityDamp write SetLinearVelocityDamp;
+    property MaximalLinearVelocity: Single read FMaximalLinearVelocity write SetMaximalLinearVelocity;
 
     { Occurs when TRigidBody starts colliding with another TRigidBody.
 
@@ -501,7 +509,10 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
     end;
 
     FKraftBody.LinearVelocityDamp := FLinearVelocityDamp;
+    FKraftBody.MaximalLinearVelocity := FMaximalLinearVelocity / Transform.World.FKraftEngine.WorldFrequency;
+
     FKraftBody.AngularVelocityDamp := FAngularVelocityDamp;
+    FKraftBody.MaximalAngularVelocity := FMaximalAngularVelocity / Transform.World.FKraftEngine.WorldFrequency;
 
     // set initial transformation
     FKraftBody.SetWorldTransformation(MatrixToKraft(Transform.WorldTransform));
@@ -560,12 +571,28 @@ begin
     Result := FAngularVelocityDamp;
 end;
 
+procedure TRigidBody.SetMaximalAngularVelocity(const AValue: Single);
+begin
+  FMaximalAngularVelocity := AValue;
+  { Kraft uses max velocity for delta time which is physics update frequency. }
+  if FKraftBody <> nil then
+    FKraftBody.MaximalAngularVelocity := AValue / FTransform.World.FKraftEngine.WorldFrequency;
+end;
+
 function TRigidBody.GetLinearVelocityDamp: Single;
 begin
   if FKraftBody <> nil then
     Result := FKraftBody.LinearVelocityDamp
   else
     Result := FLinearVelocityDamp;
+end;
+
+procedure TRigidBody.SetMaximalLinearVelocity(const AValue: Single);
+begin
+  FMaximalLinearVelocity := AValue;
+  { Kraft uses max velocity for delta time which is physics update frequency. }
+  if FKraftBody <> nil then
+    FKraftBody.MaximalLinearVelocity := AValue / FTransform.World.FKraftEngine.WorldFrequency;
 end;
 
 procedure TRigidBody.SetAngularVelocityDamp(const AValue: Single);
@@ -806,11 +833,12 @@ begin
     FKraftEngine := TKraft.Create(-1);
     FKraftEngine.ContactManager.OnContactBegin := @CollisionBegin;
     FKraftEngine.ContactManager.OnContactEnd := @CollisionEnd;
-    { Kraft sets MaximalLinearVelocity in TKraft Constructor.
-      With this limit can't make initial velocity greater than about 120.
-      That makes physics very slow, so we need remove this limitation. }
+    { Kraft sets MaximalLinearVelocity in TKraft Constructor to 2.
+      With this limit can't make velocity greater than about 120
+      (2 * engine step frequency = 2 * 60 = 120). That makes physics
+      very slow, so we need remove this limitation. }
     FKraftEngine.MaximalLinearVelocity := 0;
-    //KraftEngine.SetFrequency(120.0); // default is 60
+    //FKraftEngine.SetFrequency(120.0); // default is 60
   end;
 end;
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -710,7 +710,7 @@ end;
 procedure TCastleTransform.PhysicsChangeWorldDetach;
 begin
   { When removing 3D object from world, remove it also from physics engine world. }
-  if RigidBody <> nil then
+  if (RigidBody <> nil) and (RigidBody.FKraftBody <> nil) then
     RigidBody.DeinitializeTransform(Self);
 end;
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -169,6 +169,11 @@
     property LinearVelocityDamp: Single read FLinearVelocityDamp write SetLinearVelocityDamp;
     property MaximalLinearVelocity: Single read FMaximalLinearVelocity write SetMaximalLinearVelocity;
 
+    property InitialAngularVelocity: TVector3 read FAngularVelocity write SetAngularVelocity;
+      deprecated 'use AngularVelocity';
+    property InitialLinearVelocity: TVector3 read FLinearVelocity write SetLinearVelocity;
+      deprecated 'use LinearVelocity';
+
     { Occurs when TRigidBody starts colliding with another TRigidBody.
 
       It can occur repeatedly for the same body (in the same time instant)

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -506,7 +506,7 @@ begin
 
   Assert(Transform.World <> nil, 'Transform.World should be assigned at the time of TRigidBody.DeinitializeTransform call');
 
-  Assert((Transform.World.FKraftEngine = nil) and (FKraftBody <> nil) , 'KraftBody should not live longer than KraftEngine!');
+  Assert(not ((Transform.World.FKraftEngine = nil) and (FKraftBody <> nil)), 'KraftBody should not live longer than KraftEngine!');
 
   FreeAndNil(FKraftBody);
 
@@ -576,7 +576,6 @@ begin
   if (Transform.World <> nil) and (not Transform.World.EnablePhysics) then
     Exit;
 
-  InitializeTransform(Transform);
   UpdateCollides(Transform);
   if Dynamic then
     TransformationFromKraft

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -820,17 +820,20 @@ var
   KraftRigidBody: TKraftRigidBody;
   NextKraftRigidBody: TKraftRigidBody;
 begin
-  KraftRigidBody := FKraftEngine.RigidBodyFirst;
-
-  while Assigned(KraftRigidBody) do
+  if FKraftEngine <> nil then
   begin
-    NextKraftRigidBody := KraftRigidBody.RigidBodyNext;
-    if Assigned(KraftRigidBody.UserData) then
+    KraftRigidBody := FKraftEngine.RigidBodyFirst;
+
+    while Assigned(KraftRigidBody) do
     begin
-      CastleRigidBody := TRigidBody(KraftRigidBody.UserData);
-      CastleRigidBody.DeinitializeTransform(CastleRigidBody.FTransform);
+      NextKraftRigidBody := KraftRigidBody.RigidBodyNext;
+      if Assigned(KraftRigidBody.UserData) then
+      begin
+        CastleRigidBody := TRigidBody(KraftRigidBody.UserData);
+        CastleRigidBody.DeinitializeTransform(CastleRigidBody.FTransform);
+      end;
+      KraftRigidBody := NextKraftRigidBody;
     end;
-    KraftRigidBody := NextKraftRigidBody;
   end;
 
   FreeAndNil(FKraftEngine);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -127,6 +127,9 @@
 
     procedure UpdateCollides(const Transform: TCastleTransform);
 
+    { Sets all values from Kraft to CGE private fields. }
+    procedure SynchronizeFromKraft;
+
     procedure SetLinearVelocity(const LVelocity: TVector3);
     function GetLinearVelocity: TVector3;
 
@@ -504,6 +507,7 @@ begin
 
   Assert(not ((Transform.World.FKraftEngine = nil) and (FKraftBody <> nil)), 'KraftBody should not live longer than KraftEngine!');
 
+  SynchronizeFromKraft;
   FreeAndNil(FKraftBody);
 
   { Collider.FKraftShape is owned by FKraftBody, it was automatically freed already }
@@ -529,6 +533,16 @@ begin
     FKraftBody.CollideWithCollisionGroups := [];
     FKraftBody.CollisionGroups := [];
   end;
+end;
+
+procedure TRigidBody.SynchronizeFromKraft;
+begin
+  if FKraftBody = nil then
+    Exit;
+
+  FLinearVelocity := VectorFromKraft(FKraftBody.LinearVelocity);
+  FAngularVelocity := VectorFromKraft(FKraftBody.AngularVelocity);
+
 end;
 
 procedure TRigidBody.Update(const Transform: TCastleTransform; const SecondsPassed: Single);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -501,17 +501,14 @@ end;
 
 procedure TRigidBody.DeinitializeTransform(const Transform: TCastleTransform);
 begin
+  if FRecreateKraftInstance then
+    Exit;
+
   Assert(Transform.World <> nil, 'Transform.World should be assigned at the time of TRigidBody.DeinitializeTransform call');
 
-  if Transform.World.FKraftEngine <> nil then
-    FreeAndNil(FKraftBody)
-  else
-    { FKraftBody is owned by FKraftEngine.
-      If FKraftEngine = nil then FKraftBody was already freed.
-      This can happen because TSceneManagerWorld.Destroy frees FKraftEngine,
-      but the TCastleTransform instances (with TRigidBody)
-      may be detached later, see TTestCastleTransform.TestPhysicsWorldOwner. }
-    FKraftBody := nil;
+  Assert((Transform.World.FKraftEngine = nil) and (FKraftBody <> nil) , 'KraftBody should not live longer than KraftEngine!');
+
+  FreeAndNil(FKraftBody);
 
   { Collider.FKraftShape is owned by FKraftBody, it was automatically freed already }
   if Collider <> nil then
@@ -818,7 +815,24 @@ begin
 end;
 
 destructor TSceneManagerWorld.Destroy;
+var
+  CastleRigidBody: TRigidBody;
+  KraftRigidBody: TKraftRigidBody;
+  NextKraftRigidBody: TKraftRigidBody;
 begin
+  KraftRigidBody := FKraftEngine.RigidBodyFirst;
+
+  while Assigned(KraftRigidBody) do
+  begin
+    NextKraftRigidBody := KraftRigidBody.RigidBodyNext;
+    if Assigned(KraftRigidBody.UserData) then
+    begin
+      CastleRigidBody := TRigidBody(KraftRigidBody.UserData);
+      CastleRigidBody.DeinitializeTransform(CastleRigidBody.FTransform);
+    end;
+    KraftRigidBody := NextKraftRigidBody;
+  end;
+
   FreeAndNil(FKraftEngine);
   inherited;
 end;

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -118,9 +118,8 @@
     FExists: Boolean;
     FLockTranslation: T3DCoords;
     FLockRotation: T3DCoords;
-    FInitialAngularVelocity: TVector3;
-    FInitialLinearVelocity: TVector3;
-    FRecreateKraftInstance: Boolean;
+    FAngularVelocity: TVector3;
+    FLinearVelocity: TVector3;
     FTransform: TCastleTransform;
     FCollisionList: TCastleTransformList;
     FOnCollisionEnter: TOnCollision;
@@ -130,6 +129,9 @@
 
     procedure SetLinearVelocity(const LVelocity: TVector3);
     function GetLinearVelocity: TVector3;
+
+    procedure SetAngularVelocity(const AVelocity: TVector3);
+    function GetAngularVelocity: TVector3;
 
     procedure SetExists(const Value: Boolean);
   public
@@ -150,8 +152,7 @@
     { Transformations that we collide with currently. }
     function GetCollidingTransforms: TCastleTransformList;
 
-    property InitialAngularVelocity: TVector3 read FInitialAngularVelocity write FInitialAngularVelocity;
-    property InitialLinearVelocity: TVector3 read FInitialLinearVelocity write FInitialLinearVelocity;
+    property AngularVelocity: TVector3 read GetAngularVelocity write SetAngularVelocity;
     property LinearVelocity: TVector3 read GetLinearVelocity write SetLinearVelocity;
 
     { Occurs when TRigidBody starts colliding with another TRigidBody.
@@ -391,7 +392,7 @@ begin
   FDynamic := true;
   FExists := true;
 
-  FRecreateKraftInstance := true;
+  FKraftBody := nil;
   FCollisionList := TCastleTransformList.Create(false, nil);
   FOnCollisionEnter := nil;
   FOnCollisionExit := nil;
@@ -435,7 +436,6 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
     World := Transform.World;
     World.InitializePhysicsEngine;
 
-    FreeAndNil(FKraftBody);
     FKraftBody := TKraftRigidBody.Create(World.FKraftEngine);
     FKraftBody.UserData := Self;
 
@@ -467,17 +467,17 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
 
     UpdateCollides(Transform);
 
-    if (not InitialAngularVelocity.IsPerfectlyZero) or
-       (not InitialLinearVelocity.IsPerfectlyZero) then
+    if (not FAngularVelocity.IsPerfectlyZero) or
+       (not FLinearVelocity.IsPerfectlyZero) then
     begin
       { The behaviour is more natural when we zero the InitialXxxVelocity
         components that are locked. (Otherwise testing e.g. Setup2D in a 3D
         world makes a little unexpected motions). }
 
-      V := ZeroLockedComponents(InitialAngularVelocity, FLockRotation);
+      V := ZeroLockedComponents(FAngularVelocity, FLockRotation);
       FKraftBody.AngularVelocity := VectorToKraft(V);
 
-      V := ZeroLockedComponents(InitialLinearVelocity, FLockTranslation);
+      V := ZeroLockedComponents(FLinearVelocity, FLockTranslation);
       FKraftBody.LinearVelocity := VectorToKraft(V);
 
       FKraftBody.SetToAwake;
@@ -488,22 +488,18 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
   end;
 
 begin
+  Assert(FKraftBody = nil, 'Kraft body is initialized!');
+
   if Transform.FWorldReferences > 1 then
     raise EMultipleReferencesInWorld.Create('Do not use RigidBody physics with objects (TCastleScene or TCastleTransform) inserted multiple times into the SceneManager.Items');
 
   FTransform := Transform;
-  if FRecreateKraftInstance then
-  begin
-    FRecreateKraftInstance := false;
-    RecreateKraftInstance;
-  end;
+  RecreateKraftInstance;
 end;
 
 procedure TRigidBody.DeinitializeTransform(const Transform: TCastleTransform);
 begin
-  if FRecreateKraftInstance then
-    Exit;
-
+  Assert(FKraftBody <> nil, 'Second deinitialization!');
   Assert(Transform.World <> nil, 'Transform.World should be assigned at the time of TRigidBody.DeinitializeTransform call');
 
   Assert(not ((Transform.World.FKraftEngine = nil) and (FKraftBody <> nil)), 'KraftBody should not live longer than KraftEngine!');
@@ -514,8 +510,6 @@ begin
   if Collider <> nil then
     Collider.FKraftShape := nil;
 
-  { we in unintialized state, so initialize at nearest occasion }
-  FRecreateKraftInstance := true;
   FTransform := nil;
 end;
 
@@ -609,14 +603,42 @@ end;
 
 procedure TRigidBody.SetLinearVelocity(const LVelocity: TVector3);
 begin
-  FKraftBody.LinearVelocity := VectorToKraft(ZeroLockedComponents(LVelocity, FLockTranslation));
-  if not LVelocity.IsPerfectlyZero then
-    FKraftBody.SetToAwake;
+  if FKraftBody <> nil then
+  begin
+    FKraftBody.LinearVelocity := VectorToKraft(ZeroLockedComponents(LVelocity, FLockTranslation));
+    if not LVelocity.IsPerfectlyZero then
+      FKraftBody.SetToAwake;
+  end
+  else
+    FLinearVelocity := LVelocity;
 end;
 
 function TRigidBody.GetLinearVelocity: TVector3;
 begin
-  Result := VectorFromKraft(FKraftBody.LinearVelocity);
+  if FKraftBody <> nil then
+    Result := VectorFromKraft(FKraftBody.LinearVelocity)
+  else
+    Result := FLinearVelocity;
+end;
+
+procedure TRigidBody.SetAngularVelocity(const AVelocity: TVector3);
+begin
+  if FKraftBody <> nil then
+  begin
+    FKraftBody.AngularVelocity := VectorToKraft(ZeroLockedComponents(AVelocity, FLockTranslation));
+    if not AVelocity.IsPerfectlyZero then
+      FKraftBody.SetToAwake;
+  end
+  else
+    FAngularVelocity := AVelocity;
+end;
+
+function TRigidBody.GetAngularVelocity: TVector3;
+begin
+  if FKraftBody <> nil then
+    Result := VectorFromKraft(FKraftBody.AngularVelocity)
+  else
+    Result := FAngularVelocity;
 end;
 
 procedure TRigidBody.SetExists(const Value: Boolean);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -119,7 +119,9 @@
     FLockTranslation: T3DCoords;
     FLockRotation: T3DCoords;
     FAngularVelocity: TVector3;
+    FAngularVelocityDamp: Single;
     FLinearVelocity: TVector3;
+    FLinearVelocityDamp: Single;
     FTransform: TCastleTransform;
     FCollisionList: TCastleTransformList;
     FOnCollisionEnter: TOnCollision;
@@ -130,11 +132,17 @@
     { Sets all values from Kraft to CGE private fields. }
     procedure SynchronizeFromKraft;
 
+    procedure SetAngularVelocity(const AVelocity: TVector3);
+    function GetAngularVelocity: TVector3;
+
+    procedure SetAngularVelocityDamp(const AValue: Single);
+    function GetAngularVelocityDamp: Single;
+
     procedure SetLinearVelocity(const LVelocity: TVector3);
     function GetLinearVelocity: TVector3;
 
-    procedure SetAngularVelocity(const AVelocity: TVector3);
-    function GetAngularVelocity: TVector3;
+    procedure SetLinearVelocityDamp(const AValue: Single);
+    function GetLinearVelocityDamp: Single;
 
     procedure SetExists(const Value: Boolean);
   public
@@ -156,7 +164,10 @@
     function GetCollidingTransforms: TCastleTransformList;
 
     property AngularVelocity: TVector3 read GetAngularVelocity write SetAngularVelocity;
+    property AngularVelocityDamp: Single read GetAngularVelocityDamp write SetAngularVelocityDamp;
+
     property LinearVelocity: TVector3 read GetLinearVelocity write SetLinearVelocity;
+    property LinearVelocityDamp: Single read GetLinearVelocityDamp write SetLinearVelocityDamp;
 
     { Occurs when TRigidBody starts colliding with another TRigidBody.
 
@@ -394,6 +405,9 @@ begin
   FGravity := true;
   FDynamic := true;
   FExists := true;
+  // default damp values from Kraft
+  FLinearVelocityDamp := 0.1;
+  FAngularVelocityDamp := 0.1;
 
   FKraftBody := nil;
   FCollisionList := TCastleTransformList.Create(false, nil);
@@ -486,6 +500,9 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
       FKraftBody.SetToAwake;
     end;
 
+    FKraftBody.LinearVelocityDamp := FLinearVelocityDamp;
+    FKraftBody.AngularVelocityDamp := FAngularVelocityDamp;
+
     // set initial transformation
     FKraftBody.SetWorldTransformation(MatrixToKraft(Transform.WorldTransform));
   end;
@@ -535,14 +552,45 @@ begin
   end;
 end;
 
+function TRigidBody.GetAngularVelocityDamp: Single;
+begin
+  if FKraftBody <> nil then
+    Result := FKraftBody.AngularVelocityDamp
+  else
+    Result := FAngularVelocityDamp;
+end;
+
+function TRigidBody.GetLinearVelocityDamp: Single;
+begin
+  if FKraftBody <> nil then
+    Result := FKraftBody.LinearVelocityDamp
+  else
+    Result := FLinearVelocityDamp;
+end;
+
+procedure TRigidBody.SetAngularVelocityDamp(const AValue: Single);
+begin
+  FAngularVelocityDamp := AValue;
+  if FKraftBody <> nil then
+    FKraftBody.AngularVelocityDamp := AValue;
+end;
+
+procedure TRigidBody.SetLinearVelocityDamp(const AValue: Single);
+begin
+  FLinearVelocityDamp := AValue;
+  if FKraftBody <> nil then
+    FKraftBody.LinearVelocityDamp := AValue;
+end;
+
 procedure TRigidBody.SynchronizeFromKraft;
 begin
   if FKraftBody = nil then
     Exit;
 
   FLinearVelocity := VectorFromKraft(FKraftBody.LinearVelocity);
+  FLinearVelocityDamp := FKraftBody.LinearVelocityDamp;
   FAngularVelocity := VectorFromKraft(FKraftBody.AngularVelocity);
-
+  FAngularVelocityDamp := FKraftBody.AngularVelocityDamp;
 end;
 
 procedure TRigidBody.Update(const Transform: TCastleTransform; const SecondsPassed: Single);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -603,14 +603,13 @@ end;
 
 procedure TRigidBody.SetLinearVelocity(const LVelocity: TVector3);
 begin
+  FLinearVelocity := LVelocity;
   if FKraftBody <> nil then
   begin
     FKraftBody.LinearVelocity := VectorToKraft(ZeroLockedComponents(LVelocity, FLockTranslation));
     if not LVelocity.IsPerfectlyZero then
       FKraftBody.SetToAwake;
-  end
-  else
-    FLinearVelocity := LVelocity;
+  end;
 end;
 
 function TRigidBody.GetLinearVelocity: TVector3;
@@ -623,14 +622,13 @@ end;
 
 procedure TRigidBody.SetAngularVelocity(const AVelocity: TVector3);
 begin
+  FAngularVelocity := AVelocity;
   if FKraftBody <> nil then
   begin
     FKraftBody.AngularVelocity := VectorToKraft(ZeroLockedComponents(AVelocity, FLockTranslation));
     if not AVelocity.IsPerfectlyZero then
       FKraftBody.SetToAwake;
-  end
-  else
-    FAngularVelocity := AVelocity;
+  end;
 end;
 
 function TRigidBody.GetAngularVelocity: TVector3;

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -470,7 +470,7 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
     if (not FAngularVelocity.IsPerfectlyZero) or
        (not FLinearVelocity.IsPerfectlyZero) then
     begin
-      { The behaviour is more natural when we zero the InitialXxxVelocity
+      { The behaviour is more natural when we zero the XxxVelocity
         components that are locked. (Otherwise testing e.g. Setup2D in a 3D
         world makes a little unexpected motions). }
 


### PR DESCRIPTION
As you probably noticed `TRigidBody.GetLinearVelocity()` has some problem. There is no 100% working way to check whether there is existing `FKraftBody` or that is just hanging pointer (so I have not added this check). It's because sometimes KraftEngine could be freed before `TCastleTransforms.DeinitializeTransform` call. Like in comment in `DeinitializeTransform`:

>  { FKraftBody is owned by FKraftEngine.
      If FKraftEngine = nil then FKraftBody was already freed.
      This can happen because TSceneManagerWorld.Destroy frees FKraftEngine,
      but the TCastleTransform instances (with TRigidBody)
      may be detached later, see TTestCastleTransform.TestPhysicsWorldOwner.

Because we currently have a pointer to our `TRigidBody` in UserData. I think we can fix it and have 100% certainty that this pointer is OK. I think it will allow to avoid many mistakes/bugs in the future.

Please check it. If you approve it a lot of check will base on it. Now I back to work on my game (in CGE of course!) so you don't need to hurry :)
