### PR TITLE
New collision detection algorithm which cares about duplicate events - WIP

### DIFF
--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -1767,8 +1767,6 @@ type
     FEnablePhysics: boolean;
     { Create FKraftEngine, if not assigned yet. }
     procedure InitializePhysicsEngine;
-    procedure CollisionBegin(const ContactPair: PKraftContactPair);
-    procedure CollisionEnd(const ContactPair: PKraftContactPair);
   public
     OnCursorChange: TNotifyEvent;
     OnVisibleChange: TVisibleChangeEvent;

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -210,7 +210,7 @@
       (you can free it later, e.g. during @link(TCastleTransform.OnUpdate)). }
     property OnCollisionExit: TOnCollision read FOnCollisionExit write SetOnCollisionExit;
 
-    { Occurs when TRigidBody still colliding with another TRigidBody.
+    { Occurs when TRigidBody still collides with another TRigidBody.
 
       @italic(Warning:) Do not free the @link(TCastleTransform) instances
       that collide during this event.

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -109,6 +109,19 @@
     including the Collider and all properties of Collider,
     must be assigned before setting TCastleTransform.RigidBody . }
   TRigidBody = class(TComponent)
+  strict private
+    { List of collisions from previous step. }
+    FPrevCollisions: TList;
+    { List of collisions from current step. }
+    FCurrentCollisions: TList;
+
+    FOnCollisionEnter: TOnCollision;
+    FOnCollisionStay: TOnCollision;
+    FOnCollisionExit: TOnCollision;
+
+    procedure PhysicsPostStep(const RigidBody: TKraftRigidBody; const TimeStep: TKraftTimeStep);
+    { Assign or unassign PhysicsPostStep in TKraftBody.OnPostStep when needed. }
+    procedure CheckPhysicsPostStepNeeded;
   private
     FKraftBody: TKraftRigidBody;
     FCollider: TCollider;
@@ -126,8 +139,6 @@
     FMaximalLinearVelocity: Single;
     FTransform: TCastleTransform;
     FCollisionList: TCastleTransformList;
-    FOnCollisionEnter: TOnCollision;
-    FOnCollisionExit: TOnCollision;
 
     procedure UpdateCollides(const Transform: TCastleTransform);
 
@@ -141,6 +152,10 @@
     procedure SetLinearVelocity(const LVelocity: TVector3);
     procedure SetLinearVelocityDamp(const AValue: Single);
     procedure SetMaximalLinearVelocity(const AValue: Single);
+
+    procedure SetOnCollisionEnter(const AValue: TOnCollision);
+    procedure SetOnCollisionStay(const AValue: TOnCollision);
+    procedure SetOnCollisionExit(const AValue: TOnCollision);
 
     procedure SetExists(const Value: Boolean);
   public
@@ -193,7 +208,17 @@
       It would free the rigid body instance, which will crash the physics engine for now.
       Instead, you can set @link(TCastleTransform.Exists) to @false
       (you can free it later, e.g. during @link(TCastleTransform.OnUpdate)). }
-    property OnCollisionExit: TOnCollision read FOnCollisionExit write FOnCollisionExit;
+    property OnCollisionExit: TOnCollision read FOnCollisionExit write SetOnCollisionExit;
+
+    { Occurs when TRigidBody still colliding with another TRigidBody.
+
+      @italic(Warning:) Do not free the @link(TCastleTransform) instances
+      that collide during this event.
+      It would free the rigid body instance, which will crash the physics engine for now.
+      Instead, you can set @link(TCastleTransform.Exists) to @false
+      (you can free it later, e.g. during @link(TCastleTransform.OnUpdate)). }
+    property OnCollisionStay: TOnCollision read FOnCollisionStay write SetOnCollisionStay;
+
   published
     { Does the physics simulation move and rotate this object
       (because of gravity, or because it collides with others).
@@ -416,6 +441,9 @@ begin
 
   FKraftBody := nil;
   FCollisionList := TCastleTransformList.Create(false, nil);
+  FPrevCollisions := TList.Create;
+  FCurrentCollisions := TList.Create;
+
   FOnCollisionEnter := nil;
   FOnCollisionExit := nil;
   FTransform := nil;
@@ -444,6 +472,8 @@ begin
   FreeAndNil(FKraftBody);
   FreeAndNil(FCollider);
   FreeAndNil(FCollisionList);
+  FreeAndNil(FPrevCollisions);
+  FreeAndNil(FCurrentCollisions);
   inherited;
 end;
 
@@ -542,6 +572,8 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
       it for correct result. }
     FKraftBody.SynchronizeTransformIncludingShapes;
     Collider.FKraftShape.StoreWorldTransform;
