### PR TITLE
Triggers implementation for TRigidBody

### DIFF
--- a/examples/physics/physics_2d_collisions/gameinitialize.pas
+++ b/examples/physics/physics_2d_collisions/gameinitialize.pas
@@ -29,6 +29,7 @@ uses SysUtils, Classes, Generics.Collections, Math,
 type
   TWall = class;
   TPlane = class;
+  TTrigger = class;
 
 { Global variables ----------------------------------------------------------- }
 
@@ -42,11 +43,18 @@ var
   TopWall: TWall;
   BottomWall: TWall;
 
+  TriggerGreen: TTrigger;
+
 type
 
   TWall = class(TCastleScene)
   public
     constructor Create(AOwner: TComponent; const WallName: TComponentName; const Pos, Size, Color: TVector3); reintroduce;
+  end;
+
+  TTrigger = class(TCastleScene)
+  public
+    constructor Create(AOwner: TComponent; const TriggerName: TComponentName; const Pos, Size, Color: TVector3); reintroduce;
   end;
 
   TPlane = class(TCastleScene)
@@ -56,12 +64,56 @@ type
     constructor Create(AOwner: TComponent); override;
   end;
 
+{ TTrigger }
+
+constructor TTrigger.Create(AOwner: TComponent; const TriggerName: TComponentName;  const Pos, Size, Color: TVector3);
+var
+  Box: TBoxNode;
+  Shape: TShapeNode;
+  Root: TX3DRootNode;
+  RBody: TRigidBody;
+  Collider: TBoxCollider;
+begin
+  inherited Create(AOwner);
+
+  Translation := Pos; // initial position
+  Name := TriggerName;
+
+  Box := TBoxNode.CreateWithShape(Shape);
+  Box.Size := Size;
+
+  Shape.Appearance := TAppearanceNode.Create;
+  Shape.Appearance.Material := TMaterialNode.Create;
+  Shape.Appearance.Material.ForcePureEmissive;
+  Shape.Appearance.Material.EmissiveColor := Color;
+
+  Root := TX3DRootNode.Create;
+  Root.AddChildren(Shape);
+
+  Load(Root, true);
+
+  RBody := TRigidBody.Create(Self);
+  RBody.Dynamic := false;
+  RBody.Trigger := true;
+  RBody.Setup2D;
+
+  Collider := TBoxCollider.Create(RBody);
+  Collider.Size := Size;
+
+  RigidBody := RBody;
+end;
+
 { TPlane }
 
 procedure TPlane.CollisionEnter(const CollisionDetails: TPhysicsCollisionDetails);
 begin
   if CollisionDetails.OtherTransform <> nil then
-    LastCollisionEnter := CollisionDetails.OtherTransform.Name
+  begin
+    LastCollisionEnter := CollisionDetails.OtherTransform.Name;
+
+    if CollisionDetails.OtherTransform.RigidBody.Trigger then
+      LastCollisionEnter := LastCollisionEnter + '(trigger)';
+  end
   else
     LastCollisionEnter := 'other thing';
 end;
@@ -154,6 +206,13 @@ procedure ApplicationInitialize;
     BottomWall := TWall.Create(Application, 'BottomWall', Vector3(1024/2, 10, 0), Vector3(1000, 20, 4), Vector3(0.5, 0.5, 1.0));
     SceneManager.Items.Add(BottomWall);
   end;
+
+  procedure LoadTriggers;
+  begin
+    TriggerGreen := TTrigger.Create(Application, 'TriggerGreen', Vector3(500, 210, -3), Vector3(200, 200, 4), Vector3(0.1, 0.5, 0.0));
+    SceneManager.Items.Add(TriggerGreen);
+  end;
+
 begin
   { make UI automatically scaled }
   Window.Container.UIReferenceWidth := 1024;
@@ -169,7 +228,9 @@ begin
   Window.Controls.InsertFront(SceneManager);
 
   LoadWalls;
+  LoadTriggers;
   LoadPlane;
+
   SceneManager.NavigationType := ntNone;
 
   Status := TCastleLabel.Create(Application);
@@ -191,9 +252,12 @@ begin
   for I := 0 to CollisionsList.Count - 1 do
   begin
     if CollisionsList[I] is TWall then
-       CollisionsListTXT := CollisionsListTXT + ' ' + TWall(CollisionsList[I]).Name
+      CollisionsListTXT := CollisionsListTXT + ' ' + TWall(CollisionsList[I]).Name
     else
-       CollisionsListTXT := CollisionsListTXT + ' other thing';
+    if CollisionsList[I].RigidBody.Trigger then
+      CollisionsListTXT := CollisionsListTXT + ' trigger'
+    else
+      CollisionsListTXT := CollisionsListTXT + ' other thing';
   end;
 
   if CollisionsList.Count = 0 then

--- a/examples/physics/physics_2d_collisions/gameinitialize.pas
+++ b/examples/physics/physics_2d_collisions/gameinitialize.pas
@@ -112,7 +112,7 @@ begin
     LastCollisionEnter := CollisionDetails.OtherTransform.Name;
 
     if CollisionDetails.OtherTransform.RigidBody.Trigger then
-      LastCollisionEnter := LastCollisionEnter + '(trigger)';
+      LastCollisionEnter := LastCollisionEnter + ' (trigger)';
   end
   else
     LastCollisionEnter := 'other thing';

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -287,15 +287,15 @@
     }
     property Animated: Boolean read FAnimated write FAnimated default false;
 
