### PR TITLE
Avoid spiral of death when physics step get more time than rendering + add physics to frame profiler.

### DIFF
--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -1776,6 +1776,8 @@ type
     FCameraPosition, FCameraDirection, FCameraUp: TVector3;
     FCameraKnown: boolean;
     FEnablePhysics: boolean;
+    { Buffer to not count physics step time per frame }
+    FPhysicsTimeStep: TFloatTime;
     { Create FKraftEngine, if not assigned yet. }
     procedure InitializePhysicsEngine;
   public

--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -1776,8 +1776,6 @@ type
     FCameraPosition, FCameraDirection, FCameraUp: TVector3;
     FCameraKnown: boolean;
     FEnablePhysics: boolean;
-    { Buffer to not count physics step time per frame }
-    FPhysicsTimeStep: TFloatTime;
     { Create FKraftEngine, if not assigned yet. }
     procedure InitializePhysicsEngine;
   public

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -22,6 +22,7 @@
     FAngularVelocityRK4Integration: Boolean;
     FLinearVelocityRK4Integration: Boolean;
     FFrequency: Single;
+    FMaxPhysicsTicksPerUpdate: Integer;
 
     procedure SetAngularVelocityRK4Integration(const AValue: Boolean);
     procedure SetLinearVelocityRK4Integration(const AValue: Boolean);
@@ -35,6 +36,7 @@
       DefaultAngularVelocityRK4Integration = false;
       DefaultLinearVelocityRK4Integration = false;
       DefaultFrequency = 60.0;
+      DefaultMaxPhysicsTicksPerUpdate = 5;
 
     constructor Create(AOwner: TComponent); override;
 
@@ -42,6 +44,13 @@
     property AngularVelocityRK4Integration: Boolean read FAngularVelocityRK4Integration write SetAngularVelocityRK4Integration default DefaultAngularVelocityRK4Integration;
     property LinearVelocityRK4Integration: Boolean read FLinearVelocityRK4Integration write SetLinearVelocityRK4Integration default DefaultLinearVelocityRK4Integration;
     property Frequency: Single read FFrequency write SetFrequency default DefaultFrequency;
+
+    { This helps to avoid spiral of death when physics step get more time than rendering.
+      You can disable this by set it to 0 but then when physics takes long than render,
+      next Update will get more time and leads to infinite time.
+      When you set it to 1 simulation will get max one step per Update, so on very
+      weak hardware physics will slow down instead of jumping. }
+    property MaxPhysicsTicksPerUpdate: Integer read FMaxPhysicsTicksPerUpdate write FMaxPhysicsTicksPerUpdate default DefaultMaxPhysicsTicksPerUpdate;
   end;
 
   { Shape used for collision detection of a rigid body @link(TRigidBody). }
@@ -405,6 +414,7 @@ begin
     Exit;
 
   FFrequency := AValue;
+  SceneManagerWorld.FPhysicsTimeStep := 1.0 / FFrequency;
 
   if Assigned(SceneManagerWorld.FKraftEngine) then
     SceneManagerWorld.FKraftEngine.SetFrequency(AValue);
@@ -438,6 +448,7 @@ begin
   FAngularVelocityRK4Integration := DefaultAngularVelocityRK4Integration;
   FLinearVelocityRK4Integration := DefaultLinearVelocityRK4Integration;
   FFrequency := DefaultFrequency;
+  FMaxPhysicsTicksPerUpdate := DefaultMaxPhysicsTicksPerUpdate;
 end;
 
 { TCollider ------------------------------------------------------------------ }
@@ -1080,6 +1091,7 @@ begin
       very slow, so we need remove this limitation. }
     FKraftEngine.MaximalLinearVelocity := 0;
     FKraftEngine.SetFrequency(PhysicsProperties.Frequency);
+    FPhysicsTimeStep := 1.0 / PhysicsProperties.Frequency;
     FKraftEngine.AngularVelocityRK4Integration := PhysicsProperties.AngularVelocityRK4Integration;
     FKraftEngine.LinearVelocityRK4Integration := PhysicsProperties.LinearVelocityRK4Integration;
   end;
@@ -1113,8 +1125,9 @@ end;
 
 procedure TSceneManagerWorld.Update(const SecondsPassed: Single; var RemoveMe: TRemoveType);
 var
-  PhysicsTimeStep: TFloatTime;
   KraftGravity: TVector3;
