### PR TITLE
Fixed build-tool compilation.

### DIFF
--- a/tools/build-tool/code/castle-engine.lpi
+++ b/tools/build-tool/code/castle-engine.lpi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="10"/>
+    <Version Value="11"/>
     <General>
       <Flags>
         <MainUnitHasUsesSectionForAllUnits Value="False"/>
@@ -19,48 +19,49 @@
     </PublishOptions>
     <RunParams>
       <local>
-        <FormatVersion Value="1"/>
         <CommandLineParams Value="compile"/>
       </local>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default">
+          <local>
+            <CommandLineParams Value="compile"/>
+          </local>
+        </Mode0>
+      </Modes>
     </RunParams>
     <RequiredPackages Count="1">
       <Item1>
         <PackageName Value="castle_base"/>
       </Item1>
     </RequiredPackages>
-    <Units Count="7">
+    <Units Count="6">
       <Unit0>
         <Filename Value="castle-engine.lpr"/>
         <IsPartOfProject Value="True"/>
       </Unit0>
       <Unit1>
-        <Filename Value="toolwindowsresources.pas"/>
-        <IsPartOfProject Value="True"/>
-        <UnitName Value="ToolWindowsResources"/>
-      </Unit1>
-      <Unit2>
-        <Filename Value="toolarchitectures.pas"/>
-        <IsPartOfProject Value="True"/>
-      </Unit2>
-      <Unit3>
         <Filename Value="toolcompile.pas"/>
         <IsPartOfProject Value="True"/>
         <UnitName Value="ToolCompile"/>
-      </Unit3>
-      <Unit4>
+      </Unit1>
+      <Unit2>
         <Filename Value="toolpackage.pas"/>
         <IsPartOfProject Value="True"/>
-      </Unit4>
-      <Unit5>
+      </Unit2>
+      <Unit3>
         <Filename Value="toolproject.pas"/>
         <IsPartOfProject Value="True"/>
         <UnitName Value="ToolProject"/>
-      </Unit5>
-      <Unit6>
-        <Filename Value="../../common-code/toolutils.pas"/>
+      </Unit3>
+      <Unit4>
+        <Filename Value="../../common-code/toolarchitectures.pas"/>
         <IsPartOfProject Value="True"/>
-        <UnitName Value="ToolUtils"/>
-      </Unit6>
+      </Unit4>
+      <Unit5>
+        <Filename Value="toolutils.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit5>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/tools/build-tool/code/castle-engine.lpr
+++ b/tools/build-tool/code/castle-engine.lpr
@@ -27,8 +27,8 @@ uses SysUtils,
   CastleUtils, CastleParameters, CastleFindFiles, CastleLog,
   CastleFilesUtils, CastleURIUtils, CastleStringUtils,
   CastleApplicationProperties,
-  ToolArchitectures, ToolProject, ToolCompile, ToolUtils, ToolIOS, ToolAndroid,
-  ToolNintendoSwitch, ToolCommonUtils;
+  ToolProject, ToolCompile, ToolIOS, ToolAndroid,
+  ToolNintendoSwitch, ToolCommonUtils, ToolArchitectures, ToolUtils;
 
 var
   Target: TTarget;


### PR DESCRIPTION
I just needed to compile build-tool, but there was some unit lacks and error on project load:

```
The file "/home/and3md/fpc/castle_game_engine/tools/build-tool/code/toolarchitectures.pas" was not found.
```
Maybe you work on build-tool now, in that case just ignore(close) this PR, otherwise, this PR fixes the problem.