### PR TITLE
Physics: Fix first castle transform position update.

### DIFF
--- a/examples/physics/physics_2d_collisions/gameinitialize.pas
+++ b/examples/physics/physics_2d_collisions/gameinitialize.pas
@@ -205,7 +205,7 @@ begin
     'FPS: %s' + NL +
     'Scene Manager Objects: %d' + NL +
     'Linear velocity: %f' + NL +
-    'Use AWSD to change plane velocity, space to pause, R to restart plane ' + NL +
+    'Use AWSD to change plane velocity, space to pause, R to restart plane.' + NL +
     NL+
     'Current Plane Colisions (from TRigidBody.GetCollidingTransforms):' + NL +
     '  %s' + NL +

--- a/examples/physics/physics_2d_collisions/gameinitialize.pas
+++ b/examples/physics/physics_2d_collisions/gameinitialize.pas
@@ -20,7 +20,7 @@ interface
 
 implementation
 
-uses SysUtils, Classes, Generics.Collections,
+uses SysUtils, Classes, Generics.Collections, Math,
   CastleWindow, CastleLog, CastleScene, CastleControls, X3DNodes, CastleTransform,
   CastleFilesUtils, CastleSceneCore, CastleKeysMouse, CastleColors,
   CastleCameras, CastleVectors, CastleRenderer, CastleBoxes, Castle2DSceneManager,
@@ -73,7 +73,7 @@ var
 begin
   inherited Create(AOwner);
   Load('castle-data:/plane.x3d');
-  Translation := Vector3(50, 50, 0); // initial position
+  Translation := Vector3(550, 450, 0); // initial position
 
   RBody := TRigidBody.Create(Self);
   RBody.Dynamic := true;
@@ -130,6 +130,13 @@ end;
 
 { ---------------------------------------------------------------------------- }
 
+procedure LoadPlane;
+begin
+  Plane := TPlane.Create(Application);
+  SceneManager.Items.Add(Plane);
+  Plane.Scale := Vector3(5, 5, 0);
+end;
+
 { One-time initialization of resources. }
 procedure ApplicationInitialize;
 
@@ -147,14 +154,6 @@ procedure ApplicationInitialize;
     BottomWall := TWall.Create(Application, 'BottomWall', Vector3(1024/2, 10, 0), Vector3(1000, 20, 4), Vector3(0.5, 0.5, 1.0));
     SceneManager.Items.Add(BottomWall);
   end;
-
-  procedure LoadPlane;
-  begin
-    Plane := TPlane.Create(Application);
-    SceneManager.Items.Add(Plane);
-    Plane.Scale := Vector3(5, 5, 0);
-  end;
-
 begin
   { make UI automatically scaled }
   Window.Container.UIReferenceWidth := 1024;
@@ -206,7 +205,7 @@ begin
     'FPS: %s' + NL +
     'Scene Manager Objects: %d' + NL +
     'Linear velocity: %f' + NL +
-    'Use AWSD to change plane velocity.' + NL +
+    'Use AWSD to change plane velocity, space to pause, R to restart plane ' + NL +
     NL+
     'Current Plane Colisions (from TRigidBody.GetCollidingTransforms):' + NL +
     '  %s' + NL +
@@ -219,6 +218,8 @@ begin
      CollisionsListTXT,
      Plane.LastCollisionEnter
    ]);
+  if IsZero(SceneManager.TimeScale) then
+    Status.Caption := Status.Caption + NL + 'Paused';
 end;
 
 procedure WindowPress(Container: TUIContainer; const Event: TInputPressRelease);
@@ -237,6 +238,18 @@ begin
     Move(0, -1);
   if Event.IsKey(keyW) then
     Move(0,  1);
+  if Event.IsKey(keyR) then
+  begin
+    FreeAndNil(Plane);
+    LoadPlane;
+  end;
+  if Event.IsKey(keySpace) then
+  begin
+    if IsZero(SceneManager.TimeScale) then
+      SceneManager.TimeScale := 1
+    else
+      SceneManager.TimeScale := 0;
+  end;
 end;
 
 initialization

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -423,6 +423,12 @@ end;
 
 destructor TRigidBody.Destroy;
 begin
+  { In some cases TRigidBody can be destroyed before TCastleTransform that is assigned
+    then we need set the TCastleTransform.FRigidBody to nil to avoid dangling pointer.
+    See physics physics_3d_demo. }
+  if FTransform <> nil then
+    FTransform.FRigidBody := nil;
+
   { The FKraftBody will be freed now if you free TRigidBody
     instance explicitly. In most other cases, DeinitializeTransform
     already freed FKraftBody and set it nil. }

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -513,6 +513,13 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
 
     // set initial transformation
     FKraftBody.SetWorldTransformation(MatrixToKraft(Transform.WorldTransform));
+
+    { Synchronize kraft rigid body and shapes (colliders) transform to make collider
+      position correct, without this first (before physics step) TransformationFromKraft
+      breaks Castle transform position and make strange jump. This can be easily observed when TimeScale = 0.0
+      Because we use shape InterpolatedWorldTransform we need to store it for correct result. }
+    FKraftBody.SynchronizeTransformIncludingShapes;
+    Collider.FKraftShape.StoreWorldTransform;
   end;
 
 begin

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -425,7 +425,7 @@ destructor TRigidBody.Destroy;
 begin
   { In some cases TRigidBody can be destroyed before TCastleTransform that is assigned
     then we need set the TCastleTransform.FRigidBody to nil to avoid dangling pointer.
-    See physics physics_3d_demo. }
+    See physics_3d_demo. }
   if FTransform <> nil then
     FTransform.FRigidBody := nil;
 


### PR DESCRIPTION
Little fix for first Castle Transform position update by `TransformationFromKraft`. After `TRigidBody.InitializeTransform` Kraft shape transform was not set properly. That makes strange effects before first physics step. See code comment for more info. Tested in my game ;)