### PR TITLE
Fixed Kraft crash when you add rigid body that collides with other and remove it in the same physics step

### DIFF
--- a/src/physics/kraft/kraft.pas
+++ b/src/physics/kraft/kraft.pas
@@ -24513,17 +24513,14 @@ begin
  fStaticMoveBuffer[Index]:=ProxyID;
 end;
 
-procedure TKraftBroadPhase.StaticBufferClearMove(ProxyID: longint);
-var
-  I:integer;
+procedure TKraftBroadPhase.StaticBufferClearMove(ProxyID:longint);
+var I:integer;
 begin
-  I := 0;
-  while I < fStaticMoveBufferSize do
-  begin
-    if fStaticMoveBuffer[I]=ProxyID then
-    begin
-      if I <> fStaticMoveBufferSize - 1 then
-        move(fStaticMoveBuffer[I+1], fStaticMoveBuffer[I], SizeOf(fStaticMoveBuffer[I]) * (fStaticMoveBufferSize - I));
+  I:=0;
+  while I<fStaticMoveBufferSize do begin
+    if fStaticMoveBuffer[I]=ProxyID then begin
+      if I<>fStaticMoveBufferSize-1 then
+        move(fStaticMoveBuffer[I+1],fStaticMoveBuffer[I],SizeOf(fStaticMoveBuffer[I])*(fStaticMoveBufferSize-I));
       Dec(fStaticMoveBufferSize);
       continue;
     end;
@@ -24542,17 +24539,14 @@ begin
  fDynamicMoveBuffer[Index]:=ProxyID;
 end;
 
-procedure TKraftBroadPhase.DynamicBufferClearMove(ProxyID: longint);
-var
-  I:integer;
+procedure TKraftBroadPhase.DynamicBufferClearMove(ProxyID:longint);
+var I:integer;
 begin
-  I := 0;
-  while I < fDynamicMoveBufferSize do
-  begin
-    if fDynamicMoveBuffer[I]=ProxyID then
-    begin
-      if I <> fDynamicMoveBufferSize - 1 then
-        move(fDynamicMoveBuffer[I+1], fDynamicMoveBuffer[I], SizeOf(fDynamicMoveBuffer[I]) * (fDynamicMoveBufferSize - I));
+  I:=0;
+  while I<fDynamicMoveBufferSize do begin
+    if fDynamicMoveBuffer[I]=ProxyID then begin
+      if I<>fDynamicMoveBufferSize-1 then
+        move(fDynamicMoveBuffer[I+1],fDynamicMoveBuffer[I],SizeOf(fDynamicMoveBuffer[I])*(fDynamicMoveBufferSize-I));
       Dec(fDynamicMoveBufferSize);
       continue;
     end;
@@ -24571,17 +24565,14 @@ begin
  fKinematicMoveBuffer[Index]:=ProxyID;
 end;
 
-procedure TKraftBroadPhase.KinematicBufferClearMove(ProxyID: longint);
-var
-  I:integer;
+procedure TKraftBroadPhase.KinematicBufferClearMove(ProxyID:longint);
+var I:integer;
 begin
-  I := 0;
-  while I < fKinematicMoveBufferSize do
-  begin
-    if fKinematicMoveBuffer[I]=ProxyID then
-    begin
-      if I <> fKinematicMoveBufferSize - 1 then
-        move(fKinematicMoveBuffer[I+1], fKinematicMoveBuffer[I], SizeOf(fKinematicMoveBuffer[I]) * (fKinematicMoveBufferSize - I));
+  I:=0;
+  while I<fKinematicMoveBufferSize do begin
+    if fKinematicMoveBuffer[I]=ProxyID then begin
+      if I<>fKinematicMoveBufferSize-1 then
+        move(fKinematicMoveBuffer[I+1],fKinematicMoveBuffer[I],SizeOf(fKinematicMoveBuffer[I])*(fKinematicMoveBufferSize-I));
       Dec(fKinematicMoveBufferSize);
       continue;
     end;

--- a/src/physics/kraft/kraft.pas
+++ b/src/physics/kraft/kraft.pas
@@ -1876,8 +1876,11 @@ type PKraftForceMode=^TKraftForceMode;
        procedure UpdatePairs; {$ifdef caninline}inline;{$endif}
 
        procedure StaticBufferMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
+       procedure StaticBufferClearMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
        procedure DynamicBufferMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
+       procedure DynamicBufferClearMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
        procedure KinematicBufferMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
+       procedure KinematicBufferClearMove(ProxyID:longint); {$ifdef caninline}inline;{$endif}
 
      end;
 
@@ -18960,6 +18963,8 @@ begin
  end;
 
  if fStaticAABBTreeProxy>=0 then begin