+
+    CheckPhysicsPostStepNeeded;
   end;
 
 begin
@@ -568,6 +600,80 @@ begin
     Collider.FKraftShape := nil;
 
   FTransform := nil;
+end;
+
+procedure TRigidBody.PhysicsPostStep(const RigidBody: TKraftRigidBody; const TimeStep: TKraftTimeStep);
+var
+  ContactPairEdge: PKraftContactPairEdge;
+  RBody: TRigidBody;
+  CollisionDetails: TPhysicsCollisionDetails;
+  I: Integer;
+begin
+  FCurrentCollisions.Clear;
+  ContactPairEdge := FKraftBody.ContactPairEdgeFirst;
+  while Assigned(ContactPairEdge) do
+  begin
+    RBody := TRigidBody(ContactPairEdge^.OtherRigidBody.UserData);
+
+    // Omit next collision point with the same body.
+    if FCurrentCollisions.IndexOf(RBody) <> - 1 then
+      continue;
+
+    // Add to current collisons.
+    FCurrentCollisions.Add(RBody);
+
+    // Prepare collision data.
+    CollisionDetails.OtherTransform := RBody.FTransform;
+    CollisionDetails.Transforms[0] := FTransform;
+    CollisionDetails.Transforms[1] := CollisionDetails.OtherTransform;
+
+    // New and ongoing collisons.
+    if FPrevCollisions.IndexOf(RBody) = -1 then
+    begin
+      // New collision.
+      if Assigned(FOnCollisionEnter) then
+        FOnCollisionEnter(CollisionDetails);
+    end else
+    begin
+      // Still in collision.
+      if Assigned(FOnCollisionStay) then
+        FOnCollisionStay(CollisionDetails);
+
+      // Remove used collison.
+      FPrevCollisions.Remove(RBody);
+    end;
+
+    ContactPairEdge := ContactPairEdge^.Next;
+  end;
+
+  // check collision exit
+  if Assigned(FOnCollisionExit) then
+  begin
+    CollisionDetails.Transforms[0] := FTransform;
+
+    for I := 0  to FPrevCollisions.Count - 1 do
+    begin
+      CollisionDetails.OtherTransform := TRigidBody(FPrevCollisions[I]).FTransform;
+      CollisionDetails.Transforms[1] := CollisionDetails.OtherTransform;
+
+      FOnCollisionExit(CollisionDetails);
+    end;
+  end;
+
+  // Make previous list from current list.
+  FPrevCollisions.Clear;
+  FPrevCollisions.Assign(FCurrentCollisions);
+end;
+
+procedure TRigidBody.CheckPhysicsPostStepNeeded;
+begin
+  if not Assigned(FKraftBody) then
+    Exit;
+
+  if Assigned(FOnCollisionEnter) or Assigned(FOnCollisionStay) or Assigned(FOnCollisionExit) then
+    FKraftBody.OnPostStep := @PhysicsPostStep
+  else
+    FKraftBody.OnPostStep := nil;
 end;
 
 procedure TRigidBody.UpdateCollides(const Transform: TCastleTransform);
@@ -602,6 +708,24 @@ begin
   { Kraft uses max velocity for delta time which is physics update frequency. }
   if FKraftBody <> nil then
     FKraftBody.MaximalLinearVelocity := AValue / FTransform.World.FKraftEngine.WorldFrequency;
+end;
+
+procedure TRigidBody.SetOnCollisionEnter(const AValue: TOnCollision);
+begin
+  FOnCollisionEnter := AValue;
+  CheckPhysicsPostStepNeeded;
+end;
+
+procedure TRigidBody.SetOnCollisionStay(const AValue: TOnCollision);
+begin
+  FOnCollisionStay := AValue;
+  CheckPhysicsPostStepNeeded;
+end;
+
+procedure TRigidBody.SetOnCollisionExit(const AValue: TOnCollision);
+begin
+  FOnCollisionExit := AValue;
+  CheckPhysicsPostStepNeeded;
 end;
 
 procedure TRigidBody.SetAngularVelocityDamp(const AValue: Single);
