### PR TITLE
Screen Space Reflections (SSR)

### DIFF
--- a/src/x3d/opengl/castleviewport.pas
+++ b/src/x3d/opengl/castleviewport.pas
@@ -333,7 +333,7 @@ type
     const
       DefaultScreenSpaceAmbientOcclusion = false;
       DefaultScreenSpaceReflections = False;
-      DefaultScreenSpaceReflectionsSurfaceGlossiness = 0.25;
+      DefaultScreenSpaceReflectionsSurfaceGlossiness = 0.5;
       DefaultUseGlobalLights = true;
       DefaultUseGlobalFog = true;
       DefaultShadowVolumes = true;

--- a/src/x3d/opengl/castleviewport.pas
+++ b/src/x3d/opengl/castleviewport.pas
@@ -106,6 +106,10 @@ type
         Viewport: TCastleViewport;
         function SetupUniforms(var BoundTextureUnits: Cardinal): Boolean; override;
       end;
+      TSSRScreenEffect = class(TGLSLScreenEffect)
+        Viewport: TCastleViewport;
+        function SetupUniforms(var BoundTextureUnits: Cardinal): Boolean; override;
+      end;
     var
       FCamera: TCastleCamera;
       FRenderParams: TManagerRenderParams;
@@ -134,6 +138,11 @@ type
       SSAOShader: TSSAOScreenEffect;
       SSAOShaderInitialized: Boolean;
 
+      FScreenSpaceReflections: Boolean;
+      SSRShader: TSSRScreenEffect;
+      SSRShaderInitialized: Boolean;
+      FScreenSpaceReflectionsSurfaceGlossiness: Single;
+
       FOnCameraChanged: TNotifyEvent;
       { Renderer of shadow volumes. You can use this to optimize rendering
         of your shadow quads in RenderShadowVolume, and you can read
@@ -154,7 +163,10 @@ type
     function FillsWholeContainer: boolean;
     function IsStoredNavigation: Boolean;
     procedure SetScreenSpaceAmbientOcclusion(const Value: boolean);
+    procedure SetScreenSpaceReflections(const Value: Boolean);
+    procedure SetScreenSpaceReflectionsSurfaceGlossiness(const Value: Single);
     procedure SSAOShaderInitialize;
+    procedure SSRShaderInitialize;
     function GetNavigationType: TNavigationType;
     procedure SetAutoCamera(const Value: Boolean);
     { Make sure to call AssignDefaultCamera, if needed because of AutoCamera. }
@@ -320,6 +332,8 @@ type
   public
     const
       DefaultScreenSpaceAmbientOcclusion = false;
+      DefaultScreenSpaceReflections = False;
+      DefaultScreenSpaceReflectionsSurfaceGlossiness = 0.25;
       DefaultUseGlobalLights = true;
       DefaultUseGlobalFog = true;
       DefaultShadowVolumes = true;
@@ -522,6 +536,12 @@ type
       You can use it e.g. to disable the menu item to switch SSAO in 3D viewer. }
     function ScreenSpaceAmbientOcclusionAvailable: boolean;
 
+    { Does the graphic card support our ScreenSpaceReflections shader.
+      This does @italic(not) depend on the current state of
+      ScreenSpaceReflections property.
+      You can use it e.g. to disable the menu item to switch SSR in 3D viewer. }
+    function ScreenSpaceReflectionsAvailable: boolean;
+
     procedure GLContextOpen; override;
     procedure GLContextClose; override;
 
@@ -568,6 +588,15 @@ type
     property ScreenSpaceAmbientOcclusion: boolean
       read FScreenSpaceAmbientOcclusion write SetScreenSpaceAmbientOcclusion
       default DefaultScreenSpaceAmbientOcclusion;
+
+    { Enable built-in SSR screen effect in the world. }
+    property ScreenSpaceReflections: Boolean
+      read FScreenSpaceReflections write SetScreenSpaceReflections
+      default DefaultScreenSpaceReflections;
+
+    { Adjust SSR default surface glossiness. }
+    property ScreenSpaceReflectionsSurfaceGlossiness: Single
+      read FScreenSpaceReflectionsSurfaceGlossiness write SetScreenSpaceReflectionsSurfaceGlossiness;
 
     { Called on any camera change. }
     property OnCameraChanged: TNotifyEvent read FOnCameraChanged write FOnCameraChanged;
