### PR TITLE
Big optimization of RGBA graphics loading with fpimage (300% to 1000%)

### DIFF
--- a/src/images/castleimages_fpimage.inc
+++ b/src/images/castleimages_fpimage.inc
@@ -75,23 +75,25 @@ end;
 
 procedure TRGBAlphaImage.FromFpImage(const FPImage: TInternalCastleFpImage);
 var
-  X, Y: Integer;
-  ResultPixels: PVector4Byte;
-  Color: TFPCompactImgRGBA8BitValue;
+  Y: Integer;
+  RowSize: Integer;
+  SourceRow: PByte;
+  DestRow: PByte;
 begin
   SetSize(FPImage.Width, FPImage.Height);
 
-  ResultPixels := Pixels;
+  RowSize := FPImage.Width * 4;
+  { prepare pointers }
+  SourceRow := PByte(FPImage.FData) + RowSize * FPImage.Height;
+  DestRow := FRawPixels;
+
+  { copy lines upside down}
   for Y := FPImage.Height - 1 downto 0 do
-    for X := 0 to FPImage.Width - 1 do
-    begin
-      Color := FPImage.Colors8Bit[X, Y];
-      ResultPixels^.Data[0] := Color.R;
-      ResultPixels^.Data[1] := Color.G;
-      ResultPixels^.Data[2] := Color.B;
-      ResultPixels^.Data[3] := Color.A;
-      Inc(ResultPixels);
-    end;
+  begin
+    Dec(SourceRow, RowSize);
+    Move(SourceRow^, DestRow^, RowSize);
+    Inc(DestRow, RowSize);
+  end;
 end;
 
 procedure TGrayscaleImage.FromFpImage(const FPImage: TInternalCastleFpImage);


### PR DESCRIPTION
Recently I was looking for code to easily load 8bit per channel graphics and looked at the CGE code. I found simple way to optimize RGBA graphics loading by using `FData` directly. I know that CGE can use libpng and this change can have low priority. But gain is so big  - from 300% to 1000% speed up :)

On my Ryzen 3700X loading 1920x1080 PNG file shortened from 6 ms to 2 ms. On weaker devices like android phone it's from 154 ms to 15 ms.  

On Android also smaller images have big improvement (900 x 100 from 11ms to below 1 ms, 230 x 205 from 4 ms to below 1ms ). 

Currently I only changed the loading of RGBA images, but it is possible to make fixes for RGB as well, but we would have to be able to load graphics into TFPCompactImgRGB8Bit (I think this is a bigger task for another PR). Maybe by adding more `TInternalCastleFpImage` versions.

Unfortunately, so far I have not found a way to make FPImage load graphics into `TFPCompactImgRGB8Bit` or `TFPCompactImgRGBA8Bit` depending on the file loaded. Anyone know how to do that? 

But in many cases we have information whether the file will be RGB or RGBA. For example when jpeg is loaded we can use `TFPCompactImgRGB8Bit` or from `AllowedImageClasses` parameter.

BTW. is there easy way to disable libpng on linux? 
I do something like this to test on desktop:
```
function CastlePngInitialized: boolean;
begin
  Result := false;
  Exit;
  Result := PngLibrary <> nil;
end;
```

I didn't measure how close this change brings us to libpng but I think we should make pascal solution best as we can.

Also adding a way to invert images when we "export/package" game can give as a performance boost. Then there will be only something like:

`Move(Source, Dest, RowSize * Height);` 

Without any loop.

