### PR TITLE
allow first frame of CustomAnimation to play on first loop

### DIFF
--- a/src/images/opengl/castleglimages_sprite.inc
+++ b/src/images/opengl/castleglimages_sprite.inc
@@ -446,6 +446,9 @@ begin
     Anim := FCustomAnimations.Items[FCurrentAnimation];
     while (FTime - FCustomAnimTimestamp) >= Anim.Frames[FCustomFrame].Duration do
     begin
+      // set FFrame before Inc(FCustomFrame) to allow first frame to play on first loop
+      FCustomAnimTimestamp := FCustomAnimTimestamp + Anim.Frames[FCustomFrame].Duration;
+      FFrame := Anim.Frames[FCustomFrame].Frame;
       // todo: custom animation loops
       if FCustomFrame = High(Anim.Frames) then
       begin
@@ -455,8 +458,6 @@ begin
           Stop;
       end else
         Inc(FCustomFrame);
-      FCustomAnimTimestamp := FCustomAnimTimestamp + Anim.Frames[FCustomFrame].Duration;
-      FFrame := Anim.Frames[FCustomFrame].Frame;
     end;
   end else
     FFrame := TVideo.FrameIndexFromTime(FTime, FFrames, FFramesPerSecond, FTimeLoop, FTimeBackwards);


### PR DESCRIPTION
set FFrame before Inc(FCustomFrame) to allow first frame to play on first loop
-------
In the current TSprite, the first frame of custom animation is not played on the first loop. Please see the demo program attached. 4 frames of animation should be played on each button click, but only 3 are.

After patch, all 4 frames of animation are played on each button click.

[tsprite_animation_test.zip](https://github.com/castle-engine/castle-engine/files/4708088/tsprite_animation_test.zip)