-    { Triggers are like ghosts, they are objects that give information about,
-      a collision with them but are ignored by the physics engine. Other rigid
-      bodies can pass through them instead of react by stoping/bouncing.
+    { Triggers report when other object collides with them,
+      but still allow the other object to pass through.
+      In other words, colliding with a trigger will not cause the collider to stop or 
+      "bounce off" the trigger.
 
-      They are used to triggering events when other bodies collide with them.
-      For example to displaying tutorial messages, to collecting items (coins
-      can be triggers), to run some script when player goes to some location.
-
-      Triggers use the same events as other rigid bodies
+      They are useful as sensors. E.g. a trigger may be a coin (like in "Mario")
+      that the player can "consume" by colliding with it.
+      
+      Triggers report collisions through the same events as other rigid bodies:
       (@link(TRigidBody.OnCollisionEnter), @link(TRigidBody.OnCollisionStay),
       @link(TRigidBody.OnCollisionExit)). }
     property Trigger: Boolean read FTrigger write SetTrigger default false;

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -252,7 +252,7 @@
         )
       )
     }
-    property Dynamic: boolean read FDynamic write FDynamic default true;
+    property Dynamic: Boolean read FDynamic write FDynamic default true;
 
     { Is the transformation of this object updated often
       (relevant only when @link(Dynamic) = @false).
@@ -285,7 +285,7 @@
         )
       )
     }
-    property Animated: boolean read FAnimated write FAnimated default false;
+    property Animated: Boolean read FAnimated write FAnimated default false;
 
     { Triggers are like ghosts, they are objects that give information about,
       a collision with them but are ignored by the physics engine. Other rigid
@@ -307,7 +307,7 @@
     property Collider: TCollider read FCollider;
 
     { Is this object affected by gravity. }
-    property Gravity: boolean read FGravity write FGravity default true;
+    property Gravity: Boolean read FGravity write FGravity default true;
 
     { Disable motion (@link(TCastleTransform.Translation) change) along
       the particular (world) axis.

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -161,6 +161,7 @@
     procedure SetOnCollisionExit(const AValue: TOnCollision);
 
     procedure SetExists(const Value: Boolean);
+    procedure SetTrigger(const Value: Boolean);
   public
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
@@ -287,7 +288,7 @@
     property Animated: boolean read FAnimated write FAnimated default false;
 
 
-    property Trigger: Boolean read FTrigger write FTrigger default false;
+    property Trigger: Boolean read FTrigger write SetTrigger default false;
 
     { Shape used for collisions with this object.
       You cannot assign this property directly,
@@ -895,6 +896,22 @@ begin
       Collider.FKraftShape.Flags := Collider.FKraftShape.Flags + [ksfCollision]
     else
       Collider.FKraftShape.Flags := Collider.FKraftShape.Flags - [ksfCollision];
+  end;
+end;
+
+procedure TRigidBody.SetTrigger(const Value: Boolean);
+begin
+  if FTrigger = Value then
+    Exit;
+
+  FTrigger := Value;
+
+  if Assigned(FKraftBody) then
+  begin
+    if FTrigger then
+      FKraftBody.Flags := FKraftBody.Flags + [krbfSensor]
+    else
+      FKraftBody.Flags := FKraftBody.Flags - [krbfSensor];
   end;
 end;
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -287,7 +287,17 @@
     }
     property Animated: boolean read FAnimated write FAnimated default false;
 
+    { Triggers are like ghosts, they are objects that give information about,
+      a collision with them but are ignored by the physics engine. Other rigid
+      bodies can pass through them instead of react by stoping/bouncing.
 
+      They are used to triggering events when other bodies collide with them.
+      For example to displaying tutorial messages, to collecting items (coins
+      can be triggers), to run some script when player goes to some location.
+
+      Triggers use the same events as other rigid bodies
+      (@link(TRigidBody.OnCollisionEnter), @link(TRigidBody.OnCollisionStay),
+      @link(TRigidBody.OnCollisionExit)). }
     property Trigger: Boolean read FTrigger write SetTrigger default false;
 
     { Shape used for collisions with this object.

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -130,6 +130,7 @@
     FGravity: Boolean;
     FDynamic: Boolean;
     FAnimated: Boolean;
+    FTrigger: Boolean;
     FExists: Boolean;
     FLockTranslation: T3DCoords;
     FLockRotation: T3DCoords;
@@ -284,6 +285,9 @@
       )
     }
     property Animated: boolean read FAnimated write FAnimated default false;
+
+
+    property Trigger: Boolean read FTrigger write FTrigger default false;
 
     { Shape used for collisions with this object.
       You cannot assign this property directly,
@@ -525,6 +529,9 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
     if 2 in FLockTranslation then FKraftBody.Flags := FKraftBody.Flags + [krbfLockTranslationAxisZ];
     if not FExists then
       FKraftBody.Flags := FKraftBody.Flags - [krbfActive];
+
+    if FTrigger then
+      FKraftBody.Flags := FKraftBody.Flags + [krbfSensor];
 
     // initialize Kraft shape
     if Collider = nil then


### PR DESCRIPTION
Triggers implementation for `TRigidBody`. To make trigger just set `Trigger` property to true. 

Triggers use the same events as other rigid bodies `TRigidBody.OnCollisionEnter`, `TRigidBody.OnCollisionStay`, `TRigidBody.OnCollisionExit`.

I added simple trigger to `physics_2d_collisions` example (I think it will be expanded when we add more features to physics).