@@ -824,95 +948,12 @@ begin
   if FKraftEngine = nil then
   begin
     FKraftEngine := TKraft.Create(-1);
-    FKraftEngine.ContactManager.OnContactBegin := @CollisionBegin;
-    FKraftEngine.ContactManager.OnContactEnd := @CollisionEnd;
     { Kraft sets MaximalLinearVelocity in TKraft Constructor to 2.
       With this limit can't make velocity greater than about 120
       (2 * engine step frequency = 2 * 60 = 120). That makes physics
       very slow, so we need remove this limitation. }
     FKraftEngine.MaximalLinearVelocity := 0;
     //FKraftEngine.SetFrequency(120.0); // default is 60
-  end;
-end;
-
-procedure TSceneManagerWorld.CollisionBegin(const ContactPair: PKraftContactPair);
-var
-  CollisionDetails: TPhysicsCollisionDetails;
-  RigidBody1: TRigidBody;
-  RigidBody2: TRigidBody;
-begin
-  {
-  // I'm not sure these checks are needed.
-  if Assigned(ContactPair^.RigidBodies[0]) and  Assigned(ContactPair^.RigidBodies[0].UserData) then
-    RigidBody1 := TRigidBody(ContactPair^.RigidBodies[0].UserData)
-  else
-    RigidBody1 := nil;
-
-  if Assigned(ContactPair^.RigidBodies[1]) and  Assigned(ContactPair^.RigidBodies[1].UserData) then
-    RigidBody2 := TRigidBody(ContactPair^.RigidBodies[1].UserData)
-  else
-    RigidBody2 := nil;
-
-  if (RigidBody1 = nil) and (RigidBody2 = nil) then
-    exit;}
-
-  Assert(ContactPair^.RigidBodies[0] <> nil);
-  Assert(ContactPair^.RigidBodies[0].UserData <> nil);
-  Assert(ContactPair^.RigidBodies[1] <> nil);
-  Assert(ContactPair^.RigidBodies[1].UserData <> nil);
-
-  RigidBody1 := TRigidBody(ContactPair^.RigidBodies[0].UserData);
-  RigidBody2 := TRigidBody(ContactPair^.RigidBodies[1].UserData);
-
-  if Assigned(RigidBody1.OnCollisionEnter) or Assigned(RigidBody2.OnCollisionEnter) then
-  begin
-    CollisionDetails.Transforms[0] := RigidBody1.FTransform;
-    CollisionDetails.Transforms[1] := RigidBody2.FTransform;
-
-    if Assigned(RigidBody1.OnCollisionEnter) then
-    begin
-      CollisionDetails.OtherTransform := RigidBody2.FTransform;
-      RigidBody1.OnCollisionEnter(CollisionDetails);
-    end;
-
-    if Assigned(RigidBody2.OnCollisionEnter) then
-    begin
-      CollisionDetails.OtherTransform := RigidBody1.FTransform;
-      RigidBody2.OnCollisionEnter(CollisionDetails);
-    end;
-  end;
-end;
-
-procedure TSceneManagerWorld.CollisionEnd(const ContactPair: PKraftContactPair);
-var
-  CollisionDetails: TPhysicsCollisionDetails;
-  RigidBody1: TRigidBody;
-  RigidBody2: TRigidBody;
-begin
-  Assert(ContactPair^.RigidBodies[0] <> nil);
-  Assert(ContactPair^.RigidBodies[0].UserData <> nil);
-  Assert(ContactPair^.RigidBodies[1] <> nil);
-  Assert(ContactPair^.RigidBodies[1].UserData <> nil);
-
-  RigidBody1 := TRigidBody(ContactPair^.RigidBodies[0].UserData);
-  RigidBody2 := TRigidBody(ContactPair^.RigidBodies[1].UserData);
-
-  if Assigned(RigidBody1.OnCollisionExit) or Assigned(RigidBody2.OnCollisionExit) then
-  begin
-    CollisionDetails.Transforms[0] := RigidBody1.FTransform;
-    CollisionDetails.Transforms[1] := RigidBody2.FTransform;
-
-    if Assigned(RigidBody1.OnCollisionExit) then
-    begin
-      CollisionDetails.OtherTransform := RigidBody2.FTransform;
-      RigidBody1.OnCollisionExit(CollisionDetails);
-    end;
-
-    if Assigned(RigidBody2.OnCollisionExit) then
-    begin
-      CollisionDetails.OtherTransform := RigidBody1.FTransform;
-      RigidBody2.OnCollisionExit(CollisionDetails);
-    end;
   end;
 end;
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -199,7 +199,7 @@
       It would free the rigid body instance, which will crash the physics engine for now.
       Instead, you can set @link(TCastleTransform.Exists) to @false
       (you can free it later, e.g. during @link(TCastleTransform.OnUpdate)). }