@@ -1245,6 +1274,28 @@ begin
   Uniform('far').SetValue(1000.0);
 end;
 
+{ TSSRScreenEffect ---------------------------------------------------------- }
+
+function TCastleViewport.TSSRScreenEffect.SetupUniforms(var BoundTextureUnits: Cardinal): Boolean;
+var
+  ViewProjectionMatrix,
+  ViewProjectionMatrixInverse: TMatrix4;
+begin
+  Result := inherited;
+
+  { set special uniforms for SSR shader }
+
+  Uniform('near').SetValue(0.1);
+  Uniform('far').SetValue(1000.0);
+  ViewProjectionMatrix := Viewport.Camera.ProjectionMatrix * Viewport.Camera.Matrix;
+  if not ViewProjectionMatrix.TryInverse(ViewProjectionMatrixInverse) then
+    ViewProjectionMatrixInverse := TMatrix4.Identity;
+  Uniform('defaultSurfaceGlossiness').SetValue(Viewport.ScreenSpaceReflectionsSurfaceGlossiness);
+  Uniform('castle_ViewProjectionMatrix').SetValue(ViewProjectionMatrix);
+  Uniform('castle_ViewProjectionMatrixInverse').SetValue(ViewProjectionMatrixInverse);
+  Uniform('castle_CameraPosition').SetValue(Viewport.Camera.Position);
+end;
+
 { TCastleViewport ------------------------------------------------------- }
 
 constructor TCastleViewport.Create(AOwner: TComponent);
@@ -1256,6 +1307,7 @@ begin
   FRenderParams := TManagerRenderParams.Create;
   FPrepareParams := TPrepareParams.Create;
   FShadowVolumes := DefaultShadowVolumes;
+  FScreenSpaceReflectionsSurfaceGlossiness := DefaultScreenSpaceReflectionsSurfaceGlossiness;
   FClearDepth := true;
   InternalDistortFieldOfViewY := 1;
   InternalDistortViewAspect := 1;
@@ -2245,11 +2297,31 @@ function TCastleViewport.GetScreenEffects(const Index: Integer): TGLSLProgram;
 begin
   if ScreenSpaceAmbientOcclusion then
     SSAOShaderInitialize;
+  if ScreenSpaceReflections then
+    SSRShaderInitialize;
 
+  if ScreenSpaceAmbientOcclusion and (SSAOShader <> nil) and ScreenSpaceReflections and (SSRShader <> nil) then
+  begin
+    if Index = 0 then
+      Result := SSAOShader
+    else
+    if Index = 1 then
+      Result := SSRShader
+    else
+      Result := Items.MainScene.ScreenEffects(Index - 2);
+  end else
   if ScreenSpaceAmbientOcclusion and (SSAOShader <> nil) then
   begin
     if Index = 0 then
-      Result := SSAOShader else
+      Result := SSAOShader
+    else
+      Result := Items.MainScene.ScreenEffects(Index - 1);
+  end else
+  if ScreenSpaceReflections and (SSRShader <> nil) then
+  begin
+    if Index = 0 then
+      Result := SSRShader
+    else
       Result := Items.MainScene.ScreenEffects(Index - 1);
   end else
   if Items.MainScene <> nil then
@@ -2263,6 +2335,8 @@ function TCastleViewport.ScreenEffectsCount: Integer;
 begin
   if ScreenSpaceAmbientOcclusion then
     SSAOShaderInitialize;
+  if ScreenSpaceReflections then
+    SSRShaderInitialize;
 
   if Items.MainScene <> nil then
     Result := Items.MainScene.ScreenEffectsCount
@@ -2270,14 +2344,20 @@ begin
     Result := 0;
   if ScreenSpaceAmbientOcclusion and (SSAOShader <> nil) then
     Inc(Result);