+  if fPhysics.NewShapes then
+   fPhysics.fBroadPhase.StaticBufferClearMove(fStaticAABBTreeProxy);
   fPhysics.fStaticAABBTree.DestroyProxy(fStaticAABBTreeProxy);
   fStaticAABBTreeProxy:=-1;
  end;
@@ -18970,11 +18975,15 @@ begin
  end;
 
  if fDynamicAABBTreeProxy>=0 then begin
+  if fPhysics.NewShapes then
+    fPhysics.fBroadPhase.DynamicBufferClearMove(fDynamicAABBTreeProxy);
   fPhysics.fDynamicAABBTree.DestroyProxy(fDynamicAABBTreeProxy);
   fDynamicAABBTreeProxy:=-1;
  end;
 
  if fKinematicAABBTreeProxy>=0 then begin
+   if fPhysics.NewShapes then
+    fPhysics.fBroadPhase.KinematicBufferClearMove(fKinematicAABBTreeProxy);
   fPhysics.fKinematicAABBTree.DestroyProxy(fKinematicAABBTreeProxy);
   fKinematicAABBTreeProxy:=-1;
  end;
@@ -24504,6 +24513,24 @@ begin
  fStaticMoveBuffer[Index]:=ProxyID;
 end;
 
+procedure TKraftBroadPhase.StaticBufferClearMove(ProxyID: longint);
+var
+  I:integer;
+begin
+  I := 0;
+  while I < fStaticMoveBufferSize do
+  begin
+    if fStaticMoveBuffer[I]=ProxyID then
+    begin
+      if I <> fStaticMoveBufferSize - 1 then
+        move(fStaticMoveBuffer[I+1], fStaticMoveBuffer[I], SizeOf(fStaticMoveBuffer[I]) * (fStaticMoveBufferSize - I));
+      Dec(fStaticMoveBufferSize);
+      continue;
+    end;
+    Inc(I);
+  end;
+end;
+
 procedure TKraftBroadPhase.DynamicBufferMove(ProxyID:longint);
 var Index:longint;
 begin
@@ -24515,6 +24542,24 @@ begin
  fDynamicMoveBuffer[Index]:=ProxyID;
 end;
 
+procedure TKraftBroadPhase.DynamicBufferClearMove(ProxyID: longint);
+var
+  I:integer;
+begin
+  I := 0;
+  while I < fDynamicMoveBufferSize do
+  begin
+    if fDynamicMoveBuffer[I]=ProxyID then
+    begin
+      if I <> fDynamicMoveBufferSize - 1 then
+        move(fDynamicMoveBuffer[I+1], fDynamicMoveBuffer[I], SizeOf(fDynamicMoveBuffer[I]) * (fDynamicMoveBufferSize - I));
+      Dec(fDynamicMoveBufferSize);
+      continue;
+    end;
+    Inc(I);
+  end;
+end;
+
 procedure TKraftBroadPhase.KinematicBufferMove(ProxyID:longint);
 var Index:longint;
 begin
@@ -24524,6 +24569,24 @@ begin
   SetLength(fKinematicMoveBuffer,fKinematicMoveBufferSize*2);
  end;
  fKinematicMoveBuffer[Index]:=ProxyID;
+end;
+
+procedure TKraftBroadPhase.KinematicBufferClearMove(ProxyID: longint);
+var
+  I:integer;
+begin
+  I := 0;
+  while I < fKinematicMoveBufferSize do
+  begin
+    if fKinematicMoveBuffer[I]=ProxyID then
+    begin
+      if I <> fKinematicMoveBufferSize - 1 then
+        move(fKinematicMoveBuffer[I+1], fKinematicMoveBuffer[I], SizeOf(fKinematicMoveBuffer[I]) * (fKinematicMoveBufferSize - I));
+      Dec(fKinematicMoveBufferSize);
+      continue;
+    end;
+    Inc(I);
+  end;
 end;
 
 constructor TKraftRigidBody.Create(const APhysics:TKraft);


### PR DESCRIPTION
This PR fixes kraft crash after add and delete rigid body in the same physics step. I have this problem in my game. When level starts I show "Get ready", start timer and set `SceneManager.TimeScale := 0;`. But user can go back to menu and select another level in this case Kraft rigid bodies are created and destroyed without making physics step. That make crash Kraft.

### What does Kraft do?
When you add `TKraftRigidBody` with new shape to Kraft physics (In `TKraftRigidBody.Finish`) it's calls `TKraftShape.SynchronizeProxies`. This procedure creates AABB box, adds it to proper AABBDynamicTree and to `fPhysics.fBroadPhase`. 
Destruction of the shape remove AABB box from AABB dynamic tree, but not remove it from `fPhysics.fBroadPhase`. When next physics step come physics engine try to make contact pair with this not existing rigid body and crashes.

