### PR TITLE
Add support for Spine weighted mesh

### DIFF
--- a/packages/castle_base.lpk
+++ b/packages/castle_base.lpk
@@ -103,7 +103,7 @@ This is the same license as used by Lazarus LCL and FPC RTL.
 See https://castle-engine.io/license.php for details.
 "/>
     <Version Major="6" Minor="5"/>
-    <Files Count="693">
+    <Files Count="694">
       <Item1>
         <Filename Value="../src/3d/castleboxes.pas"/>
         <UnitName Value="CastleBoxes"/>
@@ -279,6 +279,10 @@ See https://castle-engine.io/license.php for details.
         <Filename Value="../src/base/castleinterfaces.pas"/>
         <UnitName Value="CastleInterfaces"/>
       </Item43>
+      <Item44>
+        <Filename Value="../src/x3d/castleloadgltf.pas"/>
+        <UnitName Value="CastleLoadGltf"/>
+      </Item44>
       <Item45>
         <Filename Value="../src/base/castleinternalgzio.pas"/>
         <UnitName Value="CastleInternalGzio"/>
@@ -2884,14 +2888,14 @@ See https://castle-engine.io/license.php for details.
         <Filename Value="../src/services/castletestfairy.pas"/>
         <UnitName Value="CastleTestFairy"/>
       </Item692>
-      <Item44>
-        <Filename Value="../src/x3d/castleloadgltf.pas"/>
-        <UnitName Value="CastleLoadGltf"/>
-      </Item44>
       <Item693>
         <Filename Value="../src/3d/castlethirdpersonnavigation.pas"/>
         <UnitName Value="CastleThirdPersonNavigation"/>
       </Item693>
+      <Item694>
+        <Filename Value="../src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc"/>
+        <Type Value="Include"/>
+      </Item694>
     </Files>
     <RequiredPkgs Count="1">
       <Item1>

--- a/src/x3d/x3dloadinternalspine.pas
+++ b/src/x3d/x3dloadinternalspine.pas
@@ -37,7 +37,7 @@ var
 implementation
 
 uses SysUtils, Classes, Generics.Collections, FpJson, JSONParser, JSONScanner, Math,
-  CastleVectors, CastleUtils, CastleLog, CastleURIUtils, CastleDownload,
+  CastleVectors, CastleCurves, CastleUtils, CastleLog, CastleURIUtils, CastleDownload,
   CastleStringUtils, CastleClassUtils, CastleColors, X3DLoadInternalUtils,
   CastleTriangles,
   X3DFields;

--- a/src/x3d/x3dloadinternalspine.pas
+++ b/src/x3d/x3dloadinternalspine.pas
@@ -67,6 +67,7 @@ type
   {$I x3dloadinternalspine_slottimelines.inc}
   {$I x3dloadinternalspine_drawordertimelines.inc}
   {$I x3dloadinternalspine_deformtimelines.inc}
+  {$I x3dloadinternalspine_weightedmeshtimelines.inc}
   {$I x3dloadinternalspine_animations.inc}
   {$I x3dloadinternalspine_skeleton.inc}
   {$undef read_interface}
@@ -81,6 +82,7 @@ type
   {$I x3dloadinternalspine_slottimelines.inc}
   {$I x3dloadinternalspine_drawordertimelines.inc}
   {$I x3dloadinternalspine_deformtimelines.inc}
+  {$I x3dloadinternalspine_weightedmeshtimelines.inc}
   {$I x3dloadinternalspine_animations.inc}
   {$I x3dloadinternalspine_skeleton.inc}
   {$undef read_implementation}

--- a/src/x3d/x3dloadinternalspine_animations.inc
+++ b/src/x3d/x3dloadinternalspine_animations.inc
@@ -191,14 +191,6 @@ procedure TAnimation.Parse(const Json: TJSONObject;
         ]);
         Continue;
       end;
-      if (Attachment as TMeshAttachment).Weights.Count > 0 then
-      begin
-        WritelnWarning('Attachment "%s" in slot "%s" cannot be animated: Weighted mesh with deform timeline is not supported', [
-          AttachmentName,
-          SlotName
-        ]);
-        Continue;
-      end;
       DeformTimeline := TDeformTimeline.Create;
       DeformTimeline.Slot := Slots.Find(SlotName);
       DeformTimeline.Attachment := Attachment as TMeshAttachment;