+  PhysicsTicksCount:Integer;
+  OldTimeAccumulator: TFloatTime;
 begin
   if EnablePhysics and (FKraftEngine <> nil) then
   begin
@@ -1123,6 +1136,8 @@ begin
     KraftGravity := -GravityUp * 9.81;
     FKraftEngine.Gravity.Vector := VectorToKraft(KraftGravity);
 
+    PhysicsTicksCount := 0;
+
     if not WasPhysicsStep then
     begin
       FKraftEngine.StoreWorldTransforms;
@@ -1130,13 +1145,28 @@ begin
       WasPhysicsStep := true;
     end else
     begin
-      PhysicsTimeStep := 1.0 / FKraftEngine.WorldFrequency;
       TimeAccumulator := TimeAccumulator + SecondsPassed;
-      while TimeAccumulator >= PhysicsTimeStep do
+      while TimeAccumulator >= FPhysicsTimeStep do
       begin
-        TimeAccumulator := TimeAccumulator - PhysicsTimeStep;
+        TimeAccumulator := TimeAccumulator - FPhysicsTimeStep;
         FKraftEngine.StoreWorldTransforms;
-        FKraftEngine.Step(PhysicsTimeStep);
+        FKraftEngine.Step(FPhysicsTimeStep);
+
+        Inc(PhysicsTicksCount);
+
+        { This helps to avoid spiral of death when physics step get more time than rendering. }
+        if (TimeAccumulator >= FPhysicsTimeStep) and (PhysicsProperties.MaxPhysicsTicksPerUpdate > 0) and
+           (PhysicsTicksCount >= PhysicsProperties.MaxPhysicsTicksPerUpdate) then
+        begin
+          OldTimeAccumulator := TimeAccumulator;
+          TimeAccumulator := TimeAccumulator - (FPhysicsTimeStep * Floor(TimeAccumulator / FPhysicsTimeStep));
+
+          WritelnLog('Max physics ticks in TSceneManagerWorld.Update() exceeded ('
+            + IntTostr(PhysicsTicksCount) + '). TimeAcumulator reduced from '
+            + FloatToStr(OldTimeAccumulator) + ' to ' + FloatToStr(TimeAccumulator));
+
+          break;
+        end;
       end;
 
       { One can wonder why we do interpolate below between
@@ -1160,8 +1190,8 @@ begin
         (The original https://gafferongames.com/post/fix_your_timestep/ no longer
         has comments.)
       }
-
-      FKraftEngine.InterpolateWorldTransforms(TimeAccumulator / PhysicsTimeStep);
+      FKraftEngine.InterpolateWorldTransforms(TimeAccumulator / FPhysicsTimeStep);
+      //FKraftEngine.InterpolateWorldTransforms(1.0);
     end;
   end;
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -1131,6 +1131,8 @@ var
 begin
   if EnablePhysics and (FKraftEngine <> nil) then
   begin
+    FrameProfiler.Start(fmUpdatePhysics);
+
     // update FKraftEngine.Gravity
     // TODO: do we really need to be prepared that it changes each frame?
     KraftGravity := -GravityUp * 9.81;
@@ -1193,6 +1195,7 @@ begin
       FKraftEngine.InterpolateWorldTransforms(TimeAccumulator / FPhysicsTimeStep);
       //FKraftEngine.InterpolateWorldTransforms(1.0);
     end;
+    FrameProfiler.Stop(fmUpdatePhysics);
   end;
 
   { call inherited at the end,

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -1193,7 +1193,6 @@ begin
         has comments.)
       }
       FKraftEngine.InterpolateWorldTransforms(TimeAccumulator / FPhysicsTimeStep);
-      //FKraftEngine.InterpolateWorldTransforms(1.0);
     end;
     FrameProfiler.Stop(fmUpdatePhysics);
   end;

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -22,11 +22,15 @@
     FAngularVelocityRK4Integration: Boolean;
     FLinearVelocityRK4Integration: Boolean;
     FFrequency: Single;
-    FMaxPhysicsTicksPerUpdate: Integer;
+    FMaxPhysicsTicksPerUpdate: Cardinal;
 
     procedure SetAngularVelocityRK4Integration(const AValue: Boolean);
     procedure SetLinearVelocityRK4Integration(const AValue: Boolean);
     procedure SetFrequency(const AValue: Single);
