### PR TITLE
Android: Fixed TCastleApplication.ProcessMessage loop suspending

### DIFF
--- a/src/window/castlewindow_android.inc
+++ b/src/window/castlewindow_android.inc
@@ -627,13 +627,15 @@ var
 begin
   MessageHandlingBegin := Timer;
   repeat
-    { Android app can't be suspended by WaitForMessage and AllowSuspendForInput
-      because we do not react to resize events soon enough then,
-      since we have to actually do a couple of loop passes until resize
+    { When the window is open: We cannot suspend (wait indefinitely for a message) 
+      an open window, even when AllowSuspendForInput or WaitForMessage. 
+      That's because we would not react to resize events soon enough then,
+      since we have to actually do a couple of loop passes until "resize" event
       reaches us. Reproducible on drawing_toy.
 
-      On the other hand, we must always stop the message loop when the
-      window is closed to not waste battery. }
+      When the window is closed: We can and should suspend in this case,
+      regardless of AllowSuspendForInput or WaitForMessage,
+      to not waste battery. }
     if (MainWindow = nil) or MainWindow.Closed then
     begin
       WritelnLog('Android', 'Waiting for next event without consuming CPU ticks.');
@@ -709,11 +711,9 @@ begin
   end;
 
   { Note that we ignore WaitToLimitFPS here, right now.
-    When redrawing (not MainWindow.Closed), it is always "on" in the main loop,
+    When the window is open, it is always "on" in the main loop,
     we don't control it, Android throttles render speed anyway.
-    When not redrawing, then there's not much point in WaitToLimitFPS,
-    we should rather let WaitForMessage mechanism work (when all windows are
-    closed, we should usually have WaitForMessage = true). }
+    When the window is closed, we always wait for message to conserve battery. }
 
   { the result of ProcessMessage must always be "not Terminated"
     to work with TCustomApplication correctly. }

--- a/src/window/castlewindow_android.inc
+++ b/src/window/castlewindow_android.inc
@@ -627,21 +627,23 @@ var
 begin
   MessageHandlingBegin := Timer;
   repeat
-    if WaitForMessage and AllowSuspendForInput and
-      { Unfortunately, we have to be more conservative than
-        AllowSuspendForInput to decide when we can suspend.
+    { Android app can't be suspended by WaitForMessage and AllowSuspendForInput
+      because we do not react to resize events soon enough then,
+      since we have to actually do a couple of loop passes until resize
+      reaches us. Reproducible on drawing_toy.
 
-        Right now we cannot suspend on non-closed window.
-        Otherwise we do not react to resize events soon enough,
-        since we have to actually do a couple of loop passes until resize
-        reaches us. Reproducible on drawing_toy: without this,
-        we will not receive resize before drawing. }
-      ((MainWindow = nil) or MainWindow.Closed) then
+      On the other hand, we must always stop the message loop when the
+      window is closed to not waste battery. }
+    if (MainWindow = nil) or MainWindow.Closed then
     begin
       WritelnLog('Android', 'Waiting for next event without consuming CPU ticks.');
       Ident := ALooper_pollAll(-1 { wait }, nil, @Events, @Source);
     end else
+    begin
       Ident := ALooper_pollAll(0, nil, @Events, @Source);
+      { Uncomment it to test loop suspending solution. }
+      //WritelnLog('Android', 'Looping...');
+    end;
     if Ident < 0 then Break;
 
     if Source <> nil then


### PR DESCRIPTION
This PR fix `TCastleApplication.ProcessMessage` loop suspending when game was sent to background. Without this fix when game is in background the loop still works unnecessarily wasting battery and CPU.

Now the condition only checks for the existence of the window, I removed other conditions from the check. 

## Why I removed `AllowSuspendForInput`?
In android game we need suspend loop always when the app is in background. I think `AllowSuspendForInput` will never be true in "normal" game because of:

```
function TExamineCamera.AllowSuspendForInput: boolean;
begin
  Result := false;
end;
```
The same in `TWalkCamera`.

```
function TCastleOnScreenMenu.AllowSuspendForInput: boolean;
begin
  Result := false;
end;
```

```
function TCastleApplication.AllowSuspendForInput: boolean;
var
  I: Integer;
begin
  Result := not (
    Assigned(OnUpdate) or
    Assigned(OnTimer) or
    (ApplicationProperties.OnUpdate.Count <> 0));
  if not Result then Exit;

  for I := 0 to OpenWindowsCount - 1 do
  begin
    Result := OpenWindows[I].AllowSuspendForInput;
    if not Result then Exit;
  end;
end;
```
## Tests

Tested on my game, drawing_toy, simple_3d_demo, test_bump_mapping.