### PR TITLE
Android updates

### DIFF
--- a/tools/build-tool/code/toolproject.pas
+++ b/tools/build-tool/code/toolproject.pas
@@ -339,7 +339,7 @@ constructor TCastleProject.Create(const APath: string);
   const
     { Google Play requires version code to be >= 1 }
     DefautVersionCode = 1;
-    DefaultAndroidCompileSdkVersion = 27;
+    DefaultAndroidCompileSdkVersion = 28;
     DefaultAndroidTargetSdkVersion = DefaultAndroidCompileSdkVersion;
     { See https://github.com/castle-engine/castle-engine/wiki/Android-FAQ#what-android-devices-are-supported
       for reasons behind this minimal version. }

--- a/tools/build-tool/data/android/integrated-services/admob/app/build.gradle
+++ b/tools/build-tool/data/android/integrated-services/admob/app/build.gradle
@@ -3,7 +3,7 @@
   <dependencies>
     <!-- See https://developers.google.com/android/guides/setup#split
       and https://developers.heyzap.com/docs/android_sdk_setup_and_requirements# -->
-    <dependency>compile 'com.google.android.gms:play-services-ads:16.0.0'</dependency>
-    <dependency>compile 'com.google.android.gms:play-services-location:16.0.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-ads:18.1.1'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-location:17.0.0'</dependency>
   </dependencies>
 </build_gradle_merge>

--- a/tools/build-tool/data/android/integrated-services/google_play_games/app/build.gradle
+++ b/tools/build-tool/data/android/integrated-services/google_play_games/app/build.gradle
@@ -2,8 +2,8 @@
 <build_gradle_merge>
   <dependencies>
     <!-- See https://developers.google.com/android/guides/setup#split -->
-    <dependency>compile 'com.google.android.gms:play-services-games:16.0.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-games:18.0.0'</dependency>
     <!-- for savegames, the drive API is also needed -->
-    <dependency>compile 'com.google.android.gms:play-services-drive:16.0.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-drive:17.0.0'</dependency>
   </dependencies>
 </build_gradle_merge>

--- a/tools/build-tool/data/android/integrated-services/google_play_services/app/build.gradle
+++ b/tools/build-tool/data/android/integrated-services/google_play_services/app/build.gradle
@@ -2,6 +2,6 @@
 <build_gradle_merge>
   <dependencies>
     <!-- See https://developers.google.com/android/guides/setup#split -->
-    <dependency>compile 'com.google.android.gms:play-services-base:16.0.0'</dependency>
+    <dependency>compile 'com.google.android.gms:play-services-base:17.0.0'</dependency>
   </dependencies>
 </build_gradle_merge>


### PR DESCRIPTION
Upgrades:
- default API level increased 28 to comply with Google requirements
- Google Services, Google Play Services and Admob upgraded to versions from https://developers.google.com/android/guides/setup#split According to our conversation. Tested on android 4.1.1 and on newer devices. I tested only login and achievements on Google Play Services. 