+
+  private
+    { Buffer to not count physics step time per frame }
+    FPhysicsTimeStep: TFloatTime;
 
   protected
     function SceneManagerWorld: TSceneManagerWorld; virtual; abstract;
@@ -45,12 +49,15 @@
     property LinearVelocityRK4Integration: Boolean read FLinearVelocityRK4Integration write SetLinearVelocityRK4Integration default DefaultLinearVelocityRK4Integration;
     property Frequency: Single read FFrequency write SetFrequency default DefaultFrequency;
 
-    { This helps to avoid spiral of death when physics step get more time than rendering.
-      You can disable this by set it to 0 but then when physics takes long than render,
-      next Update will get more time and leads to infinite time.
-      When you set it to 1 simulation will get max one step per Update, so on very
-      weak hardware physics will slow down instead of jumping. }
-    property MaxPhysicsTicksPerUpdate: Integer read FMaxPhysicsTicksPerUpdate write FMaxPhysicsTicksPerUpdate default DefaultMaxPhysicsTicksPerUpdate;
+    { Non-zero value avoids the "spiral of death" when the physics takes
+      a long time to calculate.
+
+      When the value is zero, physics makes always as many steps as necessary,
+      to advance the time by @code(1 / @link(Frequency)) steps.
+      This means that if physics takes a long time to calculate,
+      next time it will take even longer time to calculate (it will need more steps),
+      thus we have a "spiral of death" that leads to lower and lower FPS. }
+    property MaxPhysicsTicksPerUpdate: Cardinal read FMaxPhysicsTicksPerUpdate write FMaxPhysicsTicksPerUpdate default DefaultMaxPhysicsTicksPerUpdate;
   end;
 
   { Shape used for collision detection of a rigid body @link(TRigidBody). }
@@ -414,7 +421,7 @@ begin
     Exit;
 
   FFrequency := AValue;
-  SceneManagerWorld.FPhysicsTimeStep := 1.0 / FFrequency;
+  FPhysicsTimeStep := 1.0 / FFrequency;
 
   if Assigned(SceneManagerWorld.FKraftEngine) then
     SceneManagerWorld.FKraftEngine.SetFrequency(AValue);
@@ -448,6 +455,7 @@ begin
   FAngularVelocityRK4Integration := DefaultAngularVelocityRK4Integration;
   FLinearVelocityRK4Integration := DefaultLinearVelocityRK4Integration;
   FFrequency := DefaultFrequency;
+  FPhysicsTimeStep := 1.0 / FFrequency;
   FMaxPhysicsTicksPerUpdate := DefaultMaxPhysicsTicksPerUpdate;
 end;
 
@@ -1091,7 +1099,6 @@ begin
       very slow, so we need remove this limitation. }
     FKraftEngine.MaximalLinearVelocity := 0;
     FKraftEngine.SetFrequency(PhysicsProperties.Frequency);
-    FPhysicsTimeStep := 1.0 / PhysicsProperties.Frequency;
     FKraftEngine.AngularVelocityRK4Integration := PhysicsProperties.AngularVelocityRK4Integration;
     FKraftEngine.LinearVelocityRK4Integration := PhysicsProperties.LinearVelocityRK4Integration;
   end;
@@ -1148,20 +1155,27 @@ begin
     end else
     begin
       TimeAccumulator := TimeAccumulator + SecondsPassed;
-      while TimeAccumulator >= FPhysicsTimeStep do
+      while TimeAccumulator >= PhysicsProperties.FPhysicsTimeStep do
       begin
-        TimeAccumulator := TimeAccumulator - FPhysicsTimeStep;
+        TimeAccumulator := TimeAccumulator - PhysicsProperties.FPhysicsTimeStep;
         FKraftEngine.StoreWorldTransforms;
-        FKraftEngine.Step(FPhysicsTimeStep);
+        FKraftEngine.Step(PhysicsProperties.FPhysicsTimeStep);
 
         Inc(PhysicsTicksCount);
 
