### PR TITLE
castle-editor: Fixed taskbar button hidden on Windows

### DIFF
--- a/tools/castle-editor/code/formchooseproject.pas
+++ b/tools/castle-editor/code/formchooseproject.pas
@@ -75,20 +75,20 @@ uses CastleConfig, CastleLCLUtils, CastleURIUtils, CastleUtils,
 
 procedure TChooseProjectForm.Show;
 begin
-  {$IFDEF WINDOWS}
+  {$ifdef MSWINDOWS}
   Application.ShowMainForm := True;
-  {$ELSE}
-  TForm(Self).Show;
-  {$ENDIF}
+  {$else}
+  inherited Show;
+  {$endif}
 end;
 
 procedure TChooseProjectForm.Hide;
 begin
-  {$IFDEF WINDOWS}
+  {$ifdef MSWINDOWS}
   Application.ShowMainForm := False;
-  {$ELSE}
-  TForm(Self).Hide;
-  {$ENDIF}
+  {$else}
+  inherited Hide;
+  {$endif}
 end;
 
 procedure TChooseProjectForm.ButtonOpenClick(Sender: TObject);

--- a/tools/castle-editor/code/formchooseproject.pas
+++ b/tools/castle-editor/code/formchooseproject.pas
@@ -46,6 +46,9 @@ type
     procedure FormCreate(Sender: TObject);
     procedure FormDestroy(Sender: TObject);
     procedure FormShow(Sender: TObject);
+  protected
+    procedure Show;
+    procedure Hide;
   private
     RecentProjects: TCastleRecentFiles;
     CommandLineHandled: Boolean;
@@ -69,6 +72,24 @@ uses CastleConfig, CastleLCLUtils, CastleURIUtils, CastleUtils,
   ToolCompilerInfo, ToolFpcVersion;
 
 { TChooseProjectForm ------------------------------------------------------------- }
+
+procedure TChooseProjectForm.Show;
+begin
+  {$IFDEF WINDOWS}
+  Application.ShowMainForm := True;
+  {$ELSE}
+  TForm(Self).Show;
+  {$ENDIF}
+end;
+
+procedure TChooseProjectForm.Hide;
+begin
+  {$IFDEF WINDOWS}
+  Application.ShowMainForm := False;
+  {$ELSE}
+  TForm(Self).Hide;
+  {$ENDIF}
+end;
 
 procedure TChooseProjectForm.ButtonOpenClick(Sender: TObject);
 begin


### PR DESCRIPTION
On Windows, when we hide the main form using TForm.Hide, the button on taskbar also got hidden.
It is better to set Application.ShowMainForm field on Windows instead.