### PR TITLE
Fix Android time issue #131.

### DIFF
--- a/src/base/castletimeutils.pas
+++ b/src/base/castletimeutils.pas
@@ -26,7 +26,7 @@ interface
 
 uses
   {$ifdef MSWINDOWS} Windows, {$endif}
-  {$ifdef UNIX} BaseUnix, Unix, Dl, {$endif}
+  {$ifdef UNIX} BaseUnix, Unix, Dl, {$endif} {$ifdef ANDROID}linux, {$endif}
   SysUtils, Math, Generics.Collections,
   CastleUtils;
 
@@ -591,28 +591,28 @@ const
 {$ifdef ANDROID}
 var
   { Note that using this makes Timer not thread-safe
-    (but we neved guaranteed in the interface that it's thread-safe...). }
+    (but we neved guaranteed in the interface that it's thread-safe...).
+    This variables can be removed once everyone confirms that the solution is
+    always working.
+    }
   LastTimer: TTimerResult;
   LastTimerLog: TTimerResult;
-{$endif}
 
 function Timer: TTimerResult;
 var
-  tv: TTimeval;
+  tp: TimeSpec;
 begin
-  FpGettimeofday(@tv, nil);
+  { Android have three clocks we need use clock which never leaps forward
+    or backward. This clock we can get by clock_gettime(CLOCK_MONOTONIC).
+    The FpGettimeofday() uses "wall" clock which can go back or forward when
+    synchronization comes more info:
+    https://stackoverflow.com/questions/3832097/how-to-get-the-current-time-in-native-android-code
+    https://developer.android.com/reference/android/os/SystemClock.html }
 
-  { We can fit whole TTimeval inside QWord, no problem. }
-  Result.Value := QWord(tv.tv_sec) * 1000000 + QWord(tv.tv_usec);
+  clock_gettime(CLOCK_MONOTONIC, @tp);
+  Result.Value := QWord(tp.tv_sec) * 1000000 + QWord(tp.tv_nsec div 1000);
 
-  {$ifdef ANDROID}
-  { We cannot trust some Android systems to return increasing values here
-    (Android devices we found this bug:
-     - "Moto X Play", "XT1562", OS version 5.1.1;
-     - "Xiaomi Redmi Note 4", MediaTek Helio X20, OS version 6.0, MIUI Global 10.2
-    ).
-    Maybe they synchronize the time from the Internet, and do not take care
-    to keep it monotonic (unlike https://lwn.net/Articles/23313/ says?) }
+  { I leave this test to check the solution, but it really isn't needed anymore }
   if Result.Value < LastTimer.Value then
   begin
     { Limit logs to not affect performance (one detection can make about
@@ -625,8 +625,20 @@ begin
     Result.Value := LastTimer.Value;
   end else
     LastTimer.Value := Result.Value;
-  {$endif ANDROID}
 end;
+
+{$else}
+
+function Timer: TTimerResult;
+var
+  tv: TTimeval;
+begin
+  FpGettimeofday(@tv, nil);
+
+  { We can fit whole TTimeval inside QWord, no problem. }
+  Result.Value := QWord(tv.tv_sec) * 1000000 + QWord(tv.tv_usec);
+end;
+{$endif}
 {$endif UNIX}
 
 function TimerSeconds(const A, B: TTimerResult): TFloatTime;

--- a/src/base/castletimeutils.pas
+++ b/src/base/castletimeutils.pas
@@ -26,7 +26,7 @@ interface
 
 uses
   {$ifdef MSWINDOWS} Windows, {$endif}
-  {$ifdef UNIX} BaseUnix, Unix, Dl, {$endif} {$ifdef ANDROID}linux, {$endif}
+  {$ifdef UNIX} BaseUnix, Unix, Dl, {$endif} {$ifdef ANDROID} Linux, {$endif}
   SysUtils, Math, Generics.Collections,
   CastleUtils;
 
@@ -592,9 +592,8 @@ const
 var
   { Note that using this makes Timer not thread-safe
     (but we neved guaranteed in the interface that it's thread-safe...).
-    This variables can be removed once everyone confirms that the solution is
-    always working.
-    }
+    This variables can be removed once everyone confirms that the
+    solution of using CLOCK_MONOTONIC is always working. }
   LastTimer: TTimerResult;
   LastTimerLog: TTimerResult;
 
@@ -602,7 +601,7 @@ function Timer: TTimerResult;
 var
   tp: TimeSpec;
 begin
-  { Android have three clocks we need use clock which never leaps forward
+  { Android has three clocks we need use clock which never leaps forward
     or backward. This clock we can get by clock_gettime(CLOCK_MONOTONIC).
     The FpGettimeofday() uses "wall" clock which can go back or forward when
     synchronization comes more info:
@@ -612,7 +611,8 @@ begin
   clock_gettime(CLOCK_MONOTONIC, @tp);
   Result.Value := QWord(tp.tv_sec) * 1000000 + QWord(tp.tv_nsec div 1000);
 
-  { I leave this test to check the solution, but it really isn't needed anymore }
+  { I leave this test to check the solution of using CLOCK_MONOTONIC, but it
+    really isn't needed anymore. }
   if Result.Value < LastTimer.Value then
   begin
     { Limit logs to not affect performance (one detection can make about

--- a/src/physics/kraft/kraft.pas
+++ b/src/physics/kraft/kraft.pas
@@ -162,6 +162,9 @@ uses {$ifdef windows}
        {$ifdef linux}
         linux,
        {$endif}
+      {$ifdef android}
+       linux,
+      {$endif}
       {$else}
        SDL,
       {$endif}
@@ -10406,10 +10409,14 @@ begin
 {$ifdef linux}
   fFrequency:=1000000000;
 {$else}
+{$ifdef android}
+  fFrequency:=1000000000;
+{$else}
 {$ifdef unix}
   fFrequency:=1000000;
 {$else}
   fFrequency:=1000;
+{$endif}
 {$endif}
 {$endif}
 {$endif}
@@ -10436,10 +10443,15 @@ function TKraftHighResolutionTimer.GetTime:int64;
 var NowTimeSpec:TimeSpec;
     ia,ib:int64;
 {$else}
+{$ifdef android}
+var NowTimeSpec:TimeSpec;
+    ia,ib:int64;
+{$else}
 {$ifdef unix}
 var tv:timeval;
     tz:timezone;
     ia,ib:int64;
+{$endif}
 {$endif}
 {$endif}
 begin
@@ -10454,6 +10466,12 @@ begin
  ib:=NowTimeSpec.tv_nsec;
  result:=ia+ib;
 {$else}
+{$ifdef android}
+clock_gettime(CLOCK_MONOTONIC,@NowTimeSpec);
+ia:=int64(NowTimeSpec.tv_sec)*int64(1000000000);
+ib:=NowTimeSpec.tv_nsec;
+result:=ia+ib;
+{$else}
 {$ifdef unix}
   tz.tz_minuteswest:=0;
   tz.tz_dsttime:=0;
@@ -10463,6 +10481,7 @@ begin
   result:=ia+ib;
 {$else}
  result:=SDL_GetTicks;
+{$endif}
 {$endif}
 {$endif}
 {$endif}


### PR DESCRIPTION
As I say in #131 Androdid have three clocks. I found that `clock_gettime(CLOCK_MONOTONIC)` uses clock that we need (https://stackoverflow.com/questions/3832097/how-to-get-the-current-time-in-native-android-code). 

Because Android is linux I use `clock_gettime(CLOCK_MONOTONIC, @tp);` from linux module. This works for me. I played 2 hours my game without any freezes :) Tomorrow will do more test. Please test this too on your projects/devices.

### Kraft
I also had to fix kraft. Do we use any special version? If I do PR in Kraft repo, will I be able to just use the latest version in CGE?