+  if ScreenSpaceReflections and (SSRShader <> nil) then
+    Inc(Result);
 end;
 
 function TCastleViewport.ScreenEffectsNeedDepth: boolean;
 begin
   if ScreenSpaceAmbientOcclusion then
     SSAOShaderInitialize;
+  if ScreenSpaceReflections then
+    SSRShaderInitialize;
 
   if ScreenSpaceAmbientOcclusion and (SSAOShader <> nil) then
+    Exit(true);
+  if ScreenSpaceReflections and (SSRShader <> nil) then
     Exit(true);
   if Items.MainScene <> nil then
     Result := Items.MainScene.ScreenEffectsNeedDepth
@@ -2315,6 +2395,35 @@ begin
   SSAOShaderInitialized := true;
 end;
 
+procedure TCastleViewport.SSRShaderInitialize;
+begin
+  { Do not retry creating SSRShader if SSRShaderInitialize was already called.
+    Even if SSRShader is nil (when SSRShaderInitialize = true but
+    SSRShader = nil it means that compiling SSR shader fails on this GPU). }
+  if SSRShaderInitialized then Exit;
+
+  // SSAOShaderInitialized = false implies SSRShader = nil
+  Assert(SSRShader = nil);
+  if GLFeatures.Shaders <> gsNone then
+  begin
+    try
+      SSRShader := TSSRScreenEffect.Create;
+      SSRShader.Viewport := Self;
+      SSRShader.NeedsDepth := True;
+      SSRShader.ScreenEffectShader := {$I ssr.glsl.inc};
+      SSRShader.Link;
+    except
+      on E: EGLSLError do
+      begin
+        WritelnLog('GLSL', 'Error when initializing GLSL shader for ScreenSpaceReflectionsShader: ' + E.Message);
+        FreeAndNil(SSRShader);
+        ScreenSpaceReflections := False;
+      end;
+    end;
+  end;
+  SSRShaderInitialized := True;
+end;
+
 procedure TCastleViewport.GLContextOpen;
 begin
   inherited;
@@ -2346,11 +2455,35 @@ begin
   Result := (SSAOShader <> nil);
 end;
 
+function TCastleViewport.ScreenSpaceReflectionsAvailable: Boolean;
+begin
+  SSRShaderInitialize;
+  Result := (SSRShader <> nil);
+end;
+
 procedure TCastleViewport.SetScreenSpaceAmbientOcclusion(const Value: boolean);
 begin
   if FScreenSpaceAmbientOcclusion <> Value then
   begin
     FScreenSpaceAmbientOcclusion := Value;
+    VisibleChange([chRender]);
+  end;
+end;
+
+procedure TCastleViewport.SetScreenSpaceReflections(const Value: Boolean);
+begin
+  if FScreenSpaceReflections <> Value then
+  begin
+    FScreenSpaceReflections := Value;
+    VisibleChange([chRender]);
+  end;
+end;
+
+procedure TCastleViewport.SetScreenSpaceReflectionsSurfaceGlossiness(const Value: Single);
+begin
+  if FScreenSpaceReflectionsSurfaceGlossiness <> Value then
+  begin
+    FScreenSpaceReflectionsSurfaceGlossiness := Value;
     VisibleChange([chRender]);
   end;
 end;