@@ -215,9 +207,8 @@ procedure TAnimation.Parse(const Json: TJSONObject;
   var
     I, J: Integer;
     Attachment: TAttachment;
-    AffectedBoneTimelines: TBoneTimelineList;
-    BoneTimeline: TBoneTimeline;
     WeightedMeshTimeline: TWeightedMeshTimeline;
+    AffectedDeformTimeline: TDeformTimeline;
   begin
     for I := 0 to CurrentSkin.Attachments.Count - 1 do
     begin
@@ -225,33 +216,34 @@ procedure TAnimation.Parse(const Json: TJSONObject;
       // Make sure this attachment is a weighted mesh
       if (Attachment is TMeshAttachment) and ((Attachment as TMeshAttachment).Weights.Count > 0) then
       begin
-        AffectedBoneTimelines := TBoneTimelineList.Create;
-        AffectedBoneTimelines.OwnsObjects := False;
-        try
-          // We loop through bone timelines to find those that affect this mesh
-          for J := 0 to BoneTimelines.Count - 1 do
+        // Backup original bone timeline properties
+        for J := 0 to BoneTimelines.Count - 1 do
+          BoneTimelines[J].Backup;
+        // We generate weightedmesh timeline if the number of bone timeline > 0
+        if BoneTimelines.Count > 0 then
+        begin
+          // Search through deform timeline list to find affected one
+          AffectedDeformTimeline := nil;
+          for J := 0 to DeformTimelines.Count - 1 do
           begin
-            BoneTimeline := BoneTimelines[J];
-            AffectedBoneTimelines.Add(BoneTimeline);
-            BoneTimeline.Backup;
+            if DeformTimelines[J].Attachment.Name = Attachment.Name then
+            begin
+              AffectedDeformTimeline := DeformTimelines[J];
+              AffectedDeformTimeline.IsHandledByWeightedMeshTimeline := True;
+              Break;
+            end;
           end;
-          // We generate timeline if the number of affected bone timelines > 0
-          if AffectedBoneTimelines.Count > 0 then
-          begin
-            WeightedMeshTimeline := TWeightedMeshTimeline.Create;
-            // TODO: We need a better way to determine this timeline's unique name
-            WeightedMeshTimeline.Name := IntToStr(I);
-            WeightedMeshTimeline.Attachment := Attachment as TMeshAttachment;
-            WeightedMeshTimeline.AffectedBoneTimelines := AffectedBoneTimelines;
-            WeightedMeshTimeline.Parse;
-            WeightedMeshTimelines.Add(WeightedMeshTimeline);
-          end;
-          // Restore bone timeline properties
-          for J := 0 to AffectedBoneTimelines.Count - 1 do
-            AffectedBoneTimelines[J].Restore;
-        finally
-          FreeAndNil(AffectedBoneTimelines);
+          WeightedMeshTimeline := TWeightedMeshTimeline.Create;
+          WeightedMeshTimeline.AffectedDeformTimeline := AffectedDeformTimeline;
+          WeightedMeshTimeline.Name := IntToStr(I);
+          WeightedMeshTimeline.Attachment := Attachment as TMeshAttachment;
+          WeightedMeshTimeline.AffectedBoneTimelines := BoneTimelines;
+          WeightedMeshTimeline.Parse;
+          WeightedMeshTimelines.Add(WeightedMeshTimeline);
         end;
+        // Restore bone timeline properties
+        for J := 0 to BoneTimelines.Count - 1 do
+          BoneTimelines[J].Restore;
       end;
     end;
   end;
@@ -384,6 +376,8 @@ begin
 
   for I := 0 to DeformTimelines.Count - 1 do
   begin
+    if DeformTimelines[I].IsHandledByWeightedMeshTimeline then
+      Continue;
     DeformTimelines[I].BuildNodes(MaxTime, Container);
     { add animation name to deform timeline, to make it unique in case
       we have many animations }

--- a/src/x3d/x3dloadinternalspine_animations.inc
+++ b/src/x3d/x3dloadinternalspine_animations.inc
@@ -227,6 +227,8 @@ procedure TAnimation.Parse(const Json: TJSONObject;
           begin
             AffectedDeformTimeline := DeformTimelines[J];
             AffectedDeformTimeline.IsHandledByWeightedMeshTimeline := True;
+            // Backup the original Time
+            AffectedDeformTimeline.Backup;
             Break;
           end;
         end;

--- a/src/x3d/x3dloadinternalspine_animations.inc
+++ b/src/x3d/x3dloadinternalspine_animations.inc
@@ -219,20 +219,21 @@ procedure TAnimation.Parse(const Json: TJSONObject;
         // Backup original bone timeline properties
         for J := 0 to BoneTimelines.Count - 1 do
           BoneTimelines[J].Backup;
-        // We generate weightedmesh timeline if the number of bone timeline > 0
-        if BoneTimelines.Count > 0 then
+        // Search through deform timeline list to find affected one
+        AffectedDeformTimeline := nil;
+        for J := 0 to DeformTimelines.Count - 1 do
         begin
-          // Search through deform timeline list to find affected one
-          AffectedDeformTimeline := nil;
-          for J := 0 to DeformTimelines.Count - 1 do
+          if DeformTimelines[J].Attachment.Name = Attachment.Name then
           begin
-            if DeformTimelines[J].Attachment.Name = Attachment.Name then
-            begin
-              AffectedDeformTimeline := DeformTimelines[J];
-              AffectedDeformTimeline.IsHandledByWeightedMeshTimeline := True;
-              Break;
-            end;
+            AffectedDeformTimeline := DeformTimelines[J];
+            AffectedDeformTimeline.IsHandledByWeightedMeshTimeline := True;
+            Break;
           end;
+        end;
+        // We generate weightedmesh timeline if the number of bone timeline > 0,
+        // or has AffectedDeformTimeline
+        if (BoneTimelines.Count > 0) or (AffectedDeformTimeline <> nil) then
+        begin
           WeightedMeshTimeline := TWeightedMeshTimeline.Create;
           WeightedMeshTimeline.AffectedDeformTimeline := AffectedDeformTimeline;
           WeightedMeshTimeline.Name := IntToStr(I);

--- a/src/x3d/x3dloadinternalspine_animations.inc
+++ b/src/x3d/x3dloadinternalspine_animations.inc
@@ -191,6 +191,14 @@ procedure TAnimation.Parse(const Json: TJSONObject;
         ]);
         Continue;
       end;
+      if (Attachment as TMeshAttachment).Weights.Count > 0 then
+      begin
+        WritelnWarning('Attachment "%s" in slot "%s" cannot be animated: Weighted mesh with deform timeline is not supported', [
+          AttachmentName,
+          SlotName
+        ]);
+        Continue;
+      end;
       DeformTimeline := TDeformTimeline.Create;
       DeformTimeline.Slot := Slots.Find(SlotName);
       DeformTimeline.Attachment := Attachment as TMeshAttachment;
@@ -205,12 +213,9 @@ procedure TAnimation.Parse(const Json: TJSONObject;
     those bones }
   procedure ReadWeightedMeshTimelines;
   var
-    I, J, K: Integer;
+    I, J: Integer;
     Attachment: TAttachment;
-    AffectedBones: TBoneList;
     AffectedBoneTimelines: TBoneTimelineList;
-    MeshVertex: TMeshVertex;
-    Bone: TBone;
     BoneTimeline: TBoneTimeline;
     WeightedMeshTimeline: TWeightedMeshTimeline;
   begin
@@ -220,34 +225,15 @@ procedure TAnimation.Parse(const Json: TJSONObject;
       // Make sure this attachment is a weighted mesh
       if (Attachment is TMeshAttachment) and ((Attachment as TMeshAttachment).Weights.Count > 0) then
       begin
-        AffectedBones := TBoneList.Create;
         AffectedBoneTimelines := TBoneTimelineList.Create;
+        AffectedBoneTimelines.OwnsObjects := False;
         try
-          AffectedBones.OwnsObjects := False;
-          AffectedBoneTimelines.OwnsObjects := False;
-          // Loop through mesh to get list of affected bones
-          for J := 0 to (Attachment as TMeshAttachment).Weights.Count - 1 do
-          begin
-            MeshVertex := (Attachment as TMeshAttachment).Weights[J];
-            for K := 0 to MeshVertex.Bones.Count - 1 do
-            begin
-              Bone := MeshVertex.Bones[K].Bone;
-              if AffectedBones.FindByName(Bone.Name) = nil then
-              begin
-                AffectedBones.Add(Bone);
-              end
-            end;
-          end;
-          // Now we loop through bone timelines to find those that affect this mesh
+          // We loop through bone timelines to find those that affect this mesh
           for J := 0 to BoneTimelines.Count - 1 do
           begin
             BoneTimeline := BoneTimelines[J];
-            if AffectedBones.FindByName(BoneTimeline.Bone.Name) <> nil then
-            begin
-              AffectedBoneTimelines.Add(BoneTimeline);
-              // Backup bone timeline properties
-              BoneTimeline.Backup;
-            end;
+            AffectedBoneTimelines.Add(BoneTimeline);
+            BoneTimeline.Backup;
           end;
           // We generate timeline if the number of affected bone timelines > 0
           if AffectedBoneTimelines.Count > 0 then
@@ -255,7 +241,6 @@ procedure TAnimation.Parse(const Json: TJSONObject;
             WeightedMeshTimeline := TWeightedMeshTimeline.Create;
             // TODO: We need a better way to determine this timeline's unique name
             WeightedMeshTimeline.Name := IntToStr(I);
-            WeightedMeshTimeline.Slots := Slots;
             WeightedMeshTimeline.Attachment := Attachment as TMeshAttachment;
             WeightedMeshTimeline.AffectedBoneTimelines := AffectedBoneTimelines;
             WeightedMeshTimeline.Parse;
@@ -265,7 +250,6 @@ procedure TAnimation.Parse(const Json: TJSONObject;
           for J := 0 to AffectedBoneTimelines.Count - 1 do
             AffectedBoneTimelines[J].Restore;
         finally
-          FreeAndNil(AffectedBones);
           FreeAndNil(AffectedBoneTimelines);
         end;
       end;
@@ -398,19 +382,6 @@ begin
     Container.AddRoute(Route);
   end;
 
-  for I := 0 to WeightedMeshTimelines.Count - 1 do
-  begin
-    WeightedMeshTimelines[I].BuildNodes(MaxTime, Container);
-    { add animation name to weighted mesh timeline, to make it unique in case
-      we have many animations }
-    WeightedMeshTimelines[I].Node.X3DName := Node.X3DName + '_' +
-      WeightedMeshTimelines[I].Node.X3DName;
-    Route := TX3DRoute.Create;
-    Route.SetSourceDirectly(Node.EventFraction_changed);
-    Route.SetDestinationDirectly(WeightedMeshTimelines[I].Node.EventSet_fraction);
-    Container.AddRoute(Route);
-  end;
-
   for I := 0 to DeformTimelines.Count - 1 do
   begin
     DeformTimelines[I].BuildNodes(MaxTime, Container);
@@ -421,6 +392,19 @@ begin
     Route := TX3DRoute.Create;
     Route.SetSourceDirectly(Node.EventFraction_changed);
     Route.SetDestinationDirectly(DeformTimelines[I].Node.EventSet_fraction);
+    Container.AddRoute(Route);
+  end;
+
+  for I := 0 to WeightedMeshTimelines.Count - 1 do
+  begin
+    WeightedMeshTimelines[I].BuildNodes(MaxTime, Container);
+    { add animation name to weighted mesh timeline, to make it unique in case
+      we have many animations }
+    WeightedMeshTimelines[I].Node.X3DName := Node.X3DName + '_' +
+      WeightedMeshTimelines[I].Node.X3DName;
+    Route := TX3DRoute.Create;
+    Route.SetSourceDirectly(Node.EventFraction_changed);
+    Route.SetDestinationDirectly(WeightedMeshTimelines[I].Node.EventSet_fraction);
     Container.AddRoute(Route);
   end;
 end;

--- a/src/x3d/x3dloadinternalspine_animations.inc
+++ b/src/x3d/x3dloadinternalspine_animations.inc
@@ -22,6 +22,7 @@
     SlotTimelines: TSlotTimelineList;
     DrawOrderTimelines: TDrawOrderTimelineList;
     DeformTimelines: TDeformTimelineList;
+    WeightedMeshTimelines: TWeightedMeshTimelineList;
     Node: TTimeSensorNode;
     NodeUsedAsChild: boolean;
     constructor Create;
@@ -52,6 +53,7 @@ begin
   SlotTimelines := TSlotTimelineList.Create;
   DrawOrderTimelines := TDrawOrderTimelineList.Create;
   DeformTimelines := TDeformTimelineList.Create;
+  WeightedMeshTimelines := TWeightedMeshTimelineList.Create;
 end;
 
 destructor TAnimation.Destroy;
@@ -63,6 +65,7 @@ begin
   FreeAndNil(SlotTimelines);
   FreeAndNil(DrawOrderTimelines);
   FreeAndNil(DeformTimelines);
+  FreeAndNil(WeightedMeshTimelines);
   inherited;
 end;
 
@@ -196,6 +199,79 @@ procedure TAnimation.Parse(const Json: TJSONObject;
     end;
   end;
 
+  { There's no such thing as 'weighted mesh timeline', so we generate weighted
+    mesh timelines by checking to see if a mesh is affect by bones, and that
+    mesh is a weighted mesh or not, then we will calculate vertices affected by
+    those bones }
+  procedure ReadWeightedMeshTimelines;
+  var
+    I, J, K: Integer;
+    Attachment: TAttachment;
+    AffectedBones: TBoneList;
+    AffectedBoneTimelines: TBoneTimelineList;
+    MeshVertex: TMeshVertex;
+    Bone: TBone;
+    BoneTimeline: TBoneTimeline;
+    WeightedMeshTimeline: TWeightedMeshTimeline;
+  begin
+    for I := 0 to CurrentSkin.Attachments.Count - 1 do
+    begin
+      Attachment := CurrentSkin.Attachments[I];
+      // Make sure this attachment is a weighted mesh
+      if (Attachment is TMeshAttachment) and ((Attachment as TMeshAttachment).Weights.Count > 0) then
+      begin
+        AffectedBones := TBoneList.Create;
+        AffectedBoneTimelines := TBoneTimelineList.Create;
+        try
+          AffectedBones.OwnsObjects := False;
+          AffectedBoneTimelines.OwnsObjects := False;
+          // Loop through mesh to get list of affected bones
+          for J := 0 to (Attachment as TMeshAttachment).Weights.Count - 1 do
+          begin
+            MeshVertex := (Attachment as TMeshAttachment).Weights[J];
+            for K := 0 to MeshVertex.Bones.Count - 1 do
+            begin
+              Bone := MeshVertex.Bones[K].Bone;
+              if AffectedBones.FindByName(Bone.Name) = nil then
+              begin
+                AffectedBones.Add(Bone);
+              end
+            end;
+          end;
+          // Now we loop through bone timelines to find those that affect this mesh
+          for J := 0 to BoneTimelines.Count - 1 do
+          begin
+            BoneTimeline := BoneTimelines[J];
+            if AffectedBones.FindByName(BoneTimeline.Bone.Name) <> nil then
+            begin
+              AffectedBoneTimelines.Add(BoneTimeline);
+              // Backup bone timeline properties
+              BoneTimeline.Backup;
+            end;
+          end;
+          // We generate timeline if the number of affected bone timelines > 0
+          if AffectedBoneTimelines.Count > 0 then
+          begin
+            WeightedMeshTimeline := TWeightedMeshTimeline.Create;
+            // TODO: We need a better way to determine this timeline's unique name
+            WeightedMeshTimeline.Name := IntToStr(I);
+            WeightedMeshTimeline.Slots := Slots;
+            WeightedMeshTimeline.Attachment := Attachment as TMeshAttachment;
+            WeightedMeshTimeline.AffectedBoneTimelines := AffectedBoneTimelines;
+            WeightedMeshTimeline.Parse;
+            WeightedMeshTimelines.Add(WeightedMeshTimeline);
+          end;
+          // Restore bone timeline properties
+          for J := 0 to AffectedBoneTimelines.Count - 1 do
+            AffectedBoneTimelines[J].Restore;
+        finally
+          FreeAndNil(AffectedBones);
+          FreeAndNil(AffectedBoneTimelines);
+        end;
+      end;
+    end;
+  end;
+
 var
   I: Integer;
   Bone: TBone;
@@ -240,6 +316,8 @@ begin
         if ChildObj.Items[I] is TJSONObject then
           ReadDeformTimelines(ChildObj.Names[I], TJSONObject(ChildObj.Items[I]), Slots);
   end;
+
+  ReadWeightedMeshTimelines;
 end;
 
 procedure TAnimation.BuildNodes(const BaseUrl: string;
@@ -317,6 +395,19 @@ begin
     Route := TX3DRoute.Create;
     Route.SetSourceDirectly(Node.EventFraction_changed);
     Route.SetDestinationDirectly(DrawOrderTimelines[I].Node.EventSet_fraction);
+    Container.AddRoute(Route);
+  end;
+
+  for I := 0 to WeightedMeshTimelines.Count - 1 do
+  begin
+    WeightedMeshTimelines[I].BuildNodes(MaxTime, Container);
+    { add animation name to weighted mesh timeline, to make it unique in case
+      we have many animations }
+    WeightedMeshTimelines[I].Node.X3DName := Node.X3DName + '_' +
+      WeightedMeshTimelines[I].Node.X3DName;
+    Route := TX3DRoute.Create;
+    Route.SetSourceDirectly(Node.EventFraction_changed);
+    Route.SetDestinationDirectly(WeightedMeshTimelines[I].Node.EventSet_fraction);
     Container.AddRoute(Route);
   end;
 

--- a/src/x3d/x3dloadinternalspine_attachments.inc
+++ b/src/x3d/x3dloadinternalspine_attachments.inc
@@ -510,9 +510,9 @@ begin
   inherited;
 
   // TODO: Is this still useful?
-  //List := Coord.FdPoint.Items;
-  //for I := 0 to List.Count - 1 do
-  //  List.List^[I] := Bone.ToLocalSpace(List.List^[I]);
+  List := Coord.FdPoint.Items;
+  for I := 0 to List.Count - 1 do
+    List.List^[I] := Bone.ToLocalSpace(List.List^[I]);
 end;
 
 { TPathAttachment ---------------------------------------------------------- }

--- a/src/x3d/x3dloadinternalspine_attachments.inc
+++ b/src/x3d/x3dloadinternalspine_attachments.inc
@@ -432,6 +432,7 @@ var
   BonesCount: Cardinal;
   V: TMeshVertex;
   I: Integer;
+  Offset: Integer = 0;
 begin
   I := 0;
   while I < JsonArray.Count do
@@ -443,7 +444,8 @@ begin
         WritelnWarning('Spine', 'Mesh bonesCount is <= 0');
       V := TMeshVertex.Create;
       V.Parse(JsonArray, I + 1, BonesCount, Bones);
-      V.Offset := I;
+      V.Offset := Offset;
+      Offset := Offset + BonesCount * 2;
       Add(V);
     end else
     begin

--- a/src/x3d/x3dloadinternalspine_attachments.inc
+++ b/src/x3d/x3dloadinternalspine_attachments.inc
@@ -102,6 +102,9 @@
     constructor Create;
     destructor Destroy; override;
     procedure Parse(const Json: TJSONObject; const Bones: TBoneList); override;
+  end;
+
+  TSkinnedMeshAttachment = class(TMeshAttachment)
     procedure TransformToBoneSpace(const Bone: TBone); override;
   end;
 
@@ -168,6 +171,14 @@ begin
   if TypeName = 'clipping' then
   begin
     Result := TClippingAttachment.Create;
+    Result.SlotName := ASlotName;
+    Result.AttachmentName := AnAttachmentName;
+    Result.Parse(Json, Bones);
+  end else
+  if TypeName = 'skinnedmesh' then
+  begin
+    WritelnWarning('Spine', 'Region type skinnedmesh may not be supported in future CGE versions, please export your model again from latest Spine version');
+    Result := TSkinnedMeshAttachment.Create;
     Result.SlotName := ASlotName;
     Result.AttachmentName := AnAttachmentName;
     Result.Parse(Json, Bones);
@@ -415,7 +426,7 @@ begin
   begin
     BoneIndex := JsonArray[Index].AsInteger; Inc(Index);
     if not Between(BoneIndex, 0, AllBones.Count - 1) then
-      raise Exception.CreateFmt('Invalid bone index in Mesh.vertices: %d', [BoneIndex]);
+      raise Exception.CreateFmt('Invalid bone index in mesh.vertices: %d', [BoneIndex]);
     B := TMeshVertexBone.Create;
     Bones.Add(B);
     B.Bone := AllBones[BoneIndex];
@@ -441,7 +452,7 @@ begin
     if I + BonesCount * 4 < JsonArray.Count then
     begin
       if BonesCount = 0 then
-        WritelnWarning('Spine', 'Mesh bonesCount is <= 0');
+        WritelnWarning('Spine', 'mesh bonesCount is <= 0');
       V := TMeshVertex.Create;
       V.Parse(JsonArray, I + 1, BonesCount, Bones);
       V.Offset := Offset;
@@ -449,7 +460,7 @@ begin
       Add(V);
     end else
     begin
-      WritelnWarning('Spine', Format('Mesh weights (called "vertices" in JSON) do not have enough items (last bonesCount = %d, but array does not have enough floats)',
+      WritelnWarning('Spine', Format('mesh weights (called "vertices" in JSON) do not have enough items (last bonesCount = %d, but array does not have enough floats)',
         [BonesCount]));
       Break;
     end;
@@ -504,14 +515,16 @@ begin
   end;
 end;
 
-procedure TMeshAttachment.TransformToBoneSpace(const Bone: TBone);
+
+{ TSkinnedMeshAttachment --------------------------------------------------- }
+
+procedure TSkinnedMeshAttachment.TransformToBoneSpace(const Bone: TBone);
 var
   List: TVector3List;
   I: Integer;
 begin
   inherited;
 
-  // TODO: Is this still useful?
   List := Coord.FdPoint.Items;
   for I := 0 to List.Count - 1 do
     List.List^[I] := Bone.ToLocalSpace(List.List^[I]);

--- a/src/x3d/x3dloadinternalspine_attachments.inc
+++ b/src/x3d/x3dloadinternalspine_attachments.inc
@@ -77,31 +77,28 @@
       const TexRotated: boolean): TAbstractGeometryNode; override;
   end;
 
-  TMeshAttachment = class(TAbstractMeshAttachment)
-    procedure Parse(const Json: TJSONObject; const Bones: TBoneList); override;
-  end;
-
-  TSkinnedMeshVertexBone = class
+  TMeshVertexBone = class
     Bone: TBone;
     V: TVector2; //< vertex position in local Bone coordinate system
     Weight: Single;
   end;
-  TSkinnedMeshVertexBoneList = {$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TSkinnedMeshVertexBone>;
+  TMeshVertexBoneList = {$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TMeshVertexBone>;
 
-  TSkinnedMeshVertex = class
-    Bones: TSkinnedMeshVertexBoneList;
+  TMeshVertex = class
+    Offset: Integer; // Offset relative to where this Vertex is loaded from the list
+    Bones: TMeshVertexBoneList;
     constructor Create;
     destructor Destroy; override;
     procedure Parse(const JsonArray: TJSONArray;
       Index: Integer; const BonesCount: Cardinal; const AllBones: TBoneList);
   end;
 
-  TSkinnedMeshVertexList = class({$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TSkinnedMeshVertex>)
+  TMeshVertexList = class({$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TMeshVertex>)
     procedure Parse(const JsonArray: TJSONArray; const Bones: TBoneList);
   end;
 
-  TSkinnedMeshAttachment = class(TAbstractMeshAttachment)
-    Weights: TSkinnedMeshVertexList;
+  TMeshAttachment = class(TAbstractMeshAttachment)
+    Weights: TMeshVertexList;
     constructor Create;
     destructor Destroy; override;
     procedure Parse(const Json: TJSONObject; const Bones: TBoneList); override;
@@ -147,15 +144,6 @@ begin
   if TypeName = 'mesh' then
   begin
     Result := TMeshAttachment.Create;
-    Result.SlotName := ASlotName;
-    Result.AttachmentName := AnAttachmentName;
-    Result.Parse(Json, Bones);
-  end else
-  if TypeName = 'skinnedmesh' then
-  begin
-    WritelnWarning('Spine', Format('Spine region type "skinnedmesh" is for now not deformed during animation, for attachment "%s"',
-      [AnAttachmentName]));
-    Result := TSkinnedMeshAttachment.Create;
     Result.SlotName := ASlotName;
     Result.AttachmentName := AnAttachmentName;
     Result.Parse(Json, Bones);
@@ -403,50 +391,32 @@ end;
 
 { TMeshAttachment ------------------------------------------------------------ }
 
-procedure TMeshAttachment.Parse(const Json: TJSONObject; const Bones: TBoneList);
+{ TMeshVertex --------------------------------------------------------- }
+
+constructor TMeshVertex.Create;
 begin
   inherited;
-  ReadVector2List(Json, 'vertices', Vertices);
-
-  if Vertices.Count > UVs.Count then
-  begin
-    WritelnWarning('Spine', 'A weighted mesh (when the number of vertices > number of uvs) is not supported');
-    Invalid := true;
-  end else
-  if UVs.Count <> Vertices.Count then
-  begin
-    WritelnWarning('Spine', Format('uvs and vertices lists have different number of items, respectively %d and %d, for mesh attachment %s',
-      [UVs.Count, Vertices.Count, Name]));
-    Invalid := true;
-  end;
+  Bones := TMeshVertexBoneList.Create;
 end;
 
-{ TSkinnedMeshVertex --------------------------------------------------------- }
-
-constructor TSkinnedMeshVertex.Create;
-begin
-  inherited;
-  Bones := TSkinnedMeshVertexBoneList.Create;
-end;
-
-destructor TSkinnedMeshVertex.Destroy;
+destructor TMeshVertex.Destroy;
 begin
   FreeAndNil(Bones);
   inherited;
 end;
 
-procedure TSkinnedMeshVertex.Parse(const JsonArray: TJSONArray;
+procedure TMeshVertex.Parse(const JsonArray: TJSONArray;
   Index: Integer; const BonesCount: Cardinal; const AllBones: TBoneList);
 var
   I, BoneIndex: Integer;
-  B: TSkinnedMeshVertexBone;
+  B: TMeshVertexBone;
 begin
   for I := 0 to Integer(BonesCount) - 1 do
   begin
     BoneIndex := JsonArray[Index].AsInteger; Inc(Index);
     if not Between(BoneIndex, 0, AllBones.Count - 1) then
-      raise Exception.CreateFmt('Invalid bone index in skinnedmesh.vertices: %d', [BoneIndex]);
-    B := TSkinnedMeshVertexBone.Create;
+      raise Exception.CreateFmt('Invalid bone index in Mesh.vertices: %d', [BoneIndex]);
+    B := TMeshVertexBone.Create;
     Bones.Add(B);
     B.Bone := AllBones[BoneIndex];
     B.V[0] := JsonArray[Index].AsFloat; Inc(Index);
@@ -455,12 +425,12 @@ begin
   end;
 end;
 
-{ TSkinnedMeshVertexList ----------------------------------------------------- }
+{ TMeshVertexList ----------------------------------------------------- }
 
-procedure TSkinnedMeshVertexList.Parse(const JsonArray: TJSONArray; const Bones: TBoneList);
+procedure TMeshVertexList.Parse(const JsonArray: TJSONArray; const Bones: TBoneList);
 var
   BonesCount: Cardinal;
-  V: TSkinnedMeshVertex;
+  V: TMeshVertex;
   I: Integer;
 begin
   I := 0;
@@ -470,13 +440,14 @@ begin
     if I + BonesCount * 4 < JsonArray.Count then
     begin
       if BonesCount = 0 then
-        WritelnWarning('Spine', 'skinnedmesh bonesCount is <= 0');
-      V := TSkinnedMeshVertex.Create;
+        WritelnWarning('Spine', 'Mesh bonesCount is <= 0');
+      V := TMeshVertex.Create;
       V.Parse(JsonArray, I + 1, BonesCount, Bones);
+      V.Offset := I;
       Add(V);
     end else
     begin
-      WritelnWarning('Spine', Format('skinnedmesh weights (called "vertices" in JSON) do not have enough items (last bonesCount = %d, but array does not have enough floats)',
+      WritelnWarning('Spine', Format('Mesh weights (called "vertices" in JSON) do not have enough items (last bonesCount = %d, but array does not have enough floats)',
         [BonesCount]));
       Break;
     end;
@@ -485,55 +456,53 @@ begin
   end;
 end;
 
-{ TSkinnedMeshAttachment ----------------------------------------------------- }
+{ TMeshAttachment ----------------------------------------------------- }
 
-constructor TSkinnedMeshAttachment.Create;
+constructor TMeshAttachment.Create;
 begin
   inherited;
-  Weights := TSkinnedMeshVertexList.Create;
+  Weights := TMeshVertexList.Create;
 end;
 
-destructor TSkinnedMeshAttachment.Destroy;
+destructor TMeshAttachment.Destroy;
 begin
   FreeAndNil(Weights);
   inherited;
 end;
 
-procedure TSkinnedMeshAttachment.Parse(const Json: TJSONObject; const Bones: TBoneList);
+procedure TMeshAttachment.Parse(const Json: TJSONObject; const Bones: TBoneList);
 var
   JsonArray: TJSONArray;
   I, J: Integer;
-  VB: TSkinnedMeshVertexBone;
+  VB: TMeshVertexBone;
   V: TVector2;
 begin
   inherited;
-  JsonArray := Json.Find('vertices', jtArray) as TJSONArray;
-  if JsonArray <> nil then
-    Weights.Parse(JsonArray, Bones);
+  ReadVector2List(Json, 'vertices', Vertices);
 
-  if UVs.Count <> Weights.Count then
+  if Vertices.Count > UVs.Count then
   begin
-    WritelnWarning('Spine', Format('skinnedmesh weights (called "vertices" in JSON) and uvs have different number of items, respectively %d and %d, for skinnedmesh attachment %s',
-      [UVs.Count, Vertices.Count, Name]));
-    Exit;
-  end;
-
-  { calculate initial Vertices from Weights.
-    Similar to ComputeWorldVertices in spine-runtimes/spine-csharp/src/Attachments/SkinnedMeshAttachment.cs }
-  Vertices.Count := Weights.Count;
-  for I := 0 to Weights.Count - 1 do
-  begin
-    V := TVector2.Zero;
-    for J := 0 to Weights[I].Bones.Count - 1 do
+    Vertices.Clear;
+    JsonArray := Json.Find('vertices', jtArray) as TJSONArray;
+    if JsonArray <> nil then
+      Weights.Parse(JsonArray, Bones);
+    { calculate initial Vertices from Weights.
+      Similar to ComputeWorldVertices in spine-runtimes/spine-csharp/src/Attachments/SkinnedMeshAttachment.cs }
+    Vertices.Count := Weights.Count;
+    for I := 0 to Weights.Count - 1 do
     begin
-      VB := Weights[I].Bones[J];
-      V := V + (VB.Bone.ToWorldSpace(VB.V) * VB.Weight);
+      V := TVector2.Zero;
+      for J := 0 to Weights[I].Bones.Count - 1 do
+      begin
+        VB := Weights[I].Bones[J];
+        V := V + (VB.Bone.ToWorldSpace(VB.V) * VB.Weight);
+      end;
+      Vertices[I] := V;
     end;
-    Vertices[I] := V;
   end;
 end;
 
-procedure TSkinnedMeshAttachment.TransformToBoneSpace(const Bone: TBone);
+procedure TMeshAttachment.TransformToBoneSpace(const Bone: TBone);
 var
   List: TVector3List;
   I: Integer;

--- a/src/x3d/x3dloadinternalspine_attachments.inc
+++ b/src/x3d/x3dloadinternalspine_attachments.inc
@@ -509,9 +509,10 @@ var
 begin
   inherited;
 
-  List := Coord.FdPoint.Items;
-  for I := 0 to List.Count - 1 do
-    List.List^[I] := Bone.ToLocalSpace(List.List^[I]);
+  // TODO: Is this still useful?
+  //List := Coord.FdPoint.Items;
+  //for I := 0 to List.Count - 1 do
+  //  List.List^[I] := Bone.ToLocalSpace(List.List^[I]);
 end;
 
 { TPathAttachment ---------------------------------------------------------- }

--- a/src/x3d/x3dloadinternalspine_bones.inc
+++ b/src/x3d/x3dloadinternalspine_bones.inc
@@ -26,11 +26,10 @@
     WorldRotation: Single;
     WorldMatrix, WorldMatrixInverse: TMatrix2;
     { @groupEnd }
-
-    { Calculate world-space (well, at least in the space of whole JSON file)
-      bone parameters.
-      Similar to UpdateWorldTransform in spine-runtimes/spine-csharp/src/Bone.cs }
-    procedure UpdateWorldTransform;
+    BackupXY: TVector2;
+    BackupScale: TVector2;
+    BackupRotation: Single;
+    IsBackup: Boolean;
   public
     Name: string;
     Length: Single;
@@ -48,12 +47,23 @@
     function ToWorldSpace(const V: TVector2): TVector2;
     function ToLocalSpace(V: TVector2): TVector2; overload;
     function ToLocalSpace(const V: TVector3): TVector3; overload;
+    { Calculate world-space (well, at least in the space of whole JSON file)
+      bone parameters.
+      Similar to UpdateWorldTransform in spine-runtimes/spine-csharp/src/Bone.cs }
+    procedure UpdateWorldTransform;
+    { Backup bone's position, rotation and scale values }
+    procedure Backup;
+    { Restore bone's position, rotation and scale values }
+    procedure Restore;
   end;
 
   TBoneList = class({$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TBone>)
     { Find bone by name.
       @raises ESpineReadError If bone does not exist. }
     function Find(const BoneName: string): TBone;
+    { Find bone by name.
+      @return nil if bone does not exist. }
+    function FindByName(const BoneName: string): TBone;
     procedure Parse(const Json: TJSONObject; var Root: TBone;
       const DragonBonesFormat: boolean);
     procedure BuildNodes(const BaseUrl: string);
@@ -197,6 +207,28 @@ begin
   Result2 := ToLocalSpace(Result2);
 end;
 
+procedure TBone.Backup;
+begin
+  if not IsBackup then
+  begin
+    BackupXY := XY;
+    BackupRotation := Rotation;
+    BackupScale := Scale;
+    IsBackup := True;
+  end;
+end;
+
+procedure TBone.Restore;
+begin
+  if IsBackup then
+  begin
+    XY := BackupXY;
+    Rotation := BackupRotation;
+    Scale := BackupScale;
+    IsBackup := False;
+  end;
+end;
+
 { TBoneList ------------------------------------------------------------------ }
 
 function TBoneList.Find(const BoneName: string): TBone;
@@ -207,6 +239,16 @@ begin
     if Items[I].Name = BoneName then
       Exit(Items[I]);
   raise ESpineReadError.CreateFmt('Bone name "%s" not found', [BoneName]);
+end;
+
+function TBoneList.FindByName(const BoneName: string): TBone;
+var
+  I: Integer;
+begin
+  for I := 0 to Count - 1 do
+    if Items[I].Name = BoneName then
+      Exit(Items[I]);
+  Exit(nil);
 end;
 
 procedure TBoneList.Parse(const Json: TJSONObject; var Root: TBone; const DragonBonesFormat: boolean);

--- a/src/x3d/x3dloadinternalspine_bonetimelines.inc
+++ b/src/x3d/x3dloadinternalspine_bonetimelines.inc
@@ -19,6 +19,9 @@
   TBoneTimeline = class abstract
   strict private
     FMaxTime: Single;
+  protected
+    BackupTime: TSingleList;
+    IsBackup: Boolean;
   public
     Bone: TBone;
     Time: TSingleList;
@@ -34,14 +37,21 @@
     procedure BuildNodes(const BaseUrl: string;
       const MaxAnimationTime: Single; const Container: TX3DRootNode); virtual;
     function DoingSomething: boolean; virtual; abstract;
+    procedure Backup; virtual;
+    procedure Restore; virtual;
   end;
 
   TBoneTimelineVector2 = class(TBoneTimeline)
+  strict private
+    BackupVectors: TVector2List;
+  public
     { Position or scale values on the timeline.
       This always has the same length as @link(Time) list. }
     Vectors: TVector2List;
     constructor Create;
     destructor Destroy; override;
+    procedure Backup; override;
+    procedure Restore; override;
   end;
 
   TBoneTimelineTranslate = class(TBoneTimelineVector2)
@@ -59,6 +69,9 @@
   end;
 
   TBoneTimelineRotate = class(TBoneTimeline)
+  strict private
+    BackupAngles: TSingleList;
+  public
     { Angle values on the timeline.
       This always has the same length as @link(Time) list. }
     Angles: TSingleList;
@@ -68,6 +81,8 @@
     procedure BuildNodes(const BaseUrl: string;
       const MaxAnimationTime: Single; const Container: TX3DRootNode); override;
     function DoingSomething: boolean; override;
+    procedure Backup; override;
+    procedure Restore; override;
   end;
 
   TBoneTimelineList = class({$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TBoneTimeline>)
@@ -86,12 +101,14 @@ constructor TBoneTimeline.Create;
 begin
   inherited;
   Time := TSingleList.Create;
+  BackupTime := TSingleList.Create;
   CurveControlPoints := TVector4List.Create;
 end;
 
 destructor TBoneTimeline.Destroy;
 begin
   FreeAndNil(Time);
+  FreeAndNil(BackupTime);
   FreeAndNil(CurveControlPoints);
   inherited;
 end;
@@ -165,18 +182,52 @@ begin
   Container.AddChildren(Node);
 end;
 
+procedure TBoneTimeline.Backup;
+begin
+end;
+
+procedure TBoneTimeline.Restore;
+begin
+end;
+
 { TBoneTimelineVector2 ------------------------------------------------------- }
 
 constructor TBoneTimelineVector2.Create;
 begin
   inherited Create;
   Vectors := TVector2List.Create;
+  BackupVectors := TVector2List.Create;
 end;
 
 destructor TBoneTimelineVector2.Destroy;
 begin
   FreeAndNil(Vectors);
+  FreeAndNil(BackupVectors);
   inherited;
+end;
+
+procedure TBoneTimelineVector2.Backup;
+begin
+  if not IsBackup then
+  begin
+    BackupTime.Clear;
+    BackupVectors.Clear;
+    BackupTime.AddRange(Time);
+    BackupVectors.AddRange(Vectors);
+    IsBackup := True;
+  end;
+end;
+
+procedure TBoneTimelineVector2.Restore;
+begin
+  if IsBackup then
+  begin
+    Time.Clear;
+    Vectors.Clear;
+    Time.AddRange(BackupTime);
+    Vectors.AddRange(BackupVectors);
+    IsBackup := False;
+  end;
 end;
 
 { TBoneTimelineTranslate ----------------------------------------------------- }
@@ -333,11 +384,13 @@ constructor TBoneTimelineRotate.Create;
 begin
   inherited;
   Angles := TSingleList.Create;
+  BackupAngles := TSingleList.Create;
 end;
 
 destructor TBoneTimelineRotate.Destroy;
 begin
   FreeAndNil(Angles);
+  FreeAndNil(BackupAngles);
   inherited;
 end;
 
@@ -435,6 +488,30 @@ begin
     if Angles[I] <> 0 then
       Exit(true);
   Result := false;
+end;
+
+procedure TBoneTimelineRotate.Backup;
+begin
+  if not IsBackup then
+  begin
+    BackupTime.Clear;
+    BackupAngles.Clear;
+    BackupTime.AddRange(Time);
+    BackupAngles.AddRange(Angles);
+    IsBackup := True;
+  end;
+end;
+
+procedure TBoneTimelineRotate.Restore;
+begin
+  if IsBackup then
+  begin
+    Time.Clear;
+    Angles.Clear;
+    Time.AddRange(BackupTime);
+    Angles.AddRange(BackupAngles);
+    IsBackup := False;
+  end;
 end;
 
 {$endif}

--- a/src/x3d/x3dloadinternalspine_bonetimelines.inc
+++ b/src/x3d/x3dloadinternalspine_bonetimelines.inc
@@ -20,11 +20,11 @@
   strict private
     FMaxTime: Single;
   protected
-    BackupTime: TSingleList;
     IsBackup: Boolean;
   public
     Bone: TBone;
     Time: TSingleList;
+    BackupTime: TSingleList;
     Curve: boolean;
     CurveControlPoints: TVector4List;
     Node: TAbstractInterpolatorNode;
@@ -42,12 +42,11 @@
   end;
 
   TBoneTimelineVector2 = class(TBoneTimeline)
-  strict private
-    BackupVectors: TVector2List;
   public
     { Position or scale values on the timeline.
       This always has the same length as @link(Time) list. }
     Vectors: TVector2List;
+    BackupVectors: TVector2List;
     constructor Create;
     destructor Destroy; override;
     procedure Backup; override;
@@ -69,12 +68,10 @@
   end;
 
   TBoneTimelineRotate = class(TBoneTimeline)
-  strict private
-    BackupAngles: TSingleList;
-  public
     { Angle values on the timeline.
       This always has the same length as @link(Time) list. }
     Angles: TSingleList;
+    BackupAngles: TSingleList;
     constructor Create;
     destructor Destroy; override;
     procedure ParseSingleValue(const Json: TJSONObject); override;

--- a/src/x3d/x3dloadinternalspine_deformtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_deformtimelines.inc
@@ -134,13 +134,15 @@ begin
     end else
     // Things are a bit different for weighted mesh
     begin
+      VertexList.Count := Attachment.Weights[Attachment.Weights.Count - 1].Offset
+          + Attachment.Weights[Attachment.Weights.Count - 1].Bones.Count * 2;
       for J := 0 to Attachment.Weights.Count - 1 do
       begin
         for K := 0 to Attachment.Weights[J].Bones.Count - 1 do
         begin
           VB := Attachment.Weights[J].Bones[K];
-          VertexList.Add(VB.V.X);
-          VertexList.Add(VB.V.Y);
+          VertexList[Attachment.Weights[J].Offset + K * 2    ] := VB.V.X;
+          VertexList[Attachment.Weights[J].Offset + K * 2 + 1] := VB.V.Y;
         end;
       end;
     end;

--- a/src/x3d/x3dloadinternalspine_deformtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_deformtimelines.inc
@@ -22,13 +22,18 @@
   TDeformTimeline = class
   strict private
     FMaxTime: Single;
+    IsBackup: Boolean;
   public
     { If this is true, then we will ignore this deform during building node }
     IsHandledByWeightedMeshTimeline: Boolean;
     Slot: TSlot;
     Attachment: TMeshAttachment;
     Time: TSingleList;
+    BackupTime: TSingleList;
     Vertices: TDeformVertexList;
+    BackupVertices: TDeformVertexList;
+    Curve: Boolean;
+    CurveControlPoints: TVector4List;
     Node: TCoordinateInterpolatorNode;
     NodeUsedAsChild: Boolean;
     constructor Create;
@@ -36,6 +41,8 @@
     procedure Parse(const Json: TJSONArray);
     procedure BuildNodes(const MaxAnimationTime: Single; const Container: TX3DRootNode);
     property MaxTime: Single read FMaxTime;
+    procedure Backup;
+    procedure Restore;
   end;
 
   TDeformTimelineList = class({$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TDeformTimeline>)
@@ -48,13 +55,20 @@ constructor TDeformTimeline.Create;
 begin
   inherited;
   Time := TSingleList.Create;
-  Vertices := TDeformVertexList.Create(true);
+  BackupTime := TSingleList.Create;
+  Vertices := TDeformVertexList.Create(True);
+  BackupVertices := TDeformVertexList.Create(False);
+  CurveControlPoints := TVector4List.Create;
+  Curve := False;
 end;
 
 destructor TDeformTimeline.Destroy;
 begin
   FreeAndNil(Time);
+  FreeAndNil(BackupTime);
   FreeAndNil(Vertices);
+  FreeAndNil(BackupVertices);
+  FreeAndNil(CurveControlPoints);
   inherited;
 end;
 
@@ -67,18 +81,34 @@ var
   VertexList: TSingleList;
   Offset: Integer;
   VB: TMeshVertexBone;
+  ControlPoints: TVector4;
 begin
   for I := 0 to Json.Count - 1 do
   begin
     Obj := Json.Items[I] as TJSONObject;
     Time.Add(Obj.Get('time', 0.0));
     Offset := Obj.Get('offset', 0);
-    { TODO: Take care of 'curve' field once we implement CubicBezier version of
-      TCoordinateInterpolatorNode }
+    ControlPoints := Vector4(0, 0, 1, 1);
     CurveJson := Obj.Find('curve');
     if CurveJson <> nil then
+    begin
       if CurveJson is TJSONArray then
-        WritelnWarning('Spine', 'Deform timeline''s "curve" field is not supported');
+      begin
+        { TODO: Take care of 'curve' field once we implement CubicBezier version of
+          TCoordinateInterpolatorNode }
+        if Attachment.Weights.Count = 0 then
+          WritelnWarning('Spine', 'Deform timeline''s "curve" field is not supported for non-weighted mesh');
+        if TJSONArray(CurveJson).Count <> 4 then
+          WritelnWarning('Spine', 'Curve type interpolation is an array, but does not have 4 elements (required for Bezier curve array)') else
+        Curve := True;
+        ControlPoints[0] := TJSONArray(CurveJson).Floats[0];
+        ControlPoints[1] := TJSONArray(CurveJson).Floats[1];
+        ControlPoints[2] := TJSONArray(CurveJson).Floats[2];
+        ControlPoints[3] := TJSONArray(CurveJson).Floats[3];
+      end;
+    end;
+    CurveControlPoints.Add(ControlPoints);
+
     VertexJsonArray := Obj.Get('vertices', TJSONArray(nil));
     VertexList := TSingleList.Create;
 
@@ -152,6 +182,30 @@ begin
   Route.SetSourceDirectly(Node.EventValue_changed);
   Route.SetDestinationDirectly(Attachment.Coord.FdPoint.EventIn);
   Container.AddRoute(Route);
+end;
+
+procedure TDeformTimeline.Backup;
+begin
+  if not IsBackup then
+  begin
+    BackupTime.Clear;
+    BackupVertices.Clear;
+    BackupTime.AddRange(Time);
+    BackupVertices.AddRange(Vertices);
+    IsBackup := True;
+  end;
+end;
+
+procedure TDeformTimeline.Restore;
+begin
+  if IsBackup then
+  begin
+    Time.Clear;
+    Vertices.Clear;
+    Time.AddRange(BackupTime);
+    Vertices.AddRange(BackupVertices);
+    IsBackup := False;
+  end;
 end;
 
 {$endif}

--- a/src/x3d/x3dloadinternalspine_deformtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_deformtimelines.inc
@@ -23,6 +23,8 @@
   strict private
     FMaxTime: Single;
   public
+    { If this is true, then we will ignore this deform during building node }
+    IsHandledByWeightedMeshTimeline: Boolean;
     Slot: TSlot;
     Attachment: TMeshAttachment;
     Time: TSingleList;
@@ -58,12 +60,13 @@ end;
 
 procedure TDeformTimeline.Parse(const Json: TJSONArray);
 var
-  I, J: Integer;
+  I, J, K: Integer;
   Obj: TJSONObject;
   CurveJson: TJSONData;
   VertexJsonArray: TJSONArray;
   VertexList: TSingleList;
   Offset: Integer;
+  VB: TMeshVertexBone;
 begin
   for I := 0 to Json.Count - 1 do
   begin
@@ -89,12 +92,27 @@ begin
       (see https://github.com/castle-engine/demo-models/tree/master/spine/free_form_deformation
       for demo).
     }
-
-    VertexList.Count := Attachment.Vertices.Count * 2;
-    for J := 0 to Attachment.Vertices.Count - 1 do
+    if Attachment.Weights.Count = 0 then
+    // For mesh without weights
     begin
-      VertexList[J * 2    ] := Attachment.Vertices[J].X;
-      VertexList[J * 2 + 1] := Attachment.Vertices[J].Y;
+      VertexList.Count := Attachment.Vertices.Count * 2;
+      for J := 0 to Attachment.Vertices.Count - 1 do
+      begin
+        VertexList[J * 2    ] := Attachment.Vertices[J].X;
+        VertexList[J * 2 + 1] := Attachment.Vertices[J].Y;
+      end;
+    end else
+    // Things are a bit different for weighted mesh
+    begin
+      for J := 0 to Attachment.Weights.Count - 1 do
+      begin
+        for K := 0 to Attachment.Weights[J].Bones.Count - 1 do
+        begin
+          VB := Attachment.Weights[J].Bones[K];
+          VertexList.Add(VB.V.X);
+          VertexList.Add(VB.V.Y);
+        end;
+      end;
     end;
 
     if VertexJsonArray <> nil then

--- a/src/x3d/x3dloadinternalspine_json.inc
+++ b/src/x3d/x3dloadinternalspine_json.inc
@@ -43,7 +43,7 @@ begin
         end;
       end;
     if Vec2Index <> 0 then
-      WritelnWarning('Spine', 'Vector2 list (like uvs or vertices) ends in the middle of the vector. This is possible in case of (unsupported now) weighted mesh.');
+      WritelnWarning('Spine', 'Vector2 list (like uvs or vertices) ends in the middle of the vector. This is possible in case of weighted mesh.');
   end;
 end;
 

--- a/src/x3d/x3dloadinternalspine_slots.inc
+++ b/src/x3d/x3dloadinternalspine_slots.inc
@@ -103,6 +103,9 @@ end;
 
 procedure TSlot.BuildNodes(const BaseUrl: string;
   const AttachmentsPreferred, AttachmentsDefault: TAttachmentList);
+var
+  IsWeightedMeshAttachmentExisted: Boolean = False;
+  IsOtherAttachmentExisted: Boolean = False;
 
   { Node for a single AttachmentName. Never @nil. }
   function AttachmentNode(const AttachmentName: string): TAbstractChildNode;
@@ -136,10 +139,14 @@ procedure TSlot.BuildNodes(const BaseUrl: string;
           including bone transformation, we need to move this mesh to root bone. }
         if (A is TMeshAttachment) and ((A as TMeshAttachment).Weights.Count > 0) then
         begin
+          IsWeightedMeshAttachmentExisted := True;
           while Bone.Parent <> nil do
           begin
             Bone := Bone.Parent;
           end;
+        end else
+        begin
+          IsOtherAttachmentExisted := True;
         end;
 
         // TODO: Is this still useful?
@@ -181,6 +188,8 @@ begin
 
   for I := 0 to AttachmentNames.Count - 1 do
     SwitchNode.AddChildren(AttachmentNode(AttachmentNames[I]));
+  if IsWeightedMeshAttachmentExisted and IsOtherAttachmentExisted then
+    WritelnWarning('Spine', 'Weighted mesh attachment alongside with other types of attachment in the same slot is not supported');
   Bone.Node.AddChildren(Node);
 end;
 

--- a/src/x3d/x3dloadinternalspine_slots.inc
+++ b/src/x3d/x3dloadinternalspine_slots.inc
@@ -107,7 +107,7 @@ procedure TSlot.BuildNodes(const BaseUrl: string;
   { Node for a single AttachmentName. Never @nil. }
   function AttachmentNode(const AttachmentName: string): TAbstractChildNode;
   var
-    A: TAttachment;
+    A: TAttachment;k:integer;
   begin
     Result := nil;
 
@@ -131,6 +131,18 @@ procedure TSlot.BuildNodes(const BaseUrl: string;
             [A.Node.X3DName]);
         end;
 
+        // TODO: This is a hackjob and need a better way to handle this issue.
+        // If attachment is a weighted mesh, we will "push" it to global by finding
+        // the root bone and use that bone for this attachment instead.
+        if (A is TMeshAttachment) and ((A as TMeshAttachment).Weights.Count > 0) then
+        begin
+          while Bone.Parent <> nil do
+          begin
+            Bone := Bone.Parent;
+          end;
+        end;
+
+        // TODO: Is this still useful?
         A.TransformToBoneSpace(Bone); // transform skinnedmesh into local space
         A.NodeUsedAsChild := true;
         Result := A.Node;
@@ -159,7 +171,6 @@ var
 begin
   Node := TTransformNode.Create('SlotTransform_' + Name, BaseUrl);
   Node.FdTranslation.Value := Vector3(0, 0, DrawOrder * DrawOrderZ);
-  Bone.Node.AddChildren(Node);
   NodeUsedAsChild := true;
 
   SwitchNode := TSwitchNode.Create('SlotSwitch_' + Name, BaseUrl);
@@ -170,6 +181,7 @@ begin
 
   for I := 0 to AttachmentNames.Count - 1 do
     SwitchNode.AddChildren(AttachmentNode(AttachmentNames[I]));
+  Bone.Node.AddChildren(Node);
 end;
 
 { TSlotList ------------------------------------------------------------------ }

--- a/src/x3d/x3dloadinternalspine_slots.inc
+++ b/src/x3d/x3dloadinternalspine_slots.inc
@@ -107,7 +107,7 @@ procedure TSlot.BuildNodes(const BaseUrl: string;
   { Node for a single AttachmentName. Never @nil. }
   function AttachmentNode(const AttachmentName: string): TAbstractChildNode;
   var
-    A: TAttachment;k:integer;
+    A: TAttachment;
   begin
     Result := nil;
 
@@ -131,9 +131,9 @@ procedure TSlot.BuildNodes(const BaseUrl: string;
             [A.Node.X3DName]);
         end;
 
-        // TODO: This is a hackjob and need a better way to handle this issue.
-        // If attachment is a weighted mesh, we will "push" it to global by finding
-        // the root bone and use that bone for this attachment instead.
+        { TODO: This is a hackjob and need a better way to handle this issue.
+          Since we "baked" mesh transformation into TCoordinateInterpolatorNode,
+          including bone transformation, we need to move this mesh to root bone. }
         if (A is TMeshAttachment) and ((A as TMeshAttachment).Weights.Count > 0) then
         begin
           while Bone.Parent <> nil do

--- a/src/x3d/x3dloadinternalspine_slots.inc
+++ b/src/x3d/x3dloadinternalspine_slots.inc
@@ -149,8 +149,10 @@ var
           IsOtherAttachmentExisted := True;
         end;
 
-        // TODO: Is this still useful?
-        // A.TransformToBoneSpace(Bone); // transform skinnedmesh into local space
+        { Transform skinnedmesh into local space.
+          Note that the new weighted mesh baked transformations directly into
+          TCoordinateInterpolatorNode so this is not necessary for weighted mesh. }
+        A.TransformToBoneSpace(Bone);
         A.NodeUsedAsChild := true;
         Result := A.Node;
 

--- a/src/x3d/x3dloadinternalspine_slots.inc
+++ b/src/x3d/x3dloadinternalspine_slots.inc
@@ -143,7 +143,7 @@ procedure TSlot.BuildNodes(const BaseUrl: string;
         end;
 
         // TODO: Is this still useful?
-        A.TransformToBoneSpace(Bone); // transform skinnedmesh into local space
+        // A.TransformToBoneSpace(Bone); // transform skinnedmesh into local space
         A.NodeUsedAsChild := true;
         Result := A.Node;
 

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -62,20 +62,23 @@ procedure TWeightedMeshTimeline.Parse;
   { Example:
     - Time1: [0, 0.2, 0.65, 1]
     - Time2: [0, 0.3, 0.65, 0.7. 1]
-    * smooth the timeframes
-    - Result: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.65, 0.7, 0.8, 0.9, 1]
+    * Add additional steps to make the animation more accurac, default is 0.15
+    - Result: [0, 0.15, 0.2, 0.3, 0.45, 0.6, 0.65, 0.7, 0.75, 0.8, 0.9, 1]
   }
   procedure CombineTimeframes;
   var
     I, J: Integer;
     Value: Single;
     IsRotationRequired: Boolean = False;
+    IsCurved: Boolean = False;
   begin
     // For bone timelines
     for I := 0 to AffectedBoneTimelines.Count - 1 do
     begin
       if AffectedBoneTimelines[I] is TBoneTimelineRotate then
         IsRotationRequired := True;
+      if AffectedBoneTimelines[I].Curve then
+        IsCurved := True;
       for J := 0 to AffectedBoneTimelines[I].Time.Count - 1 do
       begin
         Value := AffectedBoneTimelines[I].Time[J];
@@ -88,6 +91,8 @@ procedure TWeightedMeshTimeline.Parse;
     // For deform timeline
     if AffectedDeformTimeline <> nil then
     begin
+      if AffectedDeformTimeline.Curve then
+        IsCurved := True;
       for I := 0 to AffectedDeformTimeline.Time.Count - 1 do
       begin
         Value := AffectedDeformTimeline.Time[I];
@@ -98,8 +103,9 @@ procedure TWeightedMeshTimeline.Parse;
       end;
     end;
     Time.Sort;
-    // Smooth the timeframes by adding more steps inbetween time
-    if IsRotationRequired or (AffectedBoneTimelines.Count > 0) then
+    // Make the timeframes more accuracy by adding more steps inbetween time
+    // Default step is 0.15
+    if IsCurved or IsRotationRequired or (AffectedBoneTimelines.Count > 0) then
     begin
       Value := 0;
       while Value < Time[Time.Count - 1] do
@@ -108,7 +114,7 @@ procedure TWeightedMeshTimeline.Parse;
         begin
           Time.Insert(0, Value);
         end;
-        Value := Value + 0.1;
+        Value := Value + 0.15;
       end;
       Time.Sort;
     end;
@@ -116,7 +122,8 @@ procedure TWeightedMeshTimeline.Parse;
 
   procedure InterpolateTimeframes;
   var
-    I, J, K, P: Integer;
+    I, J, K: Integer;
+    P, T1, T2, OldT1, OldT2: Integer;
     BoneTimeline: TBoneTimeline;
     BoneTimelineTranslate: TBoneTimelineTranslate;
     BoneTimelineScale: TBoneTimelineScale;
@@ -124,7 +131,14 @@ procedure TWeightedMeshTimeline.Parse;
     Timeframe, Timeframe1, Timeframe2: Single;
     IsExists: Boolean;
     VertexList, VertexList1, VertexList2: TSingleList;
+    T: Single;
+    ControlPoints: TCubicBezier2DPoints;
+    CachedBezierCurve: array [0..19] of TVector2;
   begin
+    ControlPoints[0] := Vector2(0, 0);
+    ControlPoints[3] := Vector2(1, 1);
+    OldT1 := 0;
+    OldT2 := 0;
     // For bone timeline
     for I := 0 to AffectedBoneTimelines.Count - 1 do
     begin
@@ -151,66 +165,141 @@ procedure TWeightedMeshTimeline.Parse;
           P := BoneTimeline.Time.IndexOf(Timeframe);
           if P = 0 then
           begin
+            BoneTimeline.BackupTime.Insert(0, Timeframe);
             if BoneTimeline is TBoneTimelineTranslate then
             begin
               BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
               BoneTimelineTranslate.Vectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
+              // Add missing value to backup values
+              BoneTimelineTranslate.BackupVectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
             end;
             if BoneTimeline is TBoneTimelineRotate then
             begin
               BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
               BoneTimelineRotate.Angles.Insert(P, BoneTimelineRotate.Angles[P]);
+              // Add missing value to backup values
+              BoneTimelineRotate.BackupAngles.Insert(P, BoneTimelineRotate.BackupAngles[P]);
             end;;
             if BoneTimeline is TBoneTimelineScale then
             begin
               BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
               BoneTimelineScale.Vectors.Insert(P, BoneTimelineScale.Vectors[P]);
+              // Add missing value to backup values
+              BoneTimelineScale.BackupVectors.Insert(P, BoneTimelineScale.BackupVectors[P]);
             end;
+            BoneTimeline.CurveControlPoints.Insert(P, Vector4(0, 0, 1, 1));
           end else
           if P = BoneTimeline.Time.Count - 1 then
           begin
+            BoneTimeline.BackupTime.Add(Timeframe);
             if BoneTimeline is TBoneTimelineTranslate then
             begin
               BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
               BoneTimelineTranslate.Vectors.Add(BoneTimelineTranslate.Vectors[BoneTimelineTranslate.Vectors.Count - 1]);
+              // Add missing value to backup values
+              BoneTimelineTranslate.BackupVectors.Add(BoneTimelineTranslate.BackupVectors[BoneTimelineTranslate.BackupVectors.Count - 1]);
             end;
             if BoneTimeline is TBoneTimelineRotate then
             begin
               BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
               BoneTimelineRotate.Angles.Add(BoneTimelineRotate.Angles[BoneTimelineRotate.Angles.Count - 1]);
-            end;;
+              // Add missing value to backup values
+              BoneTimelineRotate.BackupAngles.Add(BoneTimelineRotate.BackupAngles[BoneTimelineRotate.BackupAngles.Count - 1]);
+            end;
             if BoneTimeline is TBoneTimelineScale then
             begin
               BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
               BoneTimelineScale.Vectors.Add(BoneTimelineScale.Vectors[BoneTimelineScale.Vectors.Count - 1]);
+              // Add missing value to backup values
+              BoneTimelineScale.BackupVectors.Add(BoneTimelineScale.BackupVectors[BoneTimelineScale.BackupVectors.Count - 1]);
             end;
+            // Add missing value to backup values
+            BoneTimeline.CurveControlPoints.Add(Vector4(0, 0, 1, 1));
           end else
           begin
-            Timeframe1 := BoneTimeline.Time[P - 1];
-            Timeframe2 := BoneTimeline.Time[P + 1];
-            if BoneTimeline is TBoneTimelineTranslate then
+            // If this timeline has control points, then we need to search timeframe in original
+            // time instead for accurary result
+            if BoneTimeline.Curve then
             begin
-              BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
-              BoneTimelineTranslate.Vectors.Insert(P,
-                  Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
-                  BoneTimelineTranslate.Vectors[P - 1],
-                  BoneTimelineTranslate.Vectors[P]));
-            end;
-            if BoneTimeline is TBoneTimelineRotate then
+              for K := BoneTimeline.BackupTime.Count - 2 downto 0 do
+              begin
+                if (Timeframe > BoneTimeline.BackupTime[K]) then
+                begin
+                  T1 := K;
+                  T2 := K + 1;
+                  Break;
+                end;
+              end;
+              // This is a different timeframe compare to previous one?
+              // Then we need to generate a bezier curve in order to use it
+              // later for finding step value
+              if (T1 <> OldT1) or (T2 <> OldT2) then
+              begin;
+                ControlPoints[1] := Vector2(BoneTimeline.CurveControlPoints[T1][0], BoneTimeline.CurveControlPoints[T1][1]);
+                ControlPoints[2] := Vector2(BoneTimeline.CurveControlPoints[T1][2], BoneTimeline.CurveControlPoints[T1][3]);
+                for K := 0 to High(CachedBezierCurve) do
+                begin
+                  CachedBezierCurve[K] := CubicBezier2D(K / High(CachedBezierCurve), ControlPoints);
+                end;
+                OldT1 := T1;
+                OldT2 := T2;
+              end;
+              Timeframe1 := BoneTimeline.BackupTime[T1];
+              Timeframe2 := BoneTimeline.BackupTime[T2];
+              T := (Timeframe - Timeframe1) / (Timeframe2 - Timeframe1);
+              for K := 1 to High(CachedBezierCurve) do
+              begin
+                if CachedBezierCurve[K].X > T then
+                begin
+                  T := Lerp(
+                       (T - CachedBezierCurve[K - 1].X) / (CachedBezierCurve[K].X - CachedBezierCurve[K - 1].X),
+                       CachedBezierCurve[K - 1].Y, CachedBezierCurve[K].Y);
+                  Break;
+                end;
+              end;
+              if BoneTimeline is TBoneTimelineTranslate then
+              begin
+                BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
+                BoneTimelineTranslate.Vectors.Insert(P,
+                    Lerp(T, BoneTimelineTranslate.BackupVectors[T1], BoneTimelineTranslate.BackupVectors[T2]));
+              end;
+              if BoneTimeline is TBoneTimelineRotate then
+              begin
+                BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
+                BoneTimelineRotate.Angles.Insert(P,
+                    Lerp(T, BoneTimelineRotate.BackupAngles[T1], BoneTimelineRotate.BackupAngles[T2]));
+              end;;
+              if BoneTimeline is TBoneTimelineScale then
+              begin
+                BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
+                BoneTimelineScale.Vectors.Insert(P,
+                    Lerp(T, BoneTimelineScale.BackupVectors[T1], BoneTimelineScale.BackupVectors[T2]));
+              end;
+            end else
             begin
-              BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
-              BoneTimelineRotate.Angles.Insert(P,
-                  Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
-                  BoneTimelineRotate.Angles[P - 1],
-                  BoneTimelineRotate.Angles[P]));
-            end;;
-            if BoneTimeline is TBoneTimelineScale then
-            begin
-              BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
-              BoneTimelineScale.Vectors.Insert(P,
-                  Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
-                  BoneTimelineScale.Vectors[P - 1],
-                  BoneTimelineScale.Vectors[P]));
+              T1 := P - 1;
+              T2 := P + 1;
+              Timeframe1 := BoneTimeline.Time[T1];
+              Timeframe2 := BoneTimeline.Time[T2];
+              T := (Timeframe - Timeframe1) / (Timeframe2 - Timeframe1);
+              if BoneTimeline is TBoneTimelineTranslate then
+              begin
+                BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
+                BoneTimelineTranslate.Vectors.Insert(P,
+                    Lerp(T, BoneTimelineTranslate.Vectors[T1], BoneTimelineTranslate.Vectors[P]));
+              end;
+              if BoneTimeline is TBoneTimelineRotate then
+              begin
+                BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
+                BoneTimelineRotate.Angles.Insert(P,
+                    Lerp(T, BoneTimelineRotate.Angles[T1], BoneTimelineRotate.Angles[P]));
+              end;;
+              if BoneTimeline is TBoneTimelineScale then
+              begin
+                BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
+                BoneTimelineScale.Vectors.Insert(P,
+                    Lerp(T, BoneTimelineScale.Vectors[T1], BoneTimelineScale.Vectors[P]));
+              end;
             end;
           end;
         end;
@@ -222,7 +311,7 @@ procedure TWeightedMeshTimeline.Parse;
       for J := 0 to Time.Count - 1 do
       begin
         Timeframe := Time[J];
-        // Check to see if this timeframe exists in bone timeline
+        // Check to see if this timeframe exists in deform timeline
         IsExists := False;
         for K := 0 to AffectedDeformTimeline.Time.Count - 1 do
         begin
@@ -242,24 +331,80 @@ procedure TWeightedMeshTimeline.Parse;
           VertexList := TSingleList.Create;
           if P = 0 then
           begin
+            AffectedDeformTimeline.BackupTime.Insert(0, Timeframe);
             VertexList.AddRange(AffectedDeformTimeline.Vertices[P]);
             AffectedDeformTimeline.Vertices.Insert(P, VertexList);
+            // Add missing value to backup values
+            AffectedDeformTimeline.BackupVertices.Insert(P, VertexList);
+            AffectedDeformTimeline.CurveControlPoints.Insert(P, Vector4(0, 0, 1, 1));
           end else
           if P = AffectedDeformTimeline.Time.Count - 1 then
           begin
+            AffectedDeformTimeline.BackupTime.Add(Timeframe);
             VertexList.AddRange(AffectedDeformTimeline.Vertices[AffectedDeformTimeline.Vertices.Count - 1]);
             AffectedDeformTimeline.Vertices.Add(VertexList);
+            // Add missing value to backup values
+            AffectedDeformTimeline.BackupVertices.Add(VertexList);
+            AffectedDeformTimeline.CurveControlPoints.Add(Vector4(0, 0, 1, 1));
           end else
           begin
-            Timeframe1 := AffectedDeformTimeline.Time[P - 1];
-            Timeframe2 := AffectedDeformTimeline.Time[P + 1];
-            VertexList1 := AffectedDeformTimeline.Vertices[P - 1];
-            VertexList2 := AffectedDeformTimeline.Vertices[P];
-            VertexList.Count := VertexList1.Count;
+            // If this timeline has control points, then we need to search timeframe in original
+            // time instead for accurary result
+            if AffectedDeformTimeline.Curve then
+            begin
+              for K := AffectedDeformTimeline.BackupTime.Count - 2 downto 0 do
+              begin
+                if (Timeframe > AffectedDeformTimeline.BackupTime[K]) then
+                begin
+                  T1 := K;
+                  T2 := K + 1;
+                  Break;
+                end;
+              end;
+              // This is a different timeframe compare to previous one?
+              // Then we need to generate a bezier curve in order to use it
+              // later for finding step value
+              if (T1 <> OldT1) or (T2 <> OldT2) then
+              begin;
+                ControlPoints[1] := Vector2(AffectedDeformTimeline.CurveControlPoints[T1][0], AffectedDeformTimeline.CurveControlPoints[T1][1]);
+                ControlPoints[2] := Vector2(AffectedDeformTimeline.CurveControlPoints[T1][2], AffectedDeformTimeline.CurveControlPoints[T1][3]);
+                for K := 0 to High(CachedBezierCurve) do
+                begin
+                  CachedBezierCurve[K] := CubicBezier2D(K / High(CachedBezierCurve), ControlPoints);
+                end;
+                OldT1 := T1;
+                OldT2 := T2;
+              end;
+              Timeframe1 := AffectedDeformTimeline.BackupTime[T1];
+              Timeframe2 := AffectedDeformTimeline.BackupTime[T2];
+              VertexList1 := AffectedDeformTimeline.BackupVertices[T1];
+              VertexList2 := AffectedDeformTimeline.BackupVertices[T2];
+              VertexList.Count := VertexList1.Count;
+              T := (Timeframe - Timeframe1) / (Timeframe2 - Timeframe1);
+              for K := 1 to High(CachedBezierCurve) do
+              begin
+                if CachedBezierCurve[K].X > T then
+                begin
+                  T := Lerp(
+                       (T - CachedBezierCurve[K - 1].X) / (CachedBezierCurve[K].X - CachedBezierCurve[K - 1].X),
+                       CachedBezierCurve[K - 1].Y, CachedBezierCurve[K].Y);
+                  Break;
+                end;
+              end;
+            end else
+            begin
+              T1 := P - 1;
+              T2 := P + 1;
+              Timeframe1 := AffectedDeformTimeline.Time[T1];
+              Timeframe2 := AffectedDeformTimeline.Time[T2];
+              VertexList1 := AffectedDeformTimeline.Vertices[T1];
+              VertexList2 := AffectedDeformTimeline.Vertices[P];
+              VertexList.Count := VertexList1.Count;
+              T := (Timeframe - Timeframe1) / (Timeframe2 - Timeframe1);
+            end;
             for K := 0 to VertexList1.Count - 1 do
             begin
-              VertexList[K] := Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
-                  VertexList1[K], VertexList2[K]);
+              VertexList[K] := Lerp(T, VertexList1[K], VertexList2[K]);
             end;
             AffectedDeformTimeline.Vertices.Insert(P, VertexList);
           end;

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -54,8 +54,8 @@ begin
 end;
 
 { We now performing 'parse':
-  - Find all possible timeframes by combining timeframes from every bone timelines
-  - Perform interpolation for those bone timelines that doesnt have necesssary timeframes
+  - Find all possible timeframes by combining timeframes from every bone/deform timelines
+  - Perform interpolation for those bone/deform timelines that doesnt have necesssary timeframes
   - Perform vertex calculation
 }
 procedure TWeightedMeshTimeline.Parse;
@@ -170,21 +170,21 @@ procedure TWeightedMeshTimeline.Parse;
             begin
               BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
               BoneTimelineTranslate.Vectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
-              // Add missing value to backup values
+              // Add missing value to backup values as safeguard
               BoneTimelineTranslate.BackupVectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
             end;
             if BoneTimeline is TBoneTimelineRotate then
             begin
               BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
               BoneTimelineRotate.Angles.Insert(P, BoneTimelineRotate.Angles[P]);
-              // Add missing value to backup values
+              // Add missing value to backup values as safeguard
               BoneTimelineRotate.BackupAngles.Insert(P, BoneTimelineRotate.BackupAngles[P]);
             end;;
             if BoneTimeline is TBoneTimelineScale then
             begin
               BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
               BoneTimelineScale.Vectors.Insert(P, BoneTimelineScale.Vectors[P]);
-              // Add missing value to backup values
+              // Add missing value to backup values as safeguard
               BoneTimelineScale.BackupVectors.Insert(P, BoneTimelineScale.BackupVectors[P]);
             end;
             BoneTimeline.CurveControlPoints.Insert(P, Vector4(0, 0, 1, 1));
@@ -196,24 +196,24 @@ procedure TWeightedMeshTimeline.Parse;
             begin
               BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
               BoneTimelineTranslate.Vectors.Add(BoneTimelineTranslate.Vectors[BoneTimelineTranslate.Vectors.Count - 1]);
-              // Add missing value to backup values
+              // Add missing value to backup values as safeguard
               BoneTimelineTranslate.BackupVectors.Add(BoneTimelineTranslate.BackupVectors[BoneTimelineTranslate.BackupVectors.Count - 1]);
             end;
             if BoneTimeline is TBoneTimelineRotate then
             begin
               BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
               BoneTimelineRotate.Angles.Add(BoneTimelineRotate.Angles[BoneTimelineRotate.Angles.Count - 1]);
-              // Add missing value to backup values
+              // Add missing value to backup values as safeguard
               BoneTimelineRotate.BackupAngles.Add(BoneTimelineRotate.BackupAngles[BoneTimelineRotate.BackupAngles.Count - 1]);
             end;
             if BoneTimeline is TBoneTimelineScale then
             begin
               BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
               BoneTimelineScale.Vectors.Add(BoneTimelineScale.Vectors[BoneTimelineScale.Vectors.Count - 1]);
-              // Add missing value to backup values
+              // Add missing value to backup values as safeguard
               BoneTimelineScale.BackupVectors.Add(BoneTimelineScale.BackupVectors[BoneTimelineScale.BackupVectors.Count - 1]);
             end;
-            // Add missing value to backup values
+            // Add missing value to backup values as safeguard
             BoneTimeline.CurveControlPoints.Add(Vector4(0, 0, 1, 1));
           end else
           begin
@@ -334,7 +334,7 @@ procedure TWeightedMeshTimeline.Parse;
             AffectedDeformTimeline.BackupTime.Insert(0, Timeframe);
             VertexList.AddRange(AffectedDeformTimeline.Vertices[P]);
             AffectedDeformTimeline.Vertices.Insert(P, VertexList);
-            // Add missing value to backup values
+            // Add missing value to backup values as safeguard
             AffectedDeformTimeline.BackupVertices.Insert(P, VertexList);
             AffectedDeformTimeline.CurveControlPoints.Insert(P, Vector4(0, 0, 1, 1));
           end else
@@ -343,7 +343,7 @@ procedure TWeightedMeshTimeline.Parse;
             AffectedDeformTimeline.BackupTime.Add(Timeframe);
             VertexList.AddRange(AffectedDeformTimeline.Vertices[AffectedDeformTimeline.Vertices.Count - 1]);
             AffectedDeformTimeline.Vertices.Add(VertexList);
-            // Add missing value to backup values
+            // Add missing value to backup values as safeguard
             AffectedDeformTimeline.BackupVertices.Add(VertexList);
             AffectedDeformTimeline.CurveControlPoints.Add(Vector4(0, 0, 1, 1));
           end else

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -137,9 +137,9 @@ procedure TWeightedMeshTimeline.Parse;
     I, J, K: Integer;
     P, T1, T2, OldT1, OldT2: Integer;
     BoneTimeline: TBoneTimeline;
-    BoneTimelineTranslate: TBoneTimelineTranslate;
-    BoneTimelineScale: TBoneTimelineScale;
-    BoneTimelineRotate: TBoneTimelineRotate;
+    BoneTimelineTranslate: TBoneTimelineTranslate absolute BoneTimeline;
+    BoneTimelineScale: TBoneTimelineScale absolute BoneTimeline;
+    BoneTimelineRotate: TBoneTimelineRotate absolute BoneTimeline;
     Timeframe, Timeframe1, Timeframe2: Single;
     IsExists: Boolean;
     VertexList, VertexList1, VertexList2: TSingleList;
@@ -184,21 +184,18 @@ procedure TWeightedMeshTimeline.Parse;
             BoneTimeline.BackupTime.Insert(0, Timeframe);
             if BoneTimeline is TBoneTimelineTranslate then
             begin
-              BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
               BoneTimelineTranslate.Vectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
               // Add missing value to backup values as safeguard
               BoneTimelineTranslate.BackupVectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
             end else
             if BoneTimeline is TBoneTimelineRotate then
             begin
-              BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
               BoneTimelineRotate.Angles.Insert(P, BoneTimelineRotate.Angles[P]);
               // Add missing value to backup values as safeguard
               BoneTimelineRotate.BackupAngles.Insert(P, BoneTimelineRotate.BackupAngles[P]);
             end else
             if BoneTimeline is TBoneTimelineScale then
             begin
-              BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
               BoneTimelineScale.Vectors.Insert(P, BoneTimelineScale.Vectors[P]);
               // Add missing value to backup values as safeguard
               BoneTimelineScale.BackupVectors.Insert(P, BoneTimelineScale.BackupVectors[P]);
@@ -210,21 +207,18 @@ procedure TWeightedMeshTimeline.Parse;
             BoneTimeline.BackupTime.Add(Timeframe);
             if BoneTimeline is TBoneTimelineTranslate then
             begin
-              BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
               BoneTimelineTranslate.Vectors.Add(BoneTimelineTranslate.Vectors[BoneTimelineTranslate.Vectors.Count - 1]);
               // Add missing value to backup values as safeguard
               BoneTimelineTranslate.BackupVectors.Add(BoneTimelineTranslate.BackupVectors[BoneTimelineTranslate.BackupVectors.Count - 1]);
             end else
             if BoneTimeline is TBoneTimelineRotate then
             begin
-              BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
               BoneTimelineRotate.Angles.Add(BoneTimelineRotate.Angles[BoneTimelineRotate.Angles.Count - 1]);
               // Add missing value to backup values as safeguard
               BoneTimelineRotate.BackupAngles.Add(BoneTimelineRotate.BackupAngles[BoneTimelineRotate.BackupAngles.Count - 1]);
             end else
             if BoneTimeline is TBoneTimelineScale then
             begin
-              BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
               BoneTimelineScale.Vectors.Add(BoneTimelineScale.Vectors[BoneTimelineScale.Vectors.Count - 1]);
               // Add missing value to backup values as safeguard
               BoneTimelineScale.BackupVectors.Add(BoneTimelineScale.BackupVectors[BoneTimelineScale.BackupVectors.Count - 1]);
@@ -275,19 +269,16 @@ procedure TWeightedMeshTimeline.Parse;
               end;
               if BoneTimeline is TBoneTimelineTranslate then
               begin
-                BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
                 BoneTimelineTranslate.Vectors.Insert(P,
                     Lerp(T, BoneTimelineTranslate.BackupVectors[T1], BoneTimelineTranslate.BackupVectors[T2]));
               end else
               if BoneTimeline is TBoneTimelineRotate then
               begin
-                BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
                 BoneTimelineRotate.Angles.Insert(P,
                     Lerp(T, BoneTimelineRotate.BackupAngles[T1], BoneTimelineRotate.BackupAngles[T2]));
               end else
               if BoneTimeline is TBoneTimelineScale then
               begin
-                BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
                 BoneTimelineScale.Vectors.Insert(P,
                     Lerp(T, BoneTimelineScale.BackupVectors[T1], BoneTimelineScale.BackupVectors[T2]));
               end;
@@ -300,19 +291,16 @@ procedure TWeightedMeshTimeline.Parse;
               T := (Timeframe - Timeframe1) / (Timeframe2 - Timeframe1);
               if BoneTimeline is TBoneTimelineTranslate then
               begin
-                BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
                 BoneTimelineTranslate.Vectors.Insert(P,
                     Lerp(T, BoneTimelineTranslate.Vectors[T1], BoneTimelineTranslate.Vectors[P]));
               end else
               if BoneTimeline is TBoneTimelineRotate then
               begin
-                BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
                 BoneTimelineRotate.Angles.Insert(P,
                     Lerp(T, BoneTimelineRotate.Angles[T1], BoneTimelineRotate.Angles[P]));
               end else
               if BoneTimeline is TBoneTimelineScale then
               begin
-                BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
                 BoneTimelineScale.Vectors.Insert(P,
                     Lerp(T, BoneTimelineScale.Vectors[T1], BoneTimelineScale.Vectors[P]));
               end;

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -75,6 +75,7 @@ procedure TWeightedMeshTimeline.Parse;
     Value: Single;
     IsRotationRequired: Boolean = False;
     IsCurved: Boolean = False;
+    IsTimeframeTooLow: Boolean;
   begin
     // For bone timelines
     for I := 0 to AffectedBoneTimelines.Count - 1 do
@@ -114,10 +115,17 @@ procedure TWeightedMeshTimeline.Parse;
       Value := 0;
       while Value < Time[Time.Count - 1] do
       begin
-        if Time.IndexOf(Value) < 0 then
+        IsTimeframeTooLow := False;
+        for I := 0 to Time.Count - 1 do
         begin
-          Time.Insert(0, Value);
+          if Abs(Time[I] - Value) < 0.15 then
+          begin
+            IsTimeframeTooLow := True;
+            Break;
+          end;
         end;
+        if not IsTimeframeTooLow then
+          Time.Insert(0, Value);
         Value := Value + 0.15;
       end;
       Time.Sort;

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -23,6 +23,7 @@
     Name: String;
     Attachment: TMeshAttachment;
     AffectedBoneTimelines: TBoneTimelineList;
+    AffectedDeformTimeline: TDeformTimeline;
     Vertices: TWeightedMeshVertexList;
     Time: TSingleList;
     Node: TCoordinateInterpolatorNode;
@@ -69,11 +70,24 @@ procedure TWeightedMeshTimeline.Parse;
     I, J: Integer;
     Value: Single;
   begin
+    // For bone timelines
     for I := 0 to AffectedBoneTimelines.Count - 1 do
     begin
       for J := 0 to AffectedBoneTimelines[I].Time.Count - 1 do
       begin
         Value := AffectedBoneTimelines[I].Time[J];
+        if Time.IndexOf(Value) < 0 then
+        begin
+          Time.Add(Value);
+        end;
+      end;
+    end;
+    // For deform timeline
+    if AffectedDeformTimeline <> nil then
+    begin
+      for I := 0 to AffectedDeformTimeline.Time.Count - 1 do
+      begin
+        Value := AffectedDeformTimeline.Time[J];
         if Time.IndexOf(Value) < 0 then
         begin
           Time.Add(Value);
@@ -89,7 +103,10 @@ procedure TWeightedMeshTimeline.Parse;
       begin
         Time.Insert(0, Value);
       end;
-      Value += Time[Time.Count - 1] * 0.1;
+      if Time[Time.Count - 1] * 0.1 > 0.1 then
+        Value := Value + 0.1
+      else
+        Value := Value + Time[Time.Count - 1] * 0.1;
     end;
     Time.Sort;
   end;
@@ -103,7 +120,9 @@ procedure TWeightedMeshTimeline.Parse;
     BoneTimelineRotate: TBoneTimelineRotate;
     Timeframe, Timeframe1, Timeframe2: Single;
     IsExists: Boolean;
+    VertexList, VertexList1, VertexList2: TSingleList;
   begin
+    // For bone timeline
     for I := 0 to AffectedBoneTimelines.Count - 1 do
     begin
       BoneTimeline := AffectedBoneTimelines[I];
@@ -194,13 +213,65 @@ procedure TWeightedMeshTimeline.Parse;
         end;
       end;
     end;
+    // For deform timeline
+    if AffectedDeformTimeline <> nil then
+    begin
+      for J := 0 to Time.Count - 1 do
+      begin
+        Timeframe := Time[J];
+        // Check to see if this timeframe exists in bone timeline
+        IsExists := False;
+        for K := 0 to AffectedDeformTimeline.Time.Count - 1 do
+        begin
+          if Timeframe = AffectedDeformTimeline.Time[K] then
+          begin
+            IsExists := True;
+            Break;
+          end;
+        end;
+        // If timeframe does not exist, we insert it into deform timeline and then
+        // generate new values for this timeframe by interpolating 2 values between it
+        if not IsExists then
+        begin
+          AffectedDeformTimeline.Time.Add(Timeframe);
+          AffectedDeformTimeline.Time.Sort;
+          P := AffectedDeformTimeline.Time.IndexOf(Timeframe);
+          VertexList := TSingleList.Create;
+          if P = 0 then
+          begin
+            VertexList.AddRange(AffectedDeformTimeline.Vertices[P]);
+            AffectedDeformTimeline.Vertices.Insert(P, VertexList);
+          end else
+          if P = AffectedDeformTimeline.Time.Count - 1 then
+          begin
+            VertexList.AddRange(AffectedDeformTimeline.Vertices[AffectedDeformTimeline.Vertices.Count - 1]);
+            AffectedDeformTimeline.Vertices.Add(VertexList);
+          end else
+          begin
+            Timeframe1 := AffectedDeformTimeline.Time[P - 1];
+            Timeframe2 := AffectedDeformTimeline.Time[P + 1];
+            VertexList1 := AffectedDeformTimeline.Vertices[P - 1];
+            VertexList2 := AffectedDeformTimeline.Vertices[P];
+            VertexList.Count := VertexList1.Count;
+            for K := 0 to VertexList1.Count - 1 do
+            begin
+              VertexList[K] := Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
+                  VertexList1[K], VertexList2[K]);
+            end;
+            AffectedDeformTimeline.Vertices.Insert(P, VertexList);
+          end;
+        end;
+      end;
+    end;
   end;
 
   procedure CalculateVertices;
   var
     I, J, K, L: Integer;
+    Offset: Integer;
     VB: TMeshVertexBone;
-    V: TVector2;
+    V, V2: TVector2;
+    DeformVertexList,
     VertexList: TSingleList;
     BoneParent: TBone;
     Bones: TBoneList;
@@ -218,9 +289,11 @@ procedure TWeightedMeshTimeline.Parse;
           for K := 0 to Attachment.Weights[J].Bones.Count - 1 do
           begin
             VB := Attachment.Weights[J].Bones[K];
+            Offset := Attachment.Weights[J].Offset;
             //
             Bones.Clear;
             BoneParent := VB.Bone;
+            // Recalculate bone structure based on timeline values
             while BoneParent <> nil do
             begin
               BoneParent.Backup;
@@ -244,8 +317,16 @@ procedure TWeightedMeshTimeline.Parse;
               Bones[L].UpdateWorldTransform;
             end;
             //
-            V := V + (VB.Bone.ToWorldSpace(VB.V) * VB.Weight);
-            //
+            if AffectedDeformTimeline <> nil then
+            begin
+              DeformVertexList := AffectedDeformTimeline.Vertices[I];
+              V2.X := DeformVertexList[Offset + K * 2];
+              V2.Y := DeformVertexList[Offset + K * 2 + 1];
+              V := V + (VB.Bone.ToWorldSpace(V2) * VB.Weight);
+            end
+            else
+              V := V + (VB.Bone.ToWorldSpace(VB.V) * VB.Weight);
+            // Restore bone structure
             for L := Bones.Count - 1 downto 0 do
             begin
               Bones[L].Restore;

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -21,7 +21,6 @@
 
   TWeightedMeshTimeline = class
     Name: String;
-    Slots: TSlotList;
     Attachment: TMeshAttachment;
     AffectedBoneTimelines: TBoneTimelineList;
     Vertices: TWeightedMeshVertexList;
@@ -106,7 +105,7 @@ procedure TWeightedMeshTimeline.Parse;
           if Timeframe = BoneTimeline.Time[K] then
           begin
             IsExists := True;
-            break;
+            Break;
           end;
         end;
         // If timeframe does not exist, we insert it into bone timeline and then
@@ -193,8 +192,6 @@ procedure TWeightedMeshTimeline.Parse;
     VertexList: TSingleList;
     BoneParent: TBone;
     Bones: TBoneList;
-    Slot: TSlot;
-    IsBoneAndAttachmentBelongToSlot: Boolean;
   begin
     Bones := TBoneList.Create;
     Bones.OwnsObjects := False;
@@ -209,19 +206,6 @@ procedure TWeightedMeshTimeline.Parse;
           for K := 0 to Attachment.Weights[J].Bones.Count - 1 do
           begin
             VB := Attachment.Weights[J].Bones[K];
-            // Is this bone in the same slot with attachment?
-            IsBoneAndAttachmentBelongToSlot := False;
-            for L := 0 to Slots.Count - 1 do
-            begin
-              Slot := Slots[L];
-              if Slot.Bone.Name = VB.Bone.Name then
-              begin
-                IsBoneAndAttachmentBelongToSlot := True;
-                break;
-              end;
-            end;
-            if IsBoneAndAttachmentBelongToSlot then
-              continue;
             //
             Bones.Clear;
             BoneParent := VB.Bone;
@@ -234,18 +218,19 @@ procedure TWeightedMeshTimeline.Parse;
                 if AffectedBoneTimelines[L].Bone.Name = BoneParent.Name then
                 begin
                   if AffectedBoneTimelines[L] is TBoneTimelineTranslate then
-                    BoneParent.XY := (AffectedBoneTimelines[L] as TBoneTimelineTranslate).Vectors[I];
+                    BoneParent.XY := BoneParent.XY + (AffectedBoneTimelines[L] as TBoneTimelineTranslate).Vectors[I];
                   if AffectedBoneTimelines[L] is TBoneTimelineRotate then
-                    // TODO: Wh do we need to add 90 degree?
                     BoneParent.Rotation := BoneParent.Rotation + (AffectedBoneTimelines[L] as TBoneTimelineRotate).Angles[I];
                   if AffectedBoneTimelines[L] is TBoneTimelineScale then
-                    BoneParent.Scale := (AffectedBoneTimelines[L] as TBoneTimelineScale).Vectors[I];
+                    BoneParent.Scale := BoneParent.Scale * (AffectedBoneTimelines[L] as TBoneTimelineScale).Vectors[I];
                 end;
               end;
               BoneParent := BoneParent.Parent;
             end;
             for L := Bones.Count - 1 downto 0 do
+            begin
               Bones[L].UpdateWorldTransform;
+            end;
             //
             V := V + (VB.Bone.ToWorldSpace(VB.V) * VB.Weight);
             //

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -69,10 +69,13 @@ procedure TWeightedMeshTimeline.Parse;
   var
     I, J: Integer;
     Value: Single;
+    IsRotationRequired: Boolean = False;
   begin
     // For bone timelines
     for I := 0 to AffectedBoneTimelines.Count - 1 do
     begin
+      if AffectedBoneTimelines[I] is TBoneTimelineRotate then
+        IsRotationRequired := True;
       for J := 0 to AffectedBoneTimelines[I].Time.Count - 1 do
       begin
         Value := AffectedBoneTimelines[I].Time[J];
@@ -96,17 +99,17 @@ procedure TWeightedMeshTimeline.Parse;
     end;
     Time.Sort;
     // Smooth the timeframes by adding more steps inbetween time
-    Value := 0;
-    while Value < Time[Time.Count - 1] do
+    if IsRotationRequired then
     begin
-      if Time.IndexOf(Value) < 0 then
+      Value := 0;
+      while Value < Time[Time.Count - 1] do
       begin
-        Time.Insert(0, Value);
+        if Time.IndexOf(Value) < 0 then
+        begin
+          Time.Insert(0, Value);
+        end;
+        Value := Value + 0.1;
       end;
-      if Time[Time.Count - 1] * 0.1 > 0.1 then
-        Value := Value + 0.1
-      else
-        Value := Value + Time[Time.Count - 1] * 0.1;
     end;
     Time.Sort;
   end;

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -87,7 +87,7 @@ procedure TWeightedMeshTimeline.Parse;
     begin
       for I := 0 to AffectedDeformTimeline.Time.Count - 1 do
       begin
-        Value := AffectedDeformTimeline.Time[J];
+        Value := AffectedDeformTimeline.Time[I];
         if Time.IndexOf(Value) < 0 then
         begin
           Time.Add(Value);

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -59,9 +59,10 @@ end;
 }
 procedure TWeightedMeshTimeline.Parse;
   { Example:
-    - Time1: [0, 0.2, 0.6, 1]
-    - Time2: [0, 0.3, 0.6, 0.7. 1]
-    - Result: [0, 0.2, 0.3, 0.6, 0.7, 1]
+    - Time1: [0, 0.2, 0.65, 1]
+    - Time2: [0, 0.3, 0.65, 0.7. 1]
+    * smooth the timeframes
+    - Result: [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.65, 0.7, 0.8, 0.9, 1]
   }
   procedure CombineTimeframes;
   var
@@ -78,6 +79,17 @@ procedure TWeightedMeshTimeline.Parse;
           Time.Add(Value);
         end;
       end;
+    end;
+    Time.Sort;
+    // Smooth the timeframes by adding more steps inbetween time
+    Value := 0;
+    while Value < Time[Time.Count - 1] do
+    begin
+      if Time.IndexOf(Value) < 0 then
+      begin
+        Time.Insert(0, Value);
+      end;
+      Value += Time[Time.Count - 1] * 0.1;
     end;
     Time.Sort;
   end;
@@ -173,7 +185,7 @@ procedure TWeightedMeshTimeline.Parse;
             if BoneTimeline is TBoneTimelineScale then
             begin
               BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
-              BoneTimelineScale.Vectors.Insert(0,
+              BoneTimelineScale.Vectors.Insert(P,
                   Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
                   BoneTimelineScale.Vectors[P - 1],
                   BoneTimelineScale.Vectors[P]));

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -110,8 +110,8 @@ procedure TWeightedMeshTimeline.Parse;
         end;
         Value := Value + 0.1;
       end;
+      Time.Sort;
     end;
-    Time.Sort;
   end;
 
   procedure InterpolateTimeframes;

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -107,7 +107,7 @@ procedure TWeightedMeshTimeline.Parse;
       end;
     end;
     Time.Sort;
-    // Make the timeframes more accuracy by adding more steps inbetween time
+    // Make the animation more accurate by adding more steps inbetween
     // Default step is 0.15
     if IsCurved or IsRotationRequired or (AffectedBoneTimelines.Count > 0) then
     begin
@@ -167,6 +167,10 @@ procedure TWeightedMeshTimeline.Parse;
           BoneTimeline.Time.Add(Timeframe);
           BoneTimeline.Time.Sort;
           P := BoneTimeline.Time.IndexOf(Timeframe);
+          // TODO: If there's missing timeframe at the start of the animation,
+          // we take the value from the next timeframe. This is not correct
+          // as default behavior is to take the setup value and then make a
+          // "sudden jump" to next frame
           if P = 0 then
           begin
             BoneTimeline.BackupTime.Insert(0, Timeframe);
@@ -333,6 +337,10 @@ procedure TWeightedMeshTimeline.Parse;
           AffectedDeformTimeline.Time.Sort;
           P := AffectedDeformTimeline.Time.IndexOf(Timeframe);
           VertexList := TSingleList.Create;
+          // TODO: If there's missing timeframe at the start of the animation,
+          // we take the value from the next timeframe. This is not correct
+          // as default behavior is to take the setup value and then make a
+          // "sudden jump" to next frame
           if P = 0 then
           begin
             AffectedDeformTimeline.BackupTime.Insert(0, Timeframe);

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -99,7 +99,7 @@ procedure TWeightedMeshTimeline.Parse;
     end;
     Time.Sort;
     // Smooth the timeframes by adding more steps inbetween time
-    if IsRotationRequired then
+    if IsRotationRequired or (AffectedBoneTimelines.Count > 0) then
     begin
       Value := 0;
       while Value < Time[Time.Count - 1] do

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -470,7 +470,6 @@ procedure TWeightedMeshTimeline.Parse;
                   else
                   if AffectedBoneTimelines[L] is TBoneTimelineScale then
                     BoneParent.Scale := BoneParent.Scale * (AffectedBoneTimelines[L] as TBoneTimelineScale).Vectors[I];
-                  Break;
                 end;
               end;
               BoneParent := BoneParent.Parent;

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -62,7 +62,11 @@ procedure TWeightedMeshTimeline.Parse;
   { Example:
     - Time1: [0, 0.2, 0.65, 1]
     - Time2: [0, 0.3, 0.65, 0.7. 1]
-    * Add additional steps to make the animation more accurac, default is 0.15
+    * Add additional steps to make the animation more accurate, default is 0.15
+      Since we are doing animation by using CoordinateInterpolator, in many
+      situations, like rotation or non-linear interpolation types, the result is
+      not accurate. By adding more steps inbetween we we can achieve a more accurate
+      result, as a cost of longer loading time and more memory usage
     - Result: [0, 0.15, 0.2, 0.3, 0.45, 0.6, 0.65, 0.7, 0.75, 0.8, 0.9, 1]
   }
   procedure CombineTimeframes;
@@ -172,14 +176,14 @@ procedure TWeightedMeshTimeline.Parse;
               BoneTimelineTranslate.Vectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
               // Add missing value to backup values as safeguard
               BoneTimelineTranslate.BackupVectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
-            end;
+            end else
             if BoneTimeline is TBoneTimelineRotate then
             begin
               BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
               BoneTimelineRotate.Angles.Insert(P, BoneTimelineRotate.Angles[P]);
               // Add missing value to backup values as safeguard
               BoneTimelineRotate.BackupAngles.Insert(P, BoneTimelineRotate.BackupAngles[P]);
-            end;;
+            end else
             if BoneTimeline is TBoneTimelineScale then
             begin
               BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
@@ -198,14 +202,14 @@ procedure TWeightedMeshTimeline.Parse;
               BoneTimelineTranslate.Vectors.Add(BoneTimelineTranslate.Vectors[BoneTimelineTranslate.Vectors.Count - 1]);
               // Add missing value to backup values as safeguard
               BoneTimelineTranslate.BackupVectors.Add(BoneTimelineTranslate.BackupVectors[BoneTimelineTranslate.BackupVectors.Count - 1]);
-            end;
+            end else
             if BoneTimeline is TBoneTimelineRotate then
             begin
               BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
               BoneTimelineRotate.Angles.Add(BoneTimelineRotate.Angles[BoneTimelineRotate.Angles.Count - 1]);
               // Add missing value to backup values as safeguard
               BoneTimelineRotate.BackupAngles.Add(BoneTimelineRotate.BackupAngles[BoneTimelineRotate.BackupAngles.Count - 1]);
-            end;
+            end else
             if BoneTimeline is TBoneTimelineScale then
             begin
               BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
@@ -262,13 +266,13 @@ procedure TWeightedMeshTimeline.Parse;
                 BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
                 BoneTimelineTranslate.Vectors.Insert(P,
                     Lerp(T, BoneTimelineTranslate.BackupVectors[T1], BoneTimelineTranslate.BackupVectors[T2]));
-              end;
+              end else
               if BoneTimeline is TBoneTimelineRotate then
               begin
                 BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
                 BoneTimelineRotate.Angles.Insert(P,
                     Lerp(T, BoneTimelineRotate.BackupAngles[T1], BoneTimelineRotate.BackupAngles[T2]));
-              end;;
+              end else
               if BoneTimeline is TBoneTimelineScale then
               begin
                 BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
@@ -287,13 +291,13 @@ procedure TWeightedMeshTimeline.Parse;
                 BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
                 BoneTimelineTranslate.Vectors.Insert(P,
                     Lerp(T, BoneTimelineTranslate.Vectors[T1], BoneTimelineTranslate.Vectors[P]));
-              end;
+              end else
               if BoneTimeline is TBoneTimelineRotate then
               begin
                 BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
                 BoneTimelineRotate.Angles.Insert(P,
                     Lerp(T, BoneTimelineRotate.Angles[T1], BoneTimelineRotate.Angles[P]));
-              end;;
+              end else
               if BoneTimeline is TBoneTimelineScale then
               begin
                 BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
@@ -451,11 +455,14 @@ procedure TWeightedMeshTimeline.Parse;
                 if AffectedBoneTimelines[L].Bone.Name = BoneParent.Name then
                 begin
                   if AffectedBoneTimelines[L] is TBoneTimelineTranslate then
-                    BoneParent.XY := BoneParent.XY + (AffectedBoneTimelines[L] as TBoneTimelineTranslate).Vectors[I];
+                    BoneParent.XY := BoneParent.XY + (AffectedBoneTimelines[L] as TBoneTimelineTranslate).Vectors[I]
+                  else
                   if AffectedBoneTimelines[L] is TBoneTimelineRotate then
-                    BoneParent.Rotation := BoneParent.Rotation + (AffectedBoneTimelines[L] as TBoneTimelineRotate).Angles[I];
+                    BoneParent.Rotation := BoneParent.Rotation + (AffectedBoneTimelines[L] as TBoneTimelineRotate).Angles[I]
+                  else
                   if AffectedBoneTimelines[L] is TBoneTimelineScale then
                     BoneParent.Scale := BoneParent.Scale * (AffectedBoneTimelines[L] as TBoneTimelineScale).Vectors[I];
+                  Break;
                 end;
               end;
               BoneParent := BoneParent.Parent;

--- a/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
+++ b/src/x3d/x3dloadinternalspine_weightedmeshtimelines.inc
@@ -1,0 +1,301 @@
+{
+  Copyright 2020 Trung Le (kagamma).
+
+  This file is part of "Castle Game Engine".
+
+  "Castle Game Engine" is free software; see the file COPYING.txt,
+  included in this distribution, for details about the copyright.
+
+  "Castle Game Engine" is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+  ----------------------------------------------------------------------------
+}
+
+{ Spine weighted mesh timelines. }
+
+{$ifdef read_interface}
+  TWeightedMeshVertexList = class({$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TSingleList>)
+  end;
+
+  TWeightedMeshTimeline = class
+    Name: String;
+    Slots: TSlotList;
+    Attachment: TMeshAttachment;
+    AffectedBoneTimelines: TBoneTimelineList;
+    Vertices: TWeightedMeshVertexList;
+    Time: TSingleList;
+    Node: TCoordinateInterpolatorNode;
+    constructor Create;
+    destructor Destroy; override;
+    procedure Parse;
+    procedure BuildNodes(const MaxAnimationTime: Single; const Container: TX3DRootNode);
+  end;
+
+  TWeightedMeshTimelineList = class({$ifdef CASTLE_OBJFPC}specialize{$endif} TObjectList<TWeightedMeshTimeline>)
+  end;
+{$endif}
+
+{$ifdef read_implementation}
+
+constructor TWeightedMeshTimeline.Create;
+begin
+  inherited;
+  Time := TSingleList.Create;
+  Vertices := TWeightedMeshVertexList.Create;
+end;
+
+destructor TWeightedMeshTimeline.Destroy;
+begin
+  FreeAndNil(Vertices);
+  FreeAndNil(Time);
+  inherited;
+end;
+
+{ We now performing 'parse':
+  - Find all possible timeframes by combining timeframes from every bone timelines
+  - Perform interpolation for those bone timelines that doesnt have necesssary timeframes
+  - Perform vertex calculation
+}
+procedure TWeightedMeshTimeline.Parse;
+  { Example:
+    - Time1: [0, 0.2, 0.6, 1]
+    - Time2: [0, 0.3, 0.6, 0.7. 1]
+    - Result: [0, 0.2, 0.3, 0.6, 0.7, 1]
+  }
+  procedure CombineTimeframes;
+  var
+    I, J: Integer;
+    Value: Single;
+  begin
+    for I := 0 to AffectedBoneTimelines.Count - 1 do
+    begin
+      for J := 0 to AffectedBoneTimelines[I].Time.Count - 1 do
+      begin
+        Value := AffectedBoneTimelines[I].Time[J];
+        if Time.IndexOf(Value) < 0 then
+        begin
+          Time.Add(Value);
+        end;
+      end;
+    end;
+    Time.Sort;
+  end;
+
+  procedure InterpolateTimeframes;
+  var
+    I, J, K, P: Integer;
+    BoneTimeline: TBoneTimeline;
+    BoneTimelineTranslate: TBoneTimelineTranslate;
+    BoneTimelineScale: TBoneTimelineScale;
+    BoneTimelineRotate: TBoneTimelineRotate;
+    Timeframe, Timeframe1, Timeframe2: Single;
+    IsExists: Boolean;
+  begin
+    for I := 0 to AffectedBoneTimelines.Count - 1 do
+    begin
+      BoneTimeline := AffectedBoneTimelines[I];
+      for J := 0 to Time.Count - 1 do
+      begin
+        Timeframe := Time[J];
+        // Check to see if this timeframe exists in bone timeline
+        IsExists := False;
+        for K := 0 to BoneTimeline.Time.Count - 1 do
+        begin
+          if Timeframe = BoneTimeline.Time[K] then
+          begin
+            IsExists := True;
+            break;
+          end;
+        end;
+        // If timeframe does not exist, we insert it into bone timeline and then
+        // generate new values for this timeframe by interpolating 2 values between it
+        if not IsExists then
+        begin
+          BoneTimeline.Time.Add(Timeframe);
+          BoneTimeline.Time.Sort;
+          P := BoneTimeline.Time.IndexOf(Timeframe);
+          if P = 0 then
+          begin
+            if BoneTimeline is TBoneTimelineTranslate then
+            begin
+              BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
+              BoneTimelineTranslate.Vectors.Insert(P, BoneTimelineTranslate.Vectors[P]);
+            end;
+            if BoneTimeline is TBoneTimelineRotate then
+            begin
+              BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
+              BoneTimelineRotate.Angles.Insert(P, BoneTimelineRotate.Angles[P]);
+            end;;
+            if BoneTimeline is TBoneTimelineScale then
+            begin
+              BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
+              BoneTimelineScale.Vectors.Insert(P, BoneTimelineScale.Vectors[P]);
+            end;
+          end else
+          if P = BoneTimeline.Time.Count - 1 then
+          begin
+            if BoneTimeline is TBoneTimelineTranslate then
+            begin
+              BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
+              BoneTimelineTranslate.Vectors.Add(BoneTimelineTranslate.Vectors[BoneTimelineTranslate.Vectors.Count - 1]);
+            end;
+            if BoneTimeline is TBoneTimelineRotate then
+            begin
+              BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
+              BoneTimelineRotate.Angles.Add(BoneTimelineRotate.Angles[BoneTimelineRotate.Angles.Count - 1]);
+            end;;
+            if BoneTimeline is TBoneTimelineScale then
+            begin
+              BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
+              BoneTimelineScale.Vectors.Add(BoneTimelineScale.Vectors[BoneTimelineScale.Vectors.Count - 1]);
+            end;
+          end else
+          begin
+            Timeframe1 := BoneTimeline.Time[P - 1];
+            Timeframe2 := BoneTimeline.Time[P + 1];
+            if BoneTimeline is TBoneTimelineTranslate then
+            begin
+              BoneTimelineTranslate := BoneTimeline as TBoneTimelineTranslate;
+              BoneTimelineTranslate.Vectors.Insert(P,
+                  Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
+                  BoneTimelineTranslate.Vectors[P - 1],
+                  BoneTimelineTranslate.Vectors[P]));
+            end;
+            if BoneTimeline is TBoneTimelineRotate then
+            begin
+              BoneTimelineRotate := BoneTimeline as TBoneTimelineRotate;
+              BoneTimelineRotate.Angles.Insert(P,
+                  Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
+                  BoneTimelineRotate.Angles[P - 1],
+                  BoneTimelineRotate.Angles[P]));
+            end;;
+            if BoneTimeline is TBoneTimelineScale then
+            begin
+              BoneTimelineScale := BoneTimeline as TBoneTimelineScale;
+              BoneTimelineScale.Vectors.Insert(0,
+                  Lerp((Timeframe - Timeframe1) / (Timeframe2 - Timeframe1),
+                  BoneTimelineScale.Vectors[P - 1],
+                  BoneTimelineScale.Vectors[P]));
+            end;
+          end;
+        end;
+      end;
+    end;
+  end;
+
+  procedure CalculateVertices;
+  var
+    I, J, K, L: Integer;
+    VB: TMeshVertexBone;
+    V: TVector2;
+    VertexList: TSingleList;
+    BoneParent: TBone;
+    Bones: TBoneList;
+    Slot: TSlot;
+    IsBoneAndAttachmentBelongToSlot: Boolean;
+  begin
+    Bones := TBoneList.Create;
+    Bones.OwnsObjects := False;
+    try
+      for I := 0 to Time.Count - 1 do
+      begin
+        VertexList := TSingleList.Create;
+        VertexList.Count := Attachment.Weights.Count * 2;
+        for J := 0 to Attachment.Weights.Count - 1 do
+        begin
+          V := TVector2.Zero;
+          for K := 0 to Attachment.Weights[J].Bones.Count - 1 do
+          begin
+            VB := Attachment.Weights[J].Bones[K];
+            // Is this bone in the same slot with attachment?
+            IsBoneAndAttachmentBelongToSlot := False;
+            for L := 0 to Slots.Count - 1 do
+            begin
+              Slot := Slots[L];
+              if Slot.Bone.Name = VB.Bone.Name then
+              begin
+                IsBoneAndAttachmentBelongToSlot := True;
+                break;
+              end;
+            end;
+            if IsBoneAndAttachmentBelongToSlot then
+              continue;
+            //
+            Bones.Clear;
+            BoneParent := VB.Bone;
+            while BoneParent <> nil do
+            begin
+              BoneParent.Backup;
+              Bones.Add(BoneParent);
+              for L := 0 to AffectedBoneTimelines.Count - 1 do
+              begin
+                if AffectedBoneTimelines[L].Bone.Name = BoneParent.Name then
+                begin
+                  if AffectedBoneTimelines[L] is TBoneTimelineTranslate then
+                    BoneParent.XY := (AffectedBoneTimelines[L] as TBoneTimelineTranslate).Vectors[I];
+                  if AffectedBoneTimelines[L] is TBoneTimelineRotate then
+                    // TODO: Wh do we need to add 90 degree?
+                    BoneParent.Rotation := BoneParent.Rotation + (AffectedBoneTimelines[L] as TBoneTimelineRotate).Angles[I];
+                  if AffectedBoneTimelines[L] is TBoneTimelineScale then
+                    BoneParent.Scale := (AffectedBoneTimelines[L] as TBoneTimelineScale).Vectors[I];
+                end;
+              end;
+              BoneParent := BoneParent.Parent;
+            end;
+            for L := Bones.Count - 1 downto 0 do
+              Bones[L].UpdateWorldTransform;
+            //
+            V := V + (VB.Bone.ToWorldSpace(VB.V) * VB.Weight);
+            //
+            for L := Bones.Count - 1 downto 0 do
+            begin
+              Bones[L].Restore;
+              Bones[L].UpdateWorldTransform;
+            end;
+          end;
+          VertexList[J * 2    ] := V.X;
+          VertexList[J * 2 + 1] := V.Y;
+        end;
+        Vertices.Add(VertexList);
+      end;
+    finally
+      FreeAndNil(Bones);
+    end;
+  end;
+
+begin
+  CombineTimeframes;
+  InterpolateTimeframes;
+  CalculateVertices;
+end;
+
+procedure TWeightedMeshTimeline.BuildNodes(const MaxAnimationTime: Single; const Container: TX3DRootNode);
+var
+  I, J: Integer;
+  Route: TX3DRoute;
+  VertexList: TSingleList;
+begin
+  Node := TCoordinateInterpolatorNode.Create('WeightedMeshTimeline_' + Name);
+  for I := 0 to Time.Count - 1 do
+  begin
+    Node.FdKey.Items.Add(Time[I] / MaxAnimationTime);
+    VertexList := Vertices.Items[I];
+    Assert(not Odd(VertexList.Count)); // VertexList is a list of 2D coordinates
+    for J := 0 to VertexList.Count div 2 - 1 do
+      Node.FdKeyValue.Items.Add(Vector3(
+        VertexList.Items[2 * J],
+        VertexList.Items[2 * J + 1],
+        0
+      ));
+  end;
+  Container.AddChildren(Node);
+
+  Route := TX3DRoute.Create;
+  Route.SetSourceDirectly(Node.EventValue_changed);
+  Route.SetDestinationDirectly(Attachment.Coord.FdPoint.EventIn);
+  Container.AddRoute(Route);
+end;
+
+{$endif}


### PR DESCRIPTION
This PR is an effort to add support for one of Spine's major features: Weighted mesh.

Things that have been done so far:
- Add deprecated warning to skinnedmesh attachment.
- Support for weighted mesh, by interpolating values between bone timelines.
- Make weighted mesh work with deform timeline.
- Additional frames for better transition, this will make animation more accurate in certain situation (rotation and non-linear interpolation types) in exchange for longer load time and more memory consumption.
- Non-linear interpolation type (Bezier curve) for weighted mesh (both bone timeline and deform timeline).

Limitations:
- Due to the way we handle weighted mesh (by baking every transformations, including bones, into TCoordinateInterpolatorNode), we cannot have a mix of weighted mesh attachments and other types of attachment in the same slot.

Test models: [weighted_mesh.zip](https://github.com/castle-engine/castle-engine/files/4977810/weighted_mesh.zip)

Video: https://youtu.be/AgnwHuohewU
