### PR TITLE
Build tool: Set minimal FPC version that support 64-bit Android to 3.2.0

### DIFF
--- a/tools/build-tool/code/toolandroid.pas
+++ b/tools/build-tool/code/toolandroid.pas
@@ -57,7 +57,7 @@ begin
   if DetectAndroidCPUSCached = [] then
   begin
     DetectAndroidCPUSCached := [Arm];
-    if FPCVersion.AtLeast(3, 3, 1) then
+    if FPCVersion.AtLeast(3, 2, 0) then
       Include(DetectAndroidCPUSCached, Aarch64)
     else
       WritelnWarning('FPC version ' + FPCVersion.ToString + ' does not support compiling for 64-bit Android (Aarch64). Resulting APK will only support 32-bit Android devices.');


### PR DESCRIPTION
FPC 3.2.0 supports AArch64 (https://forum.lazarus.freepascal.org/index.php?topic=42400.0). 