--- a/src/x3d/opengl/glsl/generated-pascal/ssr.glsl.inc
+++ b/src/x3d/opengl/glsl/generated-pascal/ssr.glsl.inc
@@ -1,0 +1,179 @@
+{ -*- buffer-read-only: t -*- }
+{ DON'T EDIT -- this file was automatically generated from "source/ssr.glsl" }
+'/**' + LineEnding +
+'* Source code is based on Riccardo Balbo''s SSR shader: https://github.com/riccardobl/SimpleSSRShader/' + LineEnding +
+'*/' + LineEnding +
+'' + LineEnding +
+'uniform float near;' + LineEnding +
+'uniform float far;' + LineEnding +
+'uniform float defaultSurfaceGlossiness;' + LineEnding +
+'uniform mat4 castle_ViewProjectionMatrix;' + LineEnding +
+'uniform mat4 castle_ViewProjectionMatrixInverse;' + LineEnding +
+'uniform vec3 castle_CameraPosition;' + LineEnding +
+'' + LineEnding +
+'#define INITIAL_STEP_LENGTH 1.0' + LineEnding +
+'#define RAY_SAMPLES 16' + LineEnding +
+'#define NEARBY_SAMPLES 4' + LineEnding +
+'#define DEPTH_TEST_BIAS 0.0001' + LineEnding +
+'' + LineEnding +
+'/**' + LineEnding +
+'* Ray structure used for ray marching' + LineEnding +
+'*/' + LineEnding +
+'struct Ray {' + LineEnding +
+'  // World position of the surface from where the ray is originated' + LineEnding +
+'  vec3 worldFrom;' + LineEnding +
+'  // Same as before but in screenspace' + LineEnding +
+'  vec3 screenFrom;' + LineEnding +
+'  // Glossiness of the surface from where the ray is originated. Default is 1' + LineEnding +
+'  float surfaceGlossiness;' + LineEnding +
+'  // Its direction' + LineEnding +
+'  vec3 worldDir;' + LineEnding +
+'  // The size of one pixel' + LineEnding +
+'  vec2 pixelSize;' + LineEnding +
+'};' + LineEnding +
+'' + LineEnding +
+'/**' + LineEnding +
+'* Returned when the ray hit or miss the scene' + LineEnding +
+'*/' + LineEnding +
+'struct HitResult {' + LineEnding +
+'  // Last tested screen position (-1,-1 if missed)' + LineEnding +
+'  vec3 screenPos;' + LineEnding +
+'  // How strong the reflection is' + LineEnding +
+'  float reflStrength;' + LineEnding +
+'};' + LineEnding +
+'' + LineEnding +
+'const vec2 nearFade = vec2(0.01, 1.0);' + LineEnding +
+'const vec2 farFade = vec2(20, 300);' + LineEnding +
+'vec2 _SAMPLES[4];' + LineEnding +
+'' + LineEnding +
+'float getLinearDepth(float depth) {' + LineEnding +
+'  return (2.0 * near) / (far + near - depth * (far - near));' + LineEnding +
+'}' + LineEnding +
+'' + LineEnding +
+'vec2 getPixelSize() {' + LineEnding +
+'  return vec2(1.0 / float(screen_width), 1.0 / float(screen_height));' + LineEnding +
+'}' + LineEnding +
+'' + LineEnding +
+'vec3 worldToScreen(in vec3 worldPos) {' + LineEnding +
+'  vec4 pos = castle_ViewProjectionMatrix * vec4(worldPos, 1.0);' + LineEnding +
+'  pos.xyz /= pos.w;' + LineEnding +
+'  pos.xyz = pos.xyz * 0.5 + 0.5;' + LineEnding +
+'  return pos.xyz;' + LineEnding +
+'}' + LineEnding +
+'' + LineEnding +
+'vec3 screenToWorld(in vec3 screenPos){' + LineEnding +
+'  vec4 pos = vec4(screenPos, 1.0) * 2.0 - 1.0;' + LineEnding +
+'  pos = castle_ViewProjectionMatrixInverse * pos;' + LineEnding +
+'  return pos.xyz /= pos.w;' + LineEnding +
+'}' + LineEnding +
+'' + LineEnding +
+'/**' + LineEnding +
+'* Calculate normal from depth buffer' + LineEnding +
+'*/' + LineEnding +
+'vec3 getNormal(in vec3 worldPos, in vec2 pos) {' + LineEnding +
+'  vec2 pixelSize = getPixelSize();' + LineEnding +
+'  float depth2 = texture2D(screen_depth, pos + vec2(pixelSize.x, 0.0));' + LineEnding +
+'  float depth3 = texture2D(screen_depth, pos + vec2(0.0, pixelSize.y));' + LineEnding +
+'  vec3 worldPos2 = screenToWorld(vec3(pos + vec2(pixelSize.x, 0.0), depth2));' + LineEnding +
+'  vec3 worldPos3 = screenToWorld(vec3(pos + vec2(0.0, pixelSize.y), depth3));' + LineEnding +
+'  vec3 v1 = worldPos3 - worldPos;' + LineEnding +
+'  vec3 v2 = worldPos2 - worldPos;' + LineEnding +
+'  return normalize(cross(v1, v2));' + LineEnding +
+'}' + LineEnding +
+'' + LineEnding +
+'Ray createRay(in vec2 pos, in float depth) {' + LineEnding +
+'  Ray ray;' + LineEnding +
+'  ray.screenFrom = vec3(pos, depth);' + LineEnding +
+'  ray.worldFrom = screenToWorld(ray.screenFrom);' + LineEnding +
+'  ray.surfaceGlossiness = defaultSurfaceGlossiness;' + LineEnding +
+'  vec3 worldNormal = getNormal(ray.worldFrom, pos);' + LineEnding +
+'  // direction from camera to fragment (in world space)' + LineEnding +
+'  vec3 worldDir = normalize(ray.worldFrom - castle_CameraPosition);' + LineEnding +
+'  // reflection vector' + LineEnding +
+'  ray.worldDir = normalize(reflect(worldDir, normalize(worldNormal)));' + LineEnding +
+'  ray.pixelSize = getPixelSize();' + LineEnding +
+'  return ray;' + LineEnding +
+'}' + LineEnding +
+'' + LineEnding +
+'/**' + LineEnding +
+'* Actual ray marching happens here' + LineEnding +
+'*/' + LineEnding +
+'HitResult performRayMarching(in Ray ray){' + LineEnding +
+'  HitResult result;' + LineEnding +
+'  result.screenPos = vec3(-1.0);' + LineEnding +
+'' + LineEnding +
+'  // Current position of the sample along the ray' + LineEnding +
+'  vec3 sampleWorldPos;' + LineEnding +
+'  // Same of before, but in screen space' + LineEnding +
+'  vec3 sampleScreenPos;' + LineEnding +
+'  // Position of the nearest surface at the sample position (in screen space)' + LineEnding +
+'  vec3 hitSurfaceScreenPos;' + LineEnding +
+'  // Length of the next step' + LineEnding +
+'  float stepLength = INITIAL_STEP_LENGTH;' + LineEnding +
+'' + LineEnding +
+'  float linearSourceDepth = getLinearDepth(ray.screenFrom.z);' + LineEnding +
+'' + LineEnding +
+'  for (int i = 0; i < RAY_SAMPLES; i++) {' + LineEnding +
+'    sampleWorldPos = ray.worldFrom + ray.worldDir * stepLength;' + LineEnding +
+'    sampleScreenPos = worldToScreen(sampleWorldPos);' + LineEnding +
+'    float depth = texture2D(screen_depth, sampleScreenPos.xy);' + LineEnding +
+'' + LineEnding +
+'    hitSurfaceScreenPos = vec3(sampleScreenPos.xy, depth);' + LineEnding +
+'    vec3 hitSurfaceWorldPos = screenToWorld(hitSurfaceScreenPos);' + LineEnding +
+'' + LineEnding +
+'    int j = 0;' + LineEnding +
+'    do {' + LineEnding +
+'      // We need to linearize the depth to have consistent tests for distant samples' + LineEnding +
+'      float linearHitSurfaceDepth = getLinearDepth(hitSurfaceScreenPos.z);' + LineEnding +
+'      float linearSampleDepth = getLinearDepth(sampleScreenPos.z);' + LineEnding +
+'      bool hit =' + LineEnding +
+'          linearHitSurfaceDepth > linearSourceDepth // check if the thing we want to reflect is behind the source of the ray' + LineEnding +
+'          && abs(linearSampleDepth - linearHitSurfaceDepth) < DEPTH_TEST_BIAS; // check if the ray is (~almost) hitting the surface' + LineEnding +
+'      // if first hit (letting the cycle running helds to better performances than breaking it)' + LineEnding +
+'      if (hit && result.screenPos.x == -1.0) {' + LineEnding +
+'        result.screenPos = sampleScreenPos;' + LineEnding +
+'        // Fade distant reflections' + LineEnding +
+'        result.reflStrength = distance(hitSurfaceWorldPos, ray.worldFrom);' + LineEnding +
+'        result.reflStrength = smoothstep(nearFade.x, nearFade.y, result.reflStrength)' + LineEnding +
+'            * (1.0 - smoothstep(farFade.x, farFade.y, result.reflStrength));' + LineEnding +
+'      }' + LineEnding +
+'      hitSurfaceScreenPos = vec3(sampleScreenPos.xy, texture2D(screen_depth, sampleScreenPos.xy + _SAMPLES[j].xy * ray.pixelSize));' + LineEnding +
+'      j++;' + LineEnding +
+'    } while (j <= NEARBY_SAMPLES);' + LineEnding +
+'    // Compute next step length' + LineEnding +
+'    stepLength = length(ray.worldFrom - hitSurfaceWorldPos);' + LineEnding +
+'  }' + LineEnding +
+'  return result;' + LineEnding +
+'}' + LineEnding +
+'' + LineEnding +
+'void main(void)' + LineEnding +
+'{' + LineEnding +
+'  vec2 pos = tex_coord_frag;' + LineEnding +
+'  vec4 baseColor = texture2D(screen, pos);' + LineEnding +
+'  float depth = texture2D(screen_depth, pos);' + LineEnding +
+'  _SAMPLES[0] = vec2(1.0, 0.0);' + LineEnding +
+'  _SAMPLES[1] = vec2(-1.0, 0.0);' + LineEnding +
+'  _SAMPLES[2] = vec2(0.0, 1.0);' + LineEnding +
+'  _SAMPLES[3] = vec2(0.0, -1.0);' + LineEnding +
+'' + LineEnding +
+'  if (depth != 1.0) { // ignore the sky' + LineEnding +
+'    // Build the ray' + LineEnding +
+'    Ray ray = createRay(pos, depth);' + LineEnding +
+'' + LineEnding +
+'    // Perform ray marching' + LineEnding +
+'    HitResult result = performRayMarching(ray);' + LineEnding +
+'' + LineEnding +
+'    // Used to fade reflections near screen edges to remove artifacts' + LineEnding +
+'    float d = distance(result.screenPos.xy, vec2(0.5));' + LineEnding +
+'    d = pow(1.0 - clamp(d, 0.0, 0.5) * 2.0, 2.0);' + LineEnding +
+'' + LineEnding +
+'    // Render reflections' + LineEnding +
+'    if (result.screenPos.x > -1.0) {' + LineEnding +
+'      vec3 color = texture2D(screen, result.screenPos.xy).rgb;' + LineEnding +
+'      float a = d * ray.surfaceGlossiness * result.reflStrength;' + LineEnding +
+'      color = ((1.0 - a) * baseColor.rgb) + (a * color);' + LineEnding +
+'      baseColor.rgb = color.rgb;' + LineEnding +
+'    }' + LineEnding +
+'  }' + LineEnding +
+'  gl_FragColor = baseColor;' + LineEnding +
+'}'

--- a/src/x3d/opengl/glsl/source/ssr.glsl
+++ b/src/x3d/opengl/glsl/source/ssr.glsl
@@ -1,0 +1,177 @@
+/**
+* Source code is based on Riccardo Balbo's SSR shader: https://github.com/riccardobl/SimpleSSRShader/
+*/
+
+uniform float near;
+uniform float far;
+uniform float defaultSurfaceGlossiness;
+uniform mat4 castle_ViewProjectionMatrix;
+uniform mat4 castle_ViewProjectionMatrixInverse;
+uniform vec3 castle_CameraPosition;
+
+#define INITIAL_STEP_LENGTH 1.0
+#define RAY_SAMPLES 16
+#define NEARBY_SAMPLES 4
+#define DEPTH_TEST_BIAS 0.0001
+
+/**
+* Ray structure used for ray marching
+*/
+struct Ray {
+  // World position of the surface from where the ray is originated
+  vec3 worldFrom;
+  // Same as before but in screenspace
+  vec3 screenFrom;
+  // Glossiness of the surface from where the ray is originated. Default is 1
+  float surfaceGlossiness;
+  // Its direction
+  vec3 worldDir;
+  // The size of one pixel
+  vec2 pixelSize;
+};
+
+/**
+* Returned when the ray hit or miss the scene
+*/
+struct HitResult {
+  // Last tested screen position (-1,-1 if missed)
+  vec3 screenPos;
+  // How strong the reflection is
+  float reflStrength;
+};
+
+const vec2 nearFade = vec2(0.01, 1.0);
+const vec2 farFade = vec2(20, 300);
+vec2 _SAMPLES[4];
+
+float getLinearDepth(float depth) {
+  return (2.0 * near) / (far + near - depth * (far - near));
+}
+
+vec2 getPixelSize() {
+  return vec2(1.0 / float(screen_width), 1.0 / float(screen_height));
+}
+
+vec3 worldToScreen(in vec3 worldPos) {
+  vec4 pos = castle_ViewProjectionMatrix * vec4(worldPos, 1.0);
+  pos.xyz /= pos.w;
+  pos.xyz = pos.xyz * 0.5 + 0.5;
+  return pos.xyz;
+}
+
+vec3 screenToWorld(in vec3 screenPos){
+  vec4 pos = vec4(screenPos, 1.0) * 2.0 - 1.0;
+  pos = castle_ViewProjectionMatrixInverse * pos;
+  return pos.xyz /= pos.w;
+}
+
+/**
+* Calculate normal from depth buffer
+*/
+vec3 getNormal(in vec3 worldPos, in vec2 pos) {
+  vec2 pixelSize = getPixelSize();
+  float depth2 = texture2D(screen_depth, pos + vec2(pixelSize.x, 0.0));
+  float depth3 = texture2D(screen_depth, pos + vec2(0.0, pixelSize.y));
+  vec3 worldPos2 = screenToWorld(vec3(pos + vec2(pixelSize.x, 0.0), depth2));
+  vec3 worldPos3 = screenToWorld(vec3(pos + vec2(0.0, pixelSize.y), depth3));
+  vec3 v1 = worldPos3 - worldPos;
+  vec3 v2 = worldPos2 - worldPos;
+  return normalize(cross(v1, v2));
+}
+
+Ray createRay(in vec2 pos, in float depth) {
+  Ray ray;
+  ray.screenFrom = vec3(pos, depth);
+  ray.worldFrom = screenToWorld(ray.screenFrom);
+  ray.surfaceGlossiness = defaultSurfaceGlossiness;
+  vec3 worldNormal = getNormal(ray.worldFrom, pos);
+  // direction from camera to fragment (in world space)
+  vec3 worldDir = normalize(ray.worldFrom - castle_CameraPosition);
+  // reflection vector
+  ray.worldDir = normalize(reflect(worldDir, normalize(worldNormal)));
+  ray.pixelSize = getPixelSize();
+  return ray;
+}
+
+/**
+* Actual ray marching happens here
+*/
+HitResult performRayMarching(in Ray ray){
+  HitResult result;
+  result.screenPos = vec3(-1.0);
+
+  // Current position of the sample along the ray
+  vec3 sampleWorldPos;
+  // Same of before, but in screen space
+  vec3 sampleScreenPos;
+  // Position of the nearest surface at the sample position (in screen space)
+  vec3 hitSurfaceScreenPos;
+  // Length of the next step
+  float stepLength = INITIAL_STEP_LENGTH;
+
+  float linearSourceDepth = getLinearDepth(ray.screenFrom.z);
+
+  for (int i = 0; i < RAY_SAMPLES; i++) {
+    sampleWorldPos = ray.worldFrom + ray.worldDir * stepLength;
+    sampleScreenPos = worldToScreen(sampleWorldPos);
+    float depth = texture2D(screen_depth, sampleScreenPos.xy);
+
+    hitSurfaceScreenPos = vec3(sampleScreenPos.xy, depth);
+    vec3 hitSurfaceWorldPos = screenToWorld(hitSurfaceScreenPos);
+
+    int j = 0;
+    do {
+      // We need to linearize the depth to have consistent tests for distant samples
+      float linearHitSurfaceDepth = getLinearDepth(hitSurfaceScreenPos.z);
+      float linearSampleDepth = getLinearDepth(sampleScreenPos.z);
+      bool hit =
+          linearHitSurfaceDepth > linearSourceDepth // check if the thing we want to reflect is behind the source of the ray
+          && abs(linearSampleDepth - linearHitSurfaceDepth) < DEPTH_TEST_BIAS; // check if the ray is (~almost) hitting the surface
+      // if first hit (letting the cycle running helds to better performances than breaking it)
+      if (hit && result.screenPos.x == -1.0) {
+        result.screenPos = sampleScreenPos;
+        // Fade distant reflections
+        result.reflStrength = distance(hitSurfaceWorldPos, ray.worldFrom);
+        result.reflStrength = smoothstep(nearFade.x, nearFade.y, result.reflStrength)
+            * (1.0 - smoothstep(farFade.x, farFade.y, result.reflStrength));
+      }
+      hitSurfaceScreenPos = vec3(sampleScreenPos.xy, texture2D(screen_depth, sampleScreenPos.xy + _SAMPLES[j].xy * ray.pixelSize));
+      j++;
+    } while (j <= NEARBY_SAMPLES);
+    // Compute next step length
+    stepLength = length(ray.worldFrom - hitSurfaceWorldPos);
+  }
+  return result;
+}
+
+void main(void)
+{
+  vec2 pos = tex_coord_frag;
+  vec4 baseColor = texture2D(screen, pos);
+  float depth = texture2D(screen_depth, pos);
+  _SAMPLES[0] = vec2(1.0, 0.0);
+  _SAMPLES[1] = vec2(-1.0, 0.0);
+  _SAMPLES[2] = vec2(0.0, 1.0);
+  _SAMPLES[3] = vec2(0.0, -1.0);
+
+  if (depth != 1.0) { // ignore the sky
+    // Build the ray
+    Ray ray = createRay(pos, depth);
+
+    // Perform ray marching
+    HitResult result = performRayMarching(ray);
+
+    // Used to fade reflections near screen edges to remove artifacts
+    float d = distance(result.screenPos.xy, vec2(0.5));
+    d = pow(1.0 - clamp(d, 0.0, 0.5) * 2.0, 2.0);
+
+    // Render reflections
+    if (result.screenPos.x > -1.0) {
+      vec3 color = texture2D(screen, result.screenPos.xy).rgb;
+      float a = d * ray.surfaceGlossiness * result.reflStrength;
+      color = ((1.0 - a) * baseColor.rgb) + (a * color);
+      baseColor.rgb = color.rgb;
+    }
+  }
+  gl_FragColor = baseColor;
+}


### PR DESCRIPTION
This PR adds SSR screen effect to the engine.

The shader is based on Riccardo Balbo's implementation of SSR: https://github.com/riccardobl/SimpleSSRShader

TCastleViewport have 2 new properties:
- ScreenSpaceReflections: Enable(true)/Disable(false) SSR. Default is false.
- ScreenSpaceReflectionsSurfaceGlossiness: Adjust default surface glossiness (0..1). Default is 0.5.

Limitations:
- Since we lack various information about the scene (mainly because the engine doesn't have Deferred Rendering pipeline), the whole scene is reflectable - no bump mapping, roughness or metallic check.
- No filters (I can't figure out how best to implement it without resorting to low-level APIs).

Some screenshots:
![image1](https://user-images.githubusercontent.com/7451778/90320557-8b045380-df6c-11ea-8133-a04edb399c17.png)
![image](https://user-images.githubusercontent.com/7451778/90325816-a1c99b00-dfaa-11ea-9195-b15bac7ec4eb.png)
![image4](https://user-images.githubusercontent.com/7451778/90325645-54e4c500-dfa8-11ea-860a-cc7949262dca.png)
![image2](https://user-images.githubusercontent.com/7451778/90320562-8e97da80-df6c-11ea-8aee-a37195f4fbcc.png)