### Example to reproduce crash:
Use `physics_2d_collisions` example with this modified `Game initialize`: 
```
{ Implements the game logic. }
unit GameInitialize;

interface

implementation

uses SysUtils, Classes, Generics.Collections, Math,
  CastleWindow, CastleLog, CastleScene, CastleControls, X3DNodes, CastleTransform,
  CastleFilesUtils, CastleSceneCore, CastleKeysMouse, CastleColors,
  CastleCameras, CastleVectors, CastleRenderer, CastleBoxes, Castle2DSceneManager,
  CastleUIControls, CastleTimeUtils, CastleUtils, CastleApplicationProperties;

type
  TWall = class;
  TPlane = class;

{ Global variables ----------------------------------------------------------- }

var
  Window: TCastleWindowBase;
  SceneManager: TCastle2DSceneManager;
  Status: TCastleLabel;
  Plane: TPlane;
  LeftWall: TWall;
  RightWall: TWall;
  TopWall: TWall;
  BottomWall: TWall;

  Plane2: TPlane;

type

  TWall = class(TCastleScene)
  public
    constructor Create(AOwner: TComponent; const WallName: TComponentName; const Pos, Size, Color: TVector3); reintroduce;
  end;

  TPlane = class(TCastleScene)
  public
    LastCollisionEnter: string;
    procedure CollisionEnter(const CollisionDetails: TPhysicsCollisionDetails);
    constructor Create(AOwner: TComponent); override;
  end;

{ TPlane }

procedure TPlane.CollisionEnter(const CollisionDetails: TPhysicsCollisionDetails);
begin
  if CollisionDetails.OtherTransform <> nil then
    LastCollisionEnter := CollisionDetails.OtherTransform.Name
  else
    LastCollisionEnter := 'other thing';
end;

constructor TPlane.Create(AOwner: TComponent);
var
  RBody: TRigidBody;
  Collider: TBoxCollider;
begin
  inherited Create(AOwner);
  Load('castle-data:/plane.x3d');
  Translation := Vector3(550, 450, 0); // initial position

  RBody := TRigidBody.Create(Self);
  RBody.Dynamic := true;
  RBody.Setup2D;
  //RBody.OnCollisionEnter := @CollisionEnter;
  RBody.LinearVelocityDamp := 0;
  RBody.MaximalLinearVelocity := 200;
  RBody.AngularVelocityDamp := 0;

  Collider := TBoxCollider.Create(RBody);
  Collider.Size := LocalBoundingBox.Size * 5;
  Collider.Restitution := 0.4;

  RigidBody := RBody;
end;

{ TWall }

constructor TWall.Create(AOwner: TComponent; const WallName: TComponentName; const Pos, Size, Color: TVector3);
var
  Box: TBoxNode;
  Shape: TShapeNode;
  Root: TX3DRootNode;
  RBody: TRigidBody;
  Collider: TBoxCollider;
begin
  inherited Create(AOwner);

  Translation := Pos; // initial position
  Name := WallName;

  Box := TBoxNode.CreateWithShape(Shape);
  Box.Size := Size;

  Shape.Appearance := TAppearanceNode.Create;
  Shape.Appearance.Material := TMaterialNode.Create;
  Shape.Appearance.Material.ForcePureEmissive;
  Shape.Appearance.Material.EmissiveColor := Color;

  Root := TX3DRootNode.Create;
  Root.AddChildren(Shape);

  Load(Root, true);

  RBody := TRigidBody.Create(Self);
  RBody.Dynamic := false;
  RBody.Setup2D;

  Collider := TBoxCollider.Create(RBody);
  Collider.Size := Size;

  RigidBody := RBody;
end;

{ ---------------------------------------------------------------------------- }

procedure LoadPlane;
begin
  Plane := TPlane.Create(Application);
  SceneManager.Items.Add(Plane);
  Plane.Scale := Vector3(5, 5, 0);
end;


procedure LoadPlane2;
begin
  if Plane2 <> nil then
     Exit;
  Plane2 := TPlane.Create(Application);
  SceneManager.Items.Add(Plane2);
  Plane2.Scale := Vector3(5, 5, 0);
end;

procedure DeletePlane2;
begin
  FreeAndNil(Plane2);
end;

{ One-time initialization of resources. }
procedure ApplicationInitialize;

  procedure LoadWalls;
  begin
    LeftWall := TWall.Create(Application, 'LeftWall', Vector3(10, 768/2, 0), Vector3(20, 700, 4), Vector3(0.5, 0.5, 1.0));
    SceneManager.Items.Add(LeftWall);

    RightWall := TWall.Create(Application, 'RightWall', Vector3(1014, 768/2, 0), Vector3(20, 700, 4), Vector3(0.5, 0.5, 1.0));
    SceneManager.Items.Add(RightWall);

    TopWall := TWall.Create(Application, 'TopWall', Vector3(1024/2, 758, 0), Vector3(1000, 20, 4), Vector3(0.5, 0.5, 1.0));
    SceneManager.Items.Add(TopWall);

    BottomWall := TWall.Create(Application, 'BottomWall', Vector3(1024/2, 10, 0), Vector3(1000, 20, 4), Vector3(0.5, 0.5, 1.0));
    SceneManager.Items.Add(BottomWall);
  end;
begin
  { make UI automatically scaled }
  Window.Container.UIReferenceWidth := 1024;
  Window.Container.UIReferenceHeight := 768;
  Window.Container.UIScaling := usEncloseReferenceSize;

  SceneManager := TCastle2DSceneManager.Create(Application);
  SceneManager.FullSize := true;
  SceneManager.ProjectionHeight := 768;
  SceneManager.ProjectionAutoSize := false;
  // easy way to make the simulation feel more dynamic
  SceneManager.TimeScale := 1.5;
  Window.Controls.InsertFront(SceneManager);

  LoadWalls;
  LoadPlane;
  SceneManager.NavigationType := ntNone;

  Status := TCastleLabel.Create(Application);
  Status.Anchor(hpLeft, 40);
  Status.Anchor(vpTop, -40);
  Status.Color := Yellow;
  Window.Controls.InsertFront(Status);
end;

procedure WindowUpdate(Container: TUIContainer);
var
  CollisionsList: TCastleTransformList;
  CollisionsListTXT: String;
  I: Integer;
begin
  CollisionsList := Plane.RigidBody.GetCollidingTransforms;
  CollisionsListTXT := '';

  for I := 0 to CollisionsList.Count - 1 do
  begin
    if CollisionsList[I] is TWall then
       CollisionsListTXT := CollisionsListTXT + ' ' + TWall(CollisionsList[I]).Name
    else
       CollisionsListTXT := CollisionsListTXT + ' other thing';
  end;

  if CollisionsList.Count = 0 then
  begin
    CollisionsListTXT := CollisionsListTXT + 'nothing';
  end;

  Status.Caption := Format(
    'FPS: %s' + NL +
    'Scene Manager Objects: %d' + NL +
    'Linear velocity: %f' + NL +
    'Use AWSD to change plane velocity, space to pause, R to restart plane.' + NL +
    NL+
    'Current Plane Colisions (from TRigidBody.GetCollidingTransforms):' + NL +
    '  %s' + NL +
    NL +
    'Last Plane Collision Enter (from TRigidBody.OnCollisionEnter):' + NL +
    '  %s', [
     Container.Fps.ToString,
     SceneManager.Items.Count,
     Plane.RigidBody.LinearVelocity.Length,
     CollisionsListTXT,
     Plane.LastCollisionEnter
   ]);
  if IsZero(SceneManager.TimeScale) then
    Status.Caption := Status.Caption + NL + 'Paused';
end;

procedure WindowPress(Container: TUIContainer; const Event: TInputPressRelease);

  procedure Move(const X, Y: Single);
  begin
    Plane.RigidBody.LinearVelocity := Plane.RigidBody.LinearVelocity + 20 * Vector3(X, Y, 0);
  end;

begin
  if Event.IsKey(keyA) then
    Move(-1, 0);
  if Event.IsKey(keyD) then
    Move( 1, 0);
  if Event.IsKey(keyS) then
    Move(0, -1);
  if Event.IsKey(keyW) then
    Move(0,  1);
  if Event.IsKey(keyR) then
  begin
    FreeAndNil(Plane);
    LoadPlane;
  end;
  if Event.IsKey(keySpace) then
  begin
    if IsZero(SceneManager.TimeScale) then
      SceneManager.TimeScale := 1
    else
      SceneManager.TimeScale := 0;
  end;
  if Event.IsKey(keyInsert) then
  begin
    SceneManager.TimeScale := 0;
    LoadPlane2;
    //DeletePlane2;

    {LoadPlane2;
    DeletePlane2;

    LoadPlane2;
    DeletePlane2;}
end;

  if Event.IsKey(keyDelete) then
  begin
    DeletePlane2;
    SceneManager.TimeScale := 1;
  end;
end;

initialization
  { Set ApplicationName early, as our log uses it. }
  ApplicationProperties.ApplicationName := 'physics_2d_collisions';

  InitializeLog;

  { initialize Application callbacks }
  Application.OnInitialize := @ApplicationInitialize;

  { create Window and initialize Window callbacks }
  Window := TCastleWindowBase.Create(Application);
  Application.MainWindow := Window;
  Window.OnUpdate := @WindowUpdate;
  Window.OnPress := @WindowPress;
end.
```
### Steps to reproduce
Run this example, press `Insert` and next `Delete` key. Do it fast, because the second plane must collide with the first to make crash. With this fix everything works without crash.

Other way is to call:
```
LoadPlane2;
DeletePlane2;
```
I will make PR in official Kraft repository too.
