### PR TITLE
Remove sound buffers when change repository URL.

### DIFF
--- a/src/audio/castlesoundengine.pas
+++ b/src/audio/castlesoundengine.pas
@@ -2787,9 +2787,31 @@ var
   I: TXMLElementIterator;
   BaseUrl: string;
   TimeStart: TCastleProfilerTime;
+  J: Integer;
+  SoundInfo: TSoundInfo;
+  SoundInfoBuffer: TSoundInfoBuffer;
 begin
   if FRepositoryURL = Value then Exit;
   FRepositoryURL := Value;
+
+  { Remove sound buffers }
+  for J := 0 to FSounds.Count - 1 do
+  begin
+    SoundInfo := FSounds[J];
+    if SoundInfo is TSoundInfoBuffer then
+      SoundInfoBuffer := TSoundInfoBuffer(SoundInfo)
+    else
+      continue;
+
+    if SoundInfoBuffer.Buffer <> nil then
+    begin
+      { ommit stNone }
+      if SoundInfo.Name = '' then
+        continue;
+
+      FreeBuffer(SoundInfoBuffer.Buffer);
+    end;
+  end;
 
   FSoundGroups.Clear;
   FSounds.Clear;


### PR DESCRIPTION
Loading all music on Android is quite slow. In addition, every time you show ad or send the app to the background, it reloads.
To work around the problem I used several XML files, such as `menu.xml`, `level1.xml`, `level2.xml`.
But currently changing the repository file does not delete sound buffers, so reopening OpenAL context reloads sound buffers from previous XML files and from the new one. This PR changes this the sound buffers are freed before the new XML file is loaded.