### PR TITLE
TExamineCamera: Check FModelBox.IsEmpty when recognize pan gesture.

### DIFF
--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -2848,7 +2848,7 @@ begin
     Zoom(Factor / ZoomScale);
   end;
 
-  if MoveEnabled and (Recognizer.Gesture = gtPan) then
+  if MoveEnabled and (not FModelBox.IsEmpty) and (Recognizer.Gesture = gtPan) then
   begin
     Size := FModelBox.AverageSize;
     FTranslation.Data[0] := FTranslation.Data[0] - (DragMoveSpeed * Size * (Recognizer.PanOldOffset.X - Recognizer.PanOffset.X) / (2*MoveDivConst));


### PR DESCRIPTION
When I make pan gesture (two fingers from up to down) exception `Empty box 3d: no middle point, no sizes etc.` is raised. I found this in game menu, but most simple example is just empty window:

```
  Window.Container.UIReferenceWidth := 1024;
  Window.Container.UIReferenceHeight := 768;
  Window.Container.UIScaling := usEncloseReferenceSize;

  SceneManager := TCastle2DSceneManager.Create(Application);
  SceneManager.FullSize := true;
  SceneManager.ProjectionHeight := 768;
  SceneManager.ProjectionAutoSize := false;
  SceneManager.BackgroundColor := Gray;
  Window.Controls.InsertFront(SceneManager);
```
Of course on Android device. This simple check fixes that.