-        { This helps to avoid spiral of death when physics step get more time than rendering. }
-        if (TimeAccumulator >= FPhysicsTimeStep) and (PhysicsProperties.MaxPhysicsTicksPerUpdate > 0) and
+        { To avoid the spiral of death, we ignore some accumulated time
+          (we will not account for this time in the physics simulation,
+          so physics simulation may be slower than time perceived by user,
+          than non-physics animations etc.).
+          An alternative approach would be to prolong the simulation step
+          sometimes, but this could lead to unreliable collision detection.
+          See description of this in
+          https://github.com/castle-engine/castle-engine/pull/144#issuecomment-562850820 }
+        if (TimeAccumulator >= PhysicsProperties.FPhysicsTimeStep) and (PhysicsProperties.MaxPhysicsTicksPerUpdate <> 0) and
            (PhysicsTicksCount >= PhysicsProperties.MaxPhysicsTicksPerUpdate) then
         begin
           OldTimeAccumulator := TimeAccumulator;
-          TimeAccumulator := TimeAccumulator - (FPhysicsTimeStep * Floor(TimeAccumulator / FPhysicsTimeStep));
+          TimeAccumulator := TimeAccumulator - (PhysicsProperties.FPhysicsTimeStep * Floor(TimeAccumulator / PhysicsProperties.FPhysicsTimeStep));
 
           WritelnLog('Max physics ticks in TSceneManagerWorld.Update() exceeded ('
             + IntTostr(PhysicsTicksCount) + '). TimeAcumulator reduced from '
@@ -1192,7 +1206,7 @@ begin
         (The original https://gafferongames.com/post/fix_your_timestep/ no longer
         has comments.)
       }
-      FKraftEngine.InterpolateWorldTransforms(TimeAccumulator / FPhysicsTimeStep);
+      FKraftEngine.InterpolateWorldTransforms(TimeAccumulator / PhysicsProperties.FPhysicsTimeStep);
     end;
     FrameProfiler.Stop(fmUpdatePhysics);
   end;

--- a/src/base/castletimeutils_frameprofiler.inc
+++ b/src/base/castletimeutils_frameprofiler.inc
@@ -27,7 +27,8 @@ type
     fmRenderShapesFilterBlending,
     //fmRenderFrameProfiler,
     fmUpdate,
-    fmUpdateScene
+    fmUpdateScene,
+    fmUpdatePhysics
   );
 
   { Profiler gathering statistics about each game frame.
@@ -192,6 +193,7 @@ procedure TCastleFrameProfiler.StartFrame;
       '%s' +
       '- Update: %d%%' + NL +
       '  - TCastleSceneCore.Update: %d%%' + NL +
+      '  - Update Kraft Physics: %d%% (%.5f secs)' + NL +
       '%s' +
       '- Other:' + NL +
       '%s'
@@ -209,6 +211,8 @@ procedure TCastleFrameProfiler.StartFrame;
       DisplayUserMetrics(UserMetricsRenderNames, 1 + Ord(High(TFrameMetric)) + 1 + 0),
       Round(100 * FramesTimes[CurrentFrame, IndexFrameMetric(fmUpdate)] / TotalTime),
       Round(100 * FramesTimes[CurrentFrame, IndexFrameMetric(fmUpdateScene)] / TotalTime),
+      Round(100 * FramesTimes[CurrentFrame, IndexFrameMetric(fmUpdatePhysics)] / TotalTime),
+      FramesTimes[CurrentFrame, IndexFrameMetric(fmUpdatePhysics)],
       DisplayUserMetrics(UserMetricsUpdateNames, 1 + Ord(High(TFrameMetric)) + 1 + MaxUserMetrics),
       DisplayUserMetrics(UserMetricsOtherNames , 1 + Ord(High(TFrameMetric)) + 1 + 2 * MaxUserMetrics)
     ]));


### PR DESCRIPTION
Avoid spiral of death when physics step get more time than rendering. When there are more than 5 steps per Update, next steps are abandoned and time reduced. Don't know how big should be default value, you can change it if you think it is too low/high.

This value can be changed by `MaxPhysicsTicksPerUpdate` in `TPhysicsProperties`. When you change it to `0` protection will not work. When you change it to `1` there will be one physics step per update so simulation will slow down on weak hardware.

Physics is in frame profiler now:
```
-------------------- FrameProfiler begin
Frame time: 0.02 secs (we should have 64.29 FPS based on this):
- BeforeRender: 0%
- Render: 94% (0.01 secs, we should have 68.38 "only render FPS" based on this)
  - TCastleTransform.Render transformation: 2%
  - TCastleScene.Render: 38%
    - ShapesFilterBlending: 2%
- Update: 5%
  - TCastleSceneCore.Update: 0%
  - Update Kraft Physics: 2% (0.00037 secs)
- Other:
-------------------- FrameProfiler end
```