-    property OnCollisionEnter: TOnCollision read FOnCollisionEnter write FOnCollisionEnter;
+    property OnCollisionEnter: TOnCollision read FOnCollisionEnter write SetOnCollisionEnter;
 
     { Occurs when TRigidBody stops colliding with another TRigidBody.
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -613,11 +613,20 @@ begin
   ContactPairEdge := FKraftBody.ContactPairEdgeFirst;
   while Assigned(ContactPairEdge) do
   begin
+    if not (kcfColliding in ContactPairEdge^.ContactPair^.Flags) then
+    begin
+      ContactPairEdge := ContactPairEdge^.Next;
+      continue;
+    end;
+
     RBody := TRigidBody(ContactPairEdge^.OtherRigidBody.UserData);
 
     // Omit next collision point with the same body.
     if FCurrentCollisions.IndexOf(RBody) <> - 1 then
+    begin
+      ContactPairEdge := ContactPairEdge^.Next;
       continue;
+    end;
 
     // Add to current collisons.
     FCurrentCollisions.Add(RBody);
@@ -816,6 +825,12 @@ begin
   ContactPairEdge := FKraftBody.ContactPairEdgeFirst;
   while Assigned(ContactPairEdge) do
   begin
+    if not (kcfColliding in ContactPairEdge^.ContactPair^.Flags) then
+    begin
+      ContactPairEdge := ContactPairEdge^.Next;
+      continue;
+    end;
+
     CastleTransform := (TRigidBody(ContactPairEdge^.OtherRigidBody.UserData)).FTransform;
     if FCollisionList.IndexOf(CastleTransform) = -1 then
       FCollisionList.Add(CastleTransform);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -613,6 +613,11 @@ begin
   ContactPairEdge := FKraftBody.ContactPairEdgeFirst;
   while Assigned(ContactPairEdge) do
   begin
+    { Without this code, OnCollisonEnter reports fake collisons when
+      one of colliding body has non regural shape (for example when
+      TBoxCollider is rotated).
+      kcfColliding = From kraft source comment: "Set when contact
+      collides during a step" }
     if not (kcfColliding in ContactPairEdge^.ContactPair^.Flags) then
     begin
       ContactPairEdge := ContactPairEdge^.Next;
@@ -628,7 +633,7 @@ begin
       continue;
     end;
 
-    // Add to current collisons.
+    // Add to current collisions.
     FCurrentCollisions.Add(RBody);
 
     // Prepare collision data.
@@ -636,7 +641,7 @@ begin
     CollisionDetails.Transforms[0] := FTransform;
     CollisionDetails.Transforms[1] := CollisionDetails.OtherTransform;
 
-    // New and ongoing collisons.
+    // New and ongoing collisions.
     if FPrevCollisions.IndexOf(RBody) = -1 then
     begin
       // New collision.
@@ -648,7 +653,7 @@ begin
       if Assigned(FOnCollisionStay) then
         FOnCollisionStay(CollisionDetails);
 
-      // Remove used collison.
+      // Remove used collision.
       FPrevCollisions.Remove(RBody);
     end;
 


### PR DESCRIPTION
Old collision detection events code was based on `TKraft.OnContactBegin`/`TKraft.OnContactEnd`. But sometimes there was two `OnContactBegin` events and one `OnContactEnd` or vice versa. That makes this event very hard to use in real code (for example double damage problem). This new approach based on `TKraftRigidBody.OnPostStep` cares to make only one `OnCollisionEnter` and only one `OnCollisionExit`. 

Extra feature `OnCollisionStay` - new event that is fired each physics frame when collision still remain. 

In addition, the code is only called for bodies that have `OnCollisionXXXX` event assigned. That should be faster.