### PR TITLE
Admob: Implemented rewarded ads and a lot of fixes in interstitial ads (WIP)

### DIFF
--- a/src/services/castleads.pas
+++ b/src/services/castleads.pas
@@ -26,15 +26,29 @@ const
   { Test banner ad "unit id". You can use it with @link(TAds.InitializeAdMob) for testing purposes
     (but eventually you want to create your own, to show non-testing ads!).
 
-    From https://developers.google.com/mobile-ads-sdk/docs/admob/android/quick-start }
+    From https://developers.google.com/admob/android/test-ads }
   TestAdMobBannerUnitId = 'ca-app-pub-3940256099942544/6300978111';
 
-  { Test interstitial ad "unit id". You can use it with @link(TAds.InitializeAdMob) for testing purposes
+
+  { Test interstitial static ad "unit id". You can use it with @link(TAds.InitializeAdMob) for testing purposes
     (but eventually you want to create your own, to show non-testing ads!).
 
-    From http://stackoverflow.com/questions/12553929/is-there-any-admob-dummy-id and
-    https://github.com/googleads/googleads-mobile-android-examples/blob/master/admob/InterstitialExample/app/src/main/res/values/strings.xml }
+    From https://developers.google.com/admob/android/test-ads }
   TestAdMobInterstitialUnitId = 'ca-app-pub-3940256099942544/1033173712';
+
+
+  { Test interstitial video ad "unit id". You can use it with @link(TAds.InitializeAdMob) for testing purposes
+    (but eventually you want to create your own, to show non-testing ads!).
+
+    From https://developers.google.com/admob/android/test-ads }
+  TestAdMobInterstitialVideoUnitId = 'ca-app-pub-3940256099942544/8691691433';
+
+
+  { Test rewarded video ad "unit id". You can use it with @link(TAds.InitializeAdMob) for testing purposes
+    (but eventually you want to create your own, to show non-testing ads!).
+
+    From https://developers.google.com/admob/android/test-ads }
+  TestAdMobRewardedUnitId = 'ca-app-pub-3940256099942544/5224354917';
 
 type
   TAdNetwork = (anAdMob, anChartboost, anStartApp, anHeyzap);

--- a/tools/build-tool/data/android/integrated-services/admob/README.md
+++ b/tools/build-tool/data/android/integrated-services/admob/README.md
@@ -34,4 +34,9 @@ Statuses used by the admob service:
 | wsInvalidRequest | ERROR_CODE_INVALID_REQUEST | Invalid Request - bad Unit ID for example. |
 | wsApplicationReinitialized | - | Java application was killed, but native code survived, while waiting for ad to finish. |
 
+## Debug
+
+If you have any problems with the admob service or want more logs, change the value of the `ServiceAdMob.debug` from `false` to `true`. 
+Service source file is located in: 
+`tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java`
 

--- a/tools/build-tool/data/android/integrated-services/admob/README.md
+++ b/tools/build-tool/data/android/integrated-services/admob/README.md
@@ -1,7 +1,7 @@
 # admob
 This service enables the AdMob banner, interstitial and rewarded advertisements. Use [TAds](http://castle-engine.sourceforge.net/apidoc/html/CastleAds.TAds.html) class from the [CastleAds](http://castle-engine.sourceforge.net/apidoc/html/CastleAds.html) unit to show and control the ads from your Pascal code, with `AdNetwork` set to `anAdMob`.
 
-## Requires:
+## Requires
 * Using this service requires using also <code>google_play_services</code>.
 
 ## App ID
@@ -17,5 +17,21 @@ To do this in CGE you need to declare it in `CastleEngineManifest.xml` like this
 
 ### Test App ID
 If you just want test admob service you can use test app id: `ca-app-pub-3940256099942544~3347511713`
+
+## Watched status
+
+Statuses used by the admob service:
+
+| TAdWatchStatus | AdMob errorCode equivalent | Description | 
+| --- | --- | --- |
+| wsWatched | - | The ad was displayed. |
+| wsUnknownError | ERROR_CODE_INTERNAL_ERROR | Ad mob internal error or unknown error code. |
+| wsNetworkNotAvailable | ERROR_CODE_NETWORK_ERROR | No internet connection. |
+| wsNoAdsAvailable | ERROR_CODE_NO_FILL | No ads available. |
+| wsUserAborted | - | Rewarded ad aborted by user. |
+| wsAdNotReady | - | The ad is still loading (when we don't want to wait). |
+| wsAdNetworkNotInitialized | - | Ad network not initialized or request for uninitialized ad type. |
+| wsInvalidRequest | ERROR_CODE_INVALID_REQUEST | Invalid Request - bad Unit ID for example. |
+| wsApplicationReinitialized | - | Java application was killed, but native code survived, while waiting for ad to finish. |
 
 

--- a/tools/build-tool/data/android/integrated-services/admob/README.md
+++ b/tools/build-tool/data/android/integrated-services/admob/README.md
@@ -1,0 +1,21 @@
+# admob
+This service enables the AdMob banner, interstitial and rewarded advertisements. Use [TAds](http://castle-engine.sourceforge.net/apidoc/html/CastleAds.TAds.html) class from the [CastleAds](http://castle-engine.sourceforge.net/apidoc/html/CastleAds.html) unit to show and control the ads from your Pascal code, with `AdNetwork` set to `anAdMob`.
+
+## Requires:
+* Using this service requires using also <code>google_play_services</code>.
+
+## App ID
+
+From Ads SDK version 17 you need use App ID to properly initialize ads.
+To do this in CGE you need to declare it in `CastleEngineManifest.xml` like this:
+
+~~~~xml
+<service name="admob">
+    <parameter key="app_id" value="..."/>
+</service>
+~~~~
+
+### Test App ID
+If you just want test admob service you can use test app id: `ca-app-pub-3940256099942544~3347511713`
+
+

--- a/tools/build-tool/data/android/integrated-services/admob/app/build.gradle
+++ b/tools/build-tool/data/android/integrated-services/admob/app/build.gradle
@@ -3,7 +3,7 @@
   <dependencies>
     <!-- See https://developers.google.com/android/guides/setup#split
       and https://developers.heyzap.com/docs/android_sdk_setup_and_requirements# -->
-    <dependency>compile 'com.google.android.gms:play-services-ads:9.4.0'</dependency>
-    <dependency>compile 'com.google.android.gms:play-services-location:9.4.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-ads:17.2.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-location:16.0.0'</dependency>
   </dependencies>
 </build_gradle_merge>

--- a/tools/build-tool/data/android/integrated-services/admob/app/src/main/AndroidManifest.xml
+++ b/tools/build-tool/data/android/integrated-services/admob/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
+        <meta-data android:name="com.google.android.gms.ads.APPLICATION_ID" android:value="${ANDROID.ADMOB.APP_ID}"/>
+
         <!-- For Google Ads (see https://developers.google.com/mobile-ads-sdk/docs/admob/android/quick-start) -->
         <!-- Include the AdActivity configChanges and theme. -->
         <activity android:name="com.google.android.gms.ads.AdActivity"

--- a/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
+++ b/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
@@ -20,7 +20,9 @@ import com.google.android.gms.ads.reward.RewardItem;
 public class ServiceAdMob extends ServiceAbstract
 {
     private static final String CATEGORY = "ServiceAdMob";
-    private static final int NO_ERROR = -1;
+    private final boolean debug = false; // set to true for debug (more logs)
+
+    private static final int NO_ERROR = -1; // no error constant
 
     private boolean initialized;
     private String mBannerUnitId, mInterstitialUnitId, mRewardedUnitId;
@@ -30,14 +32,14 @@ public class ServiceAdMob extends ServiceAbstract
     private InterstitialAd interstitial = null;
     private Boolean interstitialOpenWhenLoaded = false; // used when you want to wait for interstitial ad
     private Boolean failedToLoadInterstitialLastTime = false; // when loading failed last time, this is needed to try again on next call
-    private Boolean interstitialIsLoading = false; // used to when waitUntilLoaded = false to better error reporting (true when add is loading now)
+    private Boolean interstitialIsLoading = false; // used to when waitUntilLoaded = false to better error reporting (true when ad is loading now)
     private int interstitialLastErroCode = NO_ERROR; // store last ad loading error code (interstitial)
 
     private RewardedVideoAd rewarded = null;
     private Boolean rewardedWatched = false; // should we set rewarded video as watched
     private Boolean rewardedOpenWhenLoaded = false; // used when you want to wait for rewarded ad
     private Boolean failedToLoadRewardedLastTime = false; // when loading failed last time, this is needed to try again on next call
-    private Boolean rewardedIsLoading = false; // used to when waitUntilLoaded = false to better error reporting (true when add is loading now)
+    private Boolean rewardedIsLoading = false; // used to when waitUntilLoaded = false to better error reporting (true when ad is loading now)
     private int rewardedLastErroCode = NO_ERROR; // store last ad loading error code (rewarded)
 
     private String[] testDeviceIds;
@@ -74,7 +76,9 @@ public class ServiceAdMob extends ServiceAbstract
 
     private void fullScreenAdClosed(TAdWatchStatus watchedStatus)
     {
-        logInfo(CATEGORY, "fullScreenAdClosed - watchedStatus: " + watchedStatus.toString());
+        if (debug) {
+            logInfo(CATEGORY, "fullScreenAdClosed - watchedStatus: " + watchedStatus.toString());
+        }
         messageSend(new String[]{"ads-admob-full-screen-ad-closed", Integer.toString(watchedStatus.ordinal()) });
     }
 
@@ -110,19 +114,23 @@ public class ServiceAdMob extends ServiceAbstract
         interstitial.setAdListener(new AdListener() {
             @Override
             public void onAdLoaded() {
-                logInfo(CATEGORY, "onAdLoaded");
+                if (debug) {
+                    logInfo(CATEGORY, "onAdLoaded");
+                }
                 failedToLoadInterstitialLastTime = false;
                 interstitialIsLoading = false;
                 if (interstitialOpenWhenLoaded) {
                     interstitialOpenWhenLoaded = false;
-                    logInfo(CATEGORY, "Show ad after waiting for add.");
+                    logInfo(CATEGORY, "Show ad after waiting for ad.");
                     interstitial.show();
                 }
             }
 
             @Override
             public void onAdFailedToLoad(int errorCode)  {
-                logInfo(CATEGORY, "onAdFailedToLoad");
+                if (debug) {
+                    logInfo(CATEGORY, "onAdFailedToLoad");
+                }
                 failedToLoadInterstitialLastTime = true;
                 interstitialLastErroCode = errorCode;
                 interstitialIsLoading = false;
@@ -135,7 +143,9 @@ public class ServiceAdMob extends ServiceAbstract
 
             @Override
             public void onAdClosed() {
-                logInfo(CATEGORY, "Ad Closed");
+                if (debug) {
+                    logInfo(CATEGORY, "Ad Closed");
+                }
                 fullScreenAdClosed(TAdWatchStatus.wsWatched);
                 loadInterstitial(); // load next ad
             }
@@ -148,7 +158,9 @@ public class ServiceAdMob extends ServiceAbstract
     public void loadInterstitial() {
         failedToLoadInterstitialLastTime = false;
         if (!interstitial.isLoaded()) {
-            logInfo(CATEGORY, "start loading interstitial");
+            if (debug) {
+                logInfo(CATEGORY, "Started loading interstitial.");
+            }
             interstitialIsLoading = true;
             interstitialLastErroCode = NO_ERROR;
             interstitial.loadAd(buildAdRequest());
@@ -168,13 +180,17 @@ public class ServiceAdMob extends ServiceAbstract
         {
             @Override
             public void onRewarded(RewardItem reward) {
-                logInfo(CATEGORY, "onRewarded");
+                if (debug) {
+                    logInfo(CATEGORY, "onRewarded");
+                }   
                 rewardedWatched = true;
             }
             
             @Override
             public void onRewardedVideoAdClosed() {
-                logInfo(CATEGORY, "onRewardedVideoAdClosed");
+                if (debug) {
+                    logInfo(CATEGORY, "onRewardedVideoAdClosed");
+                }
                 loadRewarded();
                 if (rewardedWatched)
                     fullScreenAdClosed(TAdWatchStatus.wsWatched);
@@ -185,7 +201,9 @@ public class ServiceAdMob extends ServiceAbstract
 
             @Override
             public void onRewardedVideoAdFailedToLoad(int errorCode) {
-                logInfo(CATEGORY, "onRewardedVideoAdFailedToLoad");
+                if (debug) {
+                    logInfo(CATEGORY, "onRewardedVideoAdFailedToLoad");
+                }
                 failedToLoadRewardedLastTime = true;
                 rewardedIsLoading = false;
                 rewardedLastErroCode = errorCode;
@@ -198,33 +216,43 @@ public class ServiceAdMob extends ServiceAbstract
 
             @Override
             public void onRewardedVideoAdLoaded() {
-                logInfo(CATEGORY, "onRewardedVideoAdLoaded");
+                if (debug) {
+                    logInfo(CATEGORY, "onRewardedVideoAdLoaded");
+                }
                 rewardedIsLoading = false;
                 if (rewardedOpenWhenLoaded) {
                     rewardedOpenWhenLoaded = false;
-                    logInfo(CATEGORY, "Show ad after waiting for add.");
+                    logInfo(CATEGORY, "Show ad after waiting for ad.");
                     rewarded.show();
                 }
             }
 
             @Override
             public void onRewardedVideoAdLeftApplication() {
-                logInfo(CATEGORY, "onRewardedVideoAdLeftApplication");
+                if (debug) {
+                    logInfo(CATEGORY, "onRewardedVideoAdLeftApplication");
+                }
             }
 
             @Override
             public void onRewardedVideoAdOpened() {
-                logInfo(CATEGORY, "onRewardedVideoAdOpened");
+                if (debug) {
+                    logInfo(CATEGORY, "onRewardedVideoAdOpened");
+                }
             }
 
             @Override
             public void onRewardedVideoStarted() {
-                logInfo(CATEGORY, "onRewardedVideoStarted");
+                if (debug) {
+                    logInfo(CATEGORY, "onRewardedVideoStarted");
+                }
             }
 
             @Override
             public void onRewardedVideoCompleted() {
-                logInfo(CATEGORY, "onRewardedVideoCompleted");
+                if (debug) {
+                    logInfo(CATEGORY, "onRewardedVideoCompleted");
+                }
             }
         });
 
@@ -235,7 +263,9 @@ public class ServiceAdMob extends ServiceAbstract
     public void loadRewarded() {
         failedToLoadRewardedLastTime = false;
         if (!rewarded.isLoaded()) {
-            logInfo(CATEGORY, "start loading rewarded video");
+            if (debug) {
+                logInfo(CATEGORY, "Started loading rewarded video.");
+            }
             rewardedIsLoading = true;
             rewardedLastErroCode = NO_ERROR;
             rewarded.loadAd(mRewardedUnitId, buildAdRequest());
@@ -301,7 +331,7 @@ public class ServiceAdMob extends ServiceAbstract
         if (initialized && !mInterstitialUnitId.equals("")) {
             if (waitUntilLoaded || interstitial.isLoaded()) {
                 if (waitUntilLoaded && !interstitial.isLoaded()) {
-                    // calling show() when add is not loaded do nothing, so we show add when it will be aviable
+                    // calling show() when ad is not loaded do nothing, so we show ad when it will be available
                     logInfo(CATEGORY, "Requested showing interstitial ad with waitUntilLoaded, and ad not ready yet. Will wait until ad is ready.");
                     interstitialOpenWhenLoaded = true;
                     if (failedToLoadInterstitialLastTime) //loading ad failed last time so there was no load in onAdClose()
@@ -318,7 +348,7 @@ public class ServiceAdMob extends ServiceAbstract
                     fullScreenAdClosed(TAdWatchStatus.wsAdNotReady);
                 }
                 else {
-                    // add loading failed so return error and try load add again (for next request)
+                    // ad loading failed so return error and try load ad again (for next request)
                     fullScreenAdClosedWithError(interstitialLastErroCode);
                     loadInterstitial();
                 }
@@ -360,7 +390,7 @@ public class ServiceAdMob extends ServiceAbstract
                     fullScreenAdClosed(TAdWatchStatus.wsAdNotReady);
                 }
                 else {
-                    // add loading failed so return error and try load add again (for next request)
+                    // ad loading failed so return error and try load ad again (for next request)
                     fullScreenAdClosedWithError(rewardedLastErroCode);
                     loadRewarded();
                 }

--- a/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
+++ b/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
@@ -93,9 +93,10 @@ public class ServiceAdMob extends ServiceAbstract
             @Override
             public void onAdFailedToLoad(int errorCode)  {
                 logInfo(CATEGORY, "onAdFailedToLoad");
-                interstitialOpenWhenLoaded = false;
                 failedToLoadInterstitialLastTime = true;
-                fullScreenAdClosed(false);
+                if (interstitialOpenWhenLoaded)
+                    fullScreenAdClosed(false);
+                interstitialOpenWhenLoaded = false;
             }
 
             @Override
@@ -147,9 +148,10 @@ public class ServiceAdMob extends ServiceAbstract
             @Override
             public void onRewardedVideoAdFailedToLoad(int errorCode) {
                 logInfo(CATEGORY, "onRewardedVideoAdFailedToLoad");
-                rewardedOpenWhenLoaded = false;
                 failedToLoadRewardedLastTime = true;
-                fullScreenAdClosed(false);
+                if (rewardedOpenWhenLoaded)
+                    fullScreenAdClosed(false);
+                rewardedOpenWhenLoaded = false;
             }
 
             @Override

--- a/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
+++ b/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
@@ -63,6 +63,10 @@ public class ServiceAdMob extends ServiceAbstract
         mInterstitialUnitId = interstitialUnitId;
         mRewardedUnitId = rewardedUnitId;
         testDeviceIds = aTestDeviceIds;
+
+        // MobileAds initialize - should be done before loading of any ad:
+        MobileAds.initialize(getActivity(), "${ANDROID.ADMOB.APP_ID}");
+
         interstitialInitialize();
         rewardedInitialize();
         logInfo(CATEGORY, "AdMob initialized");
@@ -157,10 +161,9 @@ public class ServiceAdMob extends ServiceAbstract
         if (mRewardedUnitId.equals(""))
             return;
 
-        MobileAds.initialize(getActivity(),"${ANDROID.ADMOB.APP_ID}");
         rewarded = MobileAds.getRewardedVideoAdInstance(getActivity());
 
-        // Set an AdListener.
+        // Set a RewardedVideoAdListener.
         rewarded.setRewardedVideoAdListener(new RewardedVideoAdListener()
         {
             @Override

--- a/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
+++ b/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
@@ -125,7 +125,7 @@ public class ServiceAdMob extends ServiceAbstract
         if (mRewardedUnitId == "")
             return;
 
-        MobileAds.initialize(getActivity());
+        MobileAds.initialize(getActivity(),"${ANDROID.ADMOB.APP_ID}");
         rewarded = MobileAds.getRewardedVideoAdInstance(getActivity());
 
         // Set an AdListener.
@@ -177,6 +177,11 @@ public class ServiceAdMob extends ServiceAbstract
             @Override
             public void onRewardedVideoStarted() {
                 logInfo(CATEGORY, "onRewardedVideoStarted");
+            }
+
+            @Override
+            public void onRewardedVideoCompleted() {
+                logInfo(CATEGORY, "onRewardedVideoCompleted");
             }
         });
 

--- a/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
+++ b/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
@@ -31,7 +31,7 @@ public class ServiceAdMob extends ServiceAbstract
     private Boolean failedToLoadInterstitialLastTime = false; // when loading failed last time, this is needed to try again on next call
 
     private RewardedVideoAd rewarded = null;
-	private Boolean rewardedWatched = false; // should we set rewarded video as watched
+    private Boolean rewardedWatched = false; // should we set rewarded video as watched
     private Boolean rewardedOpenWhenLoaded = false; // used when you want to wait for rewarded ad
     private Boolean failedToLoadRewardedLastTime = false; // when loading failed last time, this is needed to try again on next call
 
@@ -102,7 +102,7 @@ public class ServiceAdMob extends ServiceAbstract
             public void onAdClosed() {
                 logInfo(CATEGORY, "Ad Closed");
                 fullScreenAdClosed(true);
-				loadInterstitial(); // load next ad
+                loadInterstitial(); // load next ad
             }
         });
 
@@ -110,13 +110,13 @@ public class ServiceAdMob extends ServiceAbstract
         loadInterstitial();
     }
 
-	public void loadInterstitial() {
+    public void loadInterstitial() {
         failedToLoadInterstitialLastTime = false;
         if (!interstitial.isLoaded()) {
             logInfo(CATEGORY, "start loading interstitial");
-			interstitial.loadAd(buildAdRequest());
-		}
-	}
+            interstitial.loadAd(buildAdRequest());
+        }
+    }
 
 
     private void rewardedInitialize()
@@ -128,67 +128,67 @@ public class ServiceAdMob extends ServiceAbstract
         rewarded = MobileAds.getRewardedVideoAdInstance(getActivity());
 
         // Set an AdListener.
-		rewarded.setRewardedVideoAdListener(new RewardedVideoAdListener()
-		{
-			@Override
-			public void onRewarded(RewardItem reward) {
+        rewarded.setRewardedVideoAdListener(new RewardedVideoAdListener()
+        {
+            @Override
+            public void onRewarded(RewardItem reward) {
                 logInfo(CATEGORY, "onRewarded");
-				rewardedWatched = true;
-			}
-			
-			@Override
-			public void onRewardedVideoAdClosed() {
+                rewardedWatched = true;
+            }
+            
+            @Override
+            public void onRewardedVideoAdClosed() {
                 logInfo(CATEGORY, "onRewardedVideoAdClosed");
-				loadRewarded();
+                loadRewarded();
                 fullScreenAdClosed(rewardedWatched);
-				rewardedWatched = false;
-			}
+                rewardedWatched = false;
+            }
 
-			@Override
-			public void onRewardedVideoAdFailedToLoad(int errorCode) {
+            @Override
+            public void onRewardedVideoAdFailedToLoad(int errorCode) {
                 logInfo(CATEGORY, "onRewardedVideoAdFailedToLoad");
                 rewardedOpenWhenLoaded = false;
                 failedToLoadRewardedLastTime = true;
                 fullScreenAdClosed(false);
-			}
+            }
 
-			@Override
-			public void onRewardedVideoAdLoaded() {
+            @Override
+            public void onRewardedVideoAdLoaded() {
                 logInfo(CATEGORY, "onRewardedVideoAdLoaded");
                 if (rewardedOpenWhenLoaded) {
                     rewardedOpenWhenLoaded = false;
                     logInfo(CATEGORY, "Show ad after waiting for add.");
                     rewarded.show();
                 }
-			}
+            }
 
-			@Override
-			public void onRewardedVideoAdLeftApplication() {
+            @Override
+            public void onRewardedVideoAdLeftApplication() {
                 logInfo(CATEGORY, "onRewardedVideoAdLeftApplication");
-			}
+            }
 
-			@Override
-			public void onRewardedVideoAdOpened() {
+            @Override
+            public void onRewardedVideoAdOpened() {
                 logInfo(CATEGORY, "onRewardedVideoAdOpened");
-			}
+            }
 
-			@Override
-			public void onRewardedVideoStarted() {
-				logInfo(CATEGORY, "onRewardedVideoStarted");
-			}
-		});
+            @Override
+            public void onRewardedVideoStarted() {
+                logInfo(CATEGORY, "onRewardedVideoStarted");
+            }
+        });
 
         // Begin loading your rewarded ad.
         loadRewarded();
     }
 
-	public void loadRewarded() {
+    public void loadRewarded() {
         failedToLoadRewardedLastTime = false;
         if (!rewarded.isLoaded()) {
             logInfo(CATEGORY, "start loading rewarded video");
-			rewarded.loadAd(mRewardedUnitId, buildAdRequest());
-		}
-	}
+            rewarded.loadAd(mRewardedUnitId, buildAdRequest());
+        }
+    }
 
     private void bannerShow(int gravity)
     {
@@ -280,7 +280,7 @@ public class ServiceAdMob extends ServiceAbstract
      */
     private void rewardedDisplay(boolean waitUntilLoaded)
     {
-		rewardedWatched = false;
+        rewardedWatched = false;
         if (initialized && mRewardedUnitId != "") {
             if (waitUntilLoaded || rewarded.isLoaded()) {
                 if (waitUntilLoaded && !rewarded.isLoaded()) {

--- a/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
+++ b/tools/build-tool/data/android/integrated-services/admob/app/src/main/java/net/sourceforge/castleengine/ServiceAdMob.java
@@ -9,6 +9,10 @@ import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.InterstitialAd;
 import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.MobileAds;
+import com.google.android.gms.ads.reward.RewardedVideoAd;
+import com.google.android.gms.ads.reward.RewardedVideoAdListener;
+import com.google.android.gms.ads.reward.RewardItem;
 
 /**
  * Integration of Google Ads (AdMob) with Castle Game Engine.
@@ -18,9 +22,19 @@ public class ServiceAdMob extends ServiceAbstract
     private static final String CATEGORY = "ServiceAdMob";
 
     private boolean initialized;
-    private String mBannerUnitId, mInterstitialUnitId;
-    private ActivityPopup adPopup;
-    private InterstitialAd interstitial;
+    private String mBannerUnitId, mInterstitialUnitId, mRewardedUnitId;
+
+    private ActivityPopup adPopup = null;
+
+    private InterstitialAd interstitial = null;
+    private Boolean interstitialOpenWhenLoaded = false; // used when you want to wait for interstitial ad
+    private Boolean failedToLoadInterstitialLastTime = false; // when loading failed last time, this is needed to try again on next call
+
+    private RewardedVideoAd rewarded = null;
+	private Boolean rewardedWatched = false; // should we set rewarded video as watched
+    private Boolean rewardedOpenWhenLoaded = false; // used when you want to wait for rewarded ad
+    private Boolean failedToLoadRewardedLastTime = false; // when loading failed last time, this is needed to try again on next call
+
     private String[] testDeviceIds;
 
     public ServiceAdMob(MainActivity activity)
@@ -33,7 +47,7 @@ public class ServiceAdMob extends ServiceAbstract
         return "admob";
     }
 
-    private void initialize(String bannerUnitId, String interstitialUnitId, String[] aTestDeviceIds)
+    private void initialize(String bannerUnitId, String interstitialUnitId, String rewardedUnitId, String[] aTestDeviceIds)
     {
         if (initialized) {
             return;
@@ -42,8 +56,10 @@ public class ServiceAdMob extends ServiceAbstract
         initialized = true;
         mBannerUnitId = bannerUnitId;
         mInterstitialUnitId = interstitialUnitId;
+        mRewardedUnitId = rewardedUnitId;
         testDeviceIds = aTestDeviceIds;
         interstitialInitialize();
+        rewardedInitialize();
         logInfo(CATEGORY, "AdMob initialized");
     }
 
@@ -54,26 +70,125 @@ public class ServiceAdMob extends ServiceAbstract
 
     private void interstitialInitialize()
     {
+        if (mInterstitialUnitId == "") 
+            return;
+
         // Create the interstitial.
         interstitial = new InterstitialAd(getActivity());
         interstitial.setAdUnitId(mInterstitialUnitId);
         // Set an AdListener.
         interstitial.setAdListener(new AdListener() {
-            // unused now
-            // @Override
-            // public void onAdLoaded() {
-            // }
+            @Override
+            public void onAdLoaded() {
+                logInfo(CATEGORY, "onAdLoaded");
+                failedToLoadInterstitialLastTime = false;
+                if (interstitialOpenWhenLoaded) {
+                    interstitialOpenWhenLoaded = false;
+                    logInfo(CATEGORY, "Show ad after waiting for add.");
+                    interstitial.show();
+                }
+
+            }
+
+            @Override
+            public void onAdFailedToLoad(int errorCode)  {
+                logInfo(CATEGORY, "onAdFailedToLoad");
+                interstitialOpenWhenLoaded = false;
+                failedToLoadInterstitialLastTime = true;
+                fullScreenAdClosed(false);
+            }
 
             @Override
             public void onAdClosed() {
                 logInfo(CATEGORY, "Ad Closed");
                 fullScreenAdClosed(true);
+				loadInterstitial(); // load next ad
             }
         });
 
         // Begin loading your interstitial.
-        interstitial.loadAd(buildAdRequest());
+        loadInterstitial();
     }
+
+	public void loadInterstitial() {
+        failedToLoadInterstitialLastTime = false;
+        if (!interstitial.isLoaded()) {
+            logInfo(CATEGORY, "start loading interstitial");
+			interstitial.loadAd(buildAdRequest());
+		}
+	}
+
+
+    private void rewardedInitialize()
+    {
+        if (mRewardedUnitId == "")
+            return;
+
+        MobileAds.initialize(getActivity());
+        rewarded = MobileAds.getRewardedVideoAdInstance(getActivity());
+
+        // Set an AdListener.
+		rewarded.setRewardedVideoAdListener(new RewardedVideoAdListener()
+		{
+			@Override
+			public void onRewarded(RewardItem reward) {
+                logInfo(CATEGORY, "onRewarded");
+				rewardedWatched = true;
+			}
+			
+			@Override
+			public void onRewardedVideoAdClosed() {
+                logInfo(CATEGORY, "onRewardedVideoAdClosed");
+				loadRewarded();
+                fullScreenAdClosed(rewardedWatched);
+				rewardedWatched = false;
+			}
+
+			@Override
+			public void onRewardedVideoAdFailedToLoad(int errorCode) {
+                logInfo(CATEGORY, "onRewardedVideoAdFailedToLoad");
+                rewardedOpenWhenLoaded = false;
+                failedToLoadRewardedLastTime = true;
+                fullScreenAdClosed(false);
+			}
+
+			@Override
+			public void onRewardedVideoAdLoaded() {
+                logInfo(CATEGORY, "onRewardedVideoAdLoaded");
+                if (rewardedOpenWhenLoaded) {
+                    rewardedOpenWhenLoaded = false;
+                    logInfo(CATEGORY, "Show ad after waiting for add.");
+                    rewarded.show();
+                }
+			}
+
+			@Override
+			public void onRewardedVideoAdLeftApplication() {
+                logInfo(CATEGORY, "onRewardedVideoAdLeftApplication");
+			}
+
+			@Override
+			public void onRewardedVideoAdOpened() {
+                logInfo(CATEGORY, "onRewardedVideoAdOpened");
+			}
+
+			@Override
+			public void onRewardedVideoStarted() {
+				logInfo(CATEGORY, "onRewardedVideoStarted");
+			}
+		});
+
+        // Begin loading your rewarded ad.
+        loadRewarded();
+    }
+
+	public void loadRewarded() {
+        failedToLoadRewardedLastTime = false;
+        if (!rewarded.isLoaded()) {
+            logInfo(CATEGORY, "start loading rewarded video");
+			rewarded.loadAd(mRewardedUnitId, buildAdRequest());
+		}
+	}
 
     private void bannerShow(int gravity)
     {
@@ -123,20 +238,27 @@ public class ServiceAdMob extends ServiceAbstract
     /*
      * Invoke this when you are ready to display an interstitial.
      *
-     * If waitUntilLoaded == true, we will wait until the ad is loaded.
+     * If waitUntilLoaded == true, we will set interstitialOpenWhenLoaded to true 
+     * to show ad when it will be ready
      *
      * If waitUntilLoaded == false, we will ignore the request is the ad
      * is not ready yet (e.g. because Internet connection is slow/broken now).
      */
     private void interstitialDisplay(boolean waitUntilLoaded)
     {
-        if (initialized) {
+        if (initialized && mInterstitialUnitId != "") {
             if (waitUntilLoaded || interstitial.isLoaded()) {
                 if (waitUntilLoaded && !interstitial.isLoaded()) {
+                    // calling show() when add is not loaded do nothing, so we show add when it will be aviable
                     logInfo(CATEGORY, "Requested showing interstitial ad with waitUntilLoaded, and ad not ready yet. Will wait until ad is ready.");
+                    interstitialOpenWhenLoaded = true;
+                    if (failedToLoadInterstitialLastTime) //loading ad failed last time so there was no load in onAdClose()
+                        loadInterstitial();
+                    return;
                 }
-                interstitial.show();
-                interstitialInitialize(); // load next interstitial ad
+                else if (interstitial.isLoaded()) {
+                    interstitial.show();
+                }
             } else {
                 // pretend that ad was displayed, in case native app waits for it
                 fullScreenAdClosed(false);
@@ -147,11 +269,46 @@ public class ServiceAdMob extends ServiceAbstract
         }
     }
 
+    /*
+     * Invoke this when you are ready to display an rewarded ad.
+     *
+     * If waitUntilLoaded == true, we will set rewardedOpenWhenLoaded to true 
+     * to show ad when it will be ready
+     *
+     * If waitUntilLoaded == false, we will ignore the request is the ad
+     * is not ready yet (e.g. because Internet connection is slow/broken now).
+     */
+    private void rewardedDisplay(boolean waitUntilLoaded)
+    {
+		rewardedWatched = false;
+        if (initialized && mRewardedUnitId != "") {
+            if (waitUntilLoaded || rewarded.isLoaded()) {
+                if (waitUntilLoaded && !rewarded.isLoaded()) {
+                    logInfo(CATEGORY, "Requested showing reward ad with waitUntilLoaded, and ad not ready yet. Will wait until ad is ready.");
+                    rewardedOpenWhenLoaded = true;
+                    if (failedToLoadRewardedLastTime) //loading ad failed last time so there was no load in onRewardedAdClose()
+                        loadRewarded();
+                    return;
+                }
+                else if (rewarded.isLoaded()) {
+                    rewarded.show();
+                }
+            } else {
+                // pretend that ad was displayed, in case native app waits for it
+                fullScreenAdClosed(false);
+            }
+        } else {
+            // pretend that ad was displayed, in case native app waits for it
+            fullScreenAdClosed(false);
+        }
+    }
+
+
     @Override
     public boolean messageReceived(String[] parts)
     {
-        if (parts.length == 4 && parts[0].equals("ads-admob-initialize")) {
-            initialize(parts[1], parts[2], parts[3].split(","));
+        if (parts.length == 5 && parts[0].equals("ads-admob-initialize")) {
+            initialize(parts[1], parts[2], parts[3], parts[4].split(","));
             return true;
         } else
         if (parts.length == 2 && parts[0].equals("ads-admob-banner-show")) {
@@ -169,6 +326,14 @@ public class ServiceAdMob extends ServiceAbstract
         } else
         if (parts.length == 2 && parts[0].equals("ads-admob-show-interstitial") && parts[1].equals("no-wait")) {
             interstitialDisplay(false);
+            return true;
+        } else 
+        if (parts.length == 2 && parts[0].equals("ads-admob-show-reward") && parts[1].equals("wait-until-loaded")) {
+            rewardedDisplay(true);
+            return true;
+        } else
+        if (parts.length == 2 && parts[0].equals("ads-admob-show-reward") && parts[1].equals("no-wait")) {
+            rewardedDisplay(false);
             return true;
         } else {
             return false;

--- a/tools/build-tool/data/android/integrated-services/google_play_games/app/build.gradle
+++ b/tools/build-tool/data/android/integrated-services/google_play_games/app/build.gradle
@@ -2,8 +2,8 @@
 <build_gradle_merge>
   <dependencies>
     <!-- See https://developers.google.com/android/guides/setup#split -->
-    <dependency>compile 'com.google.android.gms:play-services-games:9.4.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-games:17.0.0'</dependency>
     <!-- for savegames, the drive API is also needed -->
-    <dependency>compile 'com.google.android.gms:play-services-drive:9.4.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-drive:16.1.0'</dependency>
   </dependencies>
 </build_gradle_merge>

--- a/tools/build-tool/data/android/integrated-services/google_play_services/app/build.gradle
+++ b/tools/build-tool/data/android/integrated-services/google_play_services/app/build.gradle
@@ -2,6 +2,6 @@
 <build_gradle_merge>
   <dependencies>
     <!-- See https://developers.google.com/android/guides/setup#split -->
-    <dependency>compile 'com.google.android.gms:play-services-base:9.4.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-base:16.1.0'</dependency>
   </dependencies>
 </build_gradle_merge>

--- a/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/TAdWatchStatus.java
+++ b/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/TAdWatchStatus.java
@@ -1,0 +1,15 @@
+/* -*- tab-width: 4 -*- */
+package net.sourceforge.castleengine;
+
+
+/* Must be synchronized with pascal TAdWatchStatus in src/services/CastleAds.pas */
+public enum TAdWatchStatus {
+    wsWatched,
+    wsUnknownError,
+    wsNetworkNotAvailable,
+    wsNoAdsAvailable,
+    wsUserAborted,
+    wsAdNotReady,
+    wsAdNetworkNotInitialized,
+    wsInvalidRequest
+}

--- a/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/TAdWatchStatus.java
+++ b/tools/build-tool/data/android/integrated/app/src/main/java/net/sourceforge/castleengine/TAdWatchStatus.java
@@ -11,5 +11,7 @@ public enum TAdWatchStatus {
     wsUserAborted,
     wsAdNotReady,
     wsAdNetworkNotInitialized,
-    wsInvalidRequest
+    wsInvalidRequest,
+    wsAdTypeUnsupported,
+    wsApplicationReinitialized
 }


### PR DESCRIPTION
This PR adds rewarded ads to Admob service and fixes some problems I noticed in interstitial.

### Rewarded:
At this stage I added `ARewardedUnitId` to `InitializeAdMob()`. When you call `ShowFullScreenAd()` with `atReward` type reward video will be showed. `OnFullScreenAdClosed` has `Watched` set to `true` only when user should get reward. 

Currently there is no way to check why `Watched` is set to `false`. There is a lot of reasons like no advertising(ERROR_CODE_NO_FILL), no internet connection(ERROR_CODE_NETWORK_ERROR), internal admob error (ERROR_CODE_INTERNAL_ERROR), bad unit ID (ERROR_CODE_INVALID_REQUEST) or the ad is not loaded and we don't want to wait. I think we should add third attribute to `OnFullScreenAdClosed` but this will break compatibility.

### Interstitial changes
I had a strange problem: sometimes ads closes automatically just after showed. I found that approach to recreate interstitial just after show makes this problem. So I rewrote it to start load new ad just after  close. I added `failedToLoadInterstitialLastTime` (maybe the name is too long) to check if load failed last time to try on next ad show request. This works for me (for example you can disable internet connection try show add and next restore connection and ads will work corectly).

### Waiting for ad
I checked that calling `show()` when ad is not ready do nothing, so I added possibility to open it just after is loaded (`interstitialOpenWhenLoaded` and `rewardedOpenWhenLoaded`).
