### PR TITLE
Fix Frogger3d and castle-game regression

### DIFF
--- a/examples/fps_game/gameinitialize.pas
+++ b/examples/fps_game/gameinitialize.pas
@@ -363,6 +363,7 @@ var
     and it follows level's properties like PreferredHeight (from level's
     NavigationInfo.avatarSize). }
 procedure CreatePlayer;
+
   procedure SetupThirdPersonNavigation;
   var
     Avatar: TCastleScene;
@@ -397,6 +398,7 @@ procedure CreatePlayer;
     Player.ThirdPersonNavigation.MoveSpeed := 4;
     Player.ThirdPersonNavigation.RunSpeed := 8;
   end;
+
 begin
   FreeAndNil(Player);
 

--- a/examples/fps_game/gameinitialize.pas
+++ b/examples/fps_game/gameinitialize.pas
@@ -351,6 +351,66 @@ end;
 var
   PlayerHUD: TPlayerHUD;
 
+
+{ Create player. Player implements:
+  - inventory,
+  - automatic picking of items by default,
+  - health (can be hurt by enemies),
+  - equipping weapon (a special item can be equipped and used to hurt enemies),
+  - footsteps
+  - and some other nice stuff.
+  - Player.Navigation is also automatically configured as Viewport.Navigation
+    and it follows level's properties like PreferredHeight (from level's
+    NavigationInfo.avatarSize). }
+procedure CreatePlayer;
+  procedure SetupThirdPersonNavigation;
+  var
+    Avatar: TCastleScene;
+  begin
+    Player.UseThirdPerson := true;
+
+    // RenderOnTop makes sense only for 1st-person camera
+    Player.RenderOnTop := false;
+
+    // TPlayer already created Avatar instance for us, just use it
+    Avatar := Player.ThirdPersonNavigation.Avatar;
+    Avatar.Load('castle-data:/avatar/avatar.gltf');
+
+    { Make Player collide using a sphere.
+      Sphere is more useful than default bounding box for avatars and creatures
+      that move in the world, look ahead, can climb stairs etc. }
+    Player.MiddleHeight := 0.9;
+    Player.CollisionSphereRadius := 0.5;
+
+    { Gravity means that object tries to maintain a constant height
+      (Player.PreferredHeight) above the ground.
+      GrowSpeed means that object raises properly (makes walking up the stairs work).
+      FallSpeed means that object falls properly (makes walking down the stairs,
+      falling down pit etc. work). }
+    Player.Gravity := true;
+    Player.GrowSpeed := 10.0;
+    Player.FallSpeed := 10.0;
+
+    Player.ThirdPersonNavigation.Input_CameraCloser.Assign(keyNone, keyNone, '', false, mbLeft, mwUp);
+    Player.ThirdPersonNavigation.Input_CameraFurther.Assign(keyNone, keyNone, '', false, mbLeft, mwDown);
+    Player.ThirdPersonNavigation.CrouchSpeed := 2;
+    Player.ThirdPersonNavigation.MoveSpeed := 4;
+    Player.ThirdPersonNavigation.RunSpeed := 8;
+  end;
+begin
+  FreeAndNil(Player);
+
+  Player := TPlayer.Create(Application);
+
+  { Use this to enable 3rd-person camera }
+  //SetupThirdPersonNavigation;
+
+  Level.Player := Player;
+
+  if Buttons <> nil then
+    Buttons.ToggleMouseLookButton.Pressed := false;
+end;
+
 { Window callbacks ----------------------------------------------------------- }
 
 procedure Press(Container: TUIContainer; const Event: TInputPressRelease);
@@ -371,6 +431,8 @@ begin
     Buttons.AddCreatureButtonClick(nil) else
   if Event.IsKey(K_F10) then
     Buttons.AddItemButtonClick(nil);
+  if Event.IsKey(K_F1) then
+    CreatePlayer;
 end;
 
 { Customized item ------------------------------------------------------------ }
@@ -455,42 +517,6 @@ end;
 { Initialize the game.
   This is assigned to Application.OnInitialize, and will be called only once. }
 procedure ApplicationInitialize;
-
-  procedure SetupThirdPersonNavigation;
-  var
-    Avatar: TCastleScene;
-  begin
-    Player.UseThirdPerson := true;
-
-    // RenderOnTop makes sense only for 1st-person camera
-    Player.RenderOnTop := false;
-
-    // TPlayer already created Avatar instance for us, just use it
-    Avatar := Player.ThirdPersonNavigation.Avatar;
-    Avatar.Load('castle-data:/avatar/avatar.gltf');
-
-    { Make Player collide using a sphere.
-      Sphere is more useful than default bounding box for avatars and creatures
-      that move in the world, look ahead, can climb stairs etc. }
-    Player.MiddleHeight := 0.9;
-    Player.CollisionSphereRadius := 0.5;
-
-    { Gravity means that object tries to maintain a constant height
-      (Player.PreferredHeight) above the ground.
-      GrowSpeed means that object raises properly (makes walking up the stairs work).
-      FallSpeed means that object falls properly (makes walking down the stairs,
-      falling down pit etc. work). }
-    Player.Gravity := true;
-    Player.GrowSpeed := 10.0;
-    Player.FallSpeed := 10.0;
-
-    Player.ThirdPersonNavigation.Input_CameraCloser.Assign(keyNone, keyNone, '', false, mbLeft, mwUp);
-    Player.ThirdPersonNavigation.Input_CameraFurther.Assign(keyNone, keyNone, '', false, mbLeft, mwDown);
-    Player.ThirdPersonNavigation.CrouchSpeed := 2;
-    Player.ThirdPersonNavigation.MoveSpeed := 4;
-    Player.ThirdPersonNavigation.RunSpeed := 8;
-  end;
-
 begin
   { Turn on some engine optimizations not enabled by default.
     TODO: In the future they should be default, and these variables should be ignored.
@@ -602,14 +628,8 @@ begin
     - and some other nice stuff.
     - Player.Navigation is also automatically configured as Viewport.Navigation
       and it follows level's properties like PreferredHeight (from level's
-      NavigationInfo.avatarSize).
-
-    We must assign Level.Player before Level.Load. }
-  Player := TPlayer.Create(Application);
-  Level.Player := Player;
-
-  { Use this to enable 3rd-person camera }
-  // SetupThirdPersonNavigation;
+      NavigationInfo.avatarSize). }
+  CreatePlayer;
 
   { Load initial level.
     This loads and adds 3D model of your level to the 3D world

--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -2900,9 +2900,30 @@ end;
 procedure TCastleTransform.CameraChanged(const ACamera: TCastleCamera);
 var
   I: Integer;
+  TransformToNotify: TCastleTransform;
 begin
   for I := 0 to List.Count - 1 do
-    List[I].CameraChanged(ACamera);
+  begin
+    TransformToNotify := List[i];
+    { Checking the component status avoids informing an object that
+      changes or initiates change of camera settings during self destruction.
+      For example this situation may appear when TPlayer delete
+      causes reinitialization of the camera in TLevel).
+
+      To do this, see Frogger3d with the changed order of Level and Player
+      creation (Level first, Player next) and play two times:
+
+      FpsPlayer := TPlayer.Create(SceneManager);
+      FpsPlayer.Blocked := true; // do not allow to move player in this game
+      SceneManager.LoadLevel('1');
+      SceneManager.Items.Add(FpsPlayer);
+      SceneManager.Player := FpsPlayer;
+
+      I think that in the case of user games there may be more such situations,
+      so it is worth checking this. }
+    if not (csDestroying in TransformToNotify.ComponentState) then
+      TransformToNotify.CameraChanged(ACamera);
+  end;
 end;
 
 procedure TCastleTransform.CameraChanged(const ACamera: TCastleNavigation);

--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -2900,30 +2900,9 @@ end;
 procedure TCastleTransform.CameraChanged(const ACamera: TCastleCamera);
 var
   I: Integer;
-  TransformToNotify: TCastleTransform;
 begin
   for I := 0 to List.Count - 1 do
-  begin
-    TransformToNotify := List[i];
-    { Checking the component status avoids informing an object that
-      changes or initiates change of camera settings during self destruction.
-      For example this situation may appear when TPlayer delete
-      causes reinitialization of the camera in TLevel).
-
-      To do this, see Frogger3d with the changed order of Level and Player
-      creation (Level first, Player next) and play two times:
-
-      FpsPlayer := TPlayer.Create(SceneManager);
-      FpsPlayer.Blocked := true; // do not allow to move player in this game
-      SceneManager.LoadLevel('1');
-      SceneManager.Items.Add(FpsPlayer);
-      SceneManager.Player := FpsPlayer;
-
-      I think that in the case of user games there may be more such situations,
-      so it is worth checking this. }
-    if not (csDestroying in TransformToNotify.ComponentState) then
-      TransformToNotify.CameraChanged(ACamera);
-  end;
+      List[I].CameraChanged(ACamera);
 end;
 
 procedure TCastleTransform.CameraChanged(const ACamera: TCastleNavigation);

--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -2902,7 +2902,7 @@ var
   I: Integer;
 begin
   for I := 0 to List.Count - 1 do
-      List[I].CameraChanged(ACamera);
+    List[I].CameraChanged(ACamera);
 end;
 
 procedure TCastleTransform.CameraChanged(const ACamera: TCastleNavigation);

--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -1181,7 +1181,10 @@ begin
   if FPlayer <> Value then
   begin
     if FPlayer <> nil then
+    begin
       FPlayer.RemoveFreeNotification(Self);
+      Items.Remove(FPlayer);
+    end;
     FPlayer := Value;
     if FPlayer <> nil then
     begin
@@ -1189,10 +1192,11 @@ begin
       FPlayer.InternalLevel := Self;
     end;
     Viewport.AvoidNavigationCollisions := Value;
+
+    { Reintialize camera and navigation only when level was loaded. }
+    if FInfo <> nil then
+      InitializeCamera;
   end;
-  { Reintialize camera and navigation only when level was loaded. }
-  if FInfo <> nil then
-    InitializeCamera;
 end;
 
 procedure TLevel.InitializeCamera;

--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -1320,8 +1320,7 @@ begin
       begin
         Items.Insert(1, ThirdPersonNavigation.AvatarHierarchy);
         Player.LevelChanged;
-      end
-      else
+      end else
         Items.Add(ThirdPersonNavigation.AvatarHierarchy);
     end else
     if ThirdPersonNavigation.Avatar <> nil then

--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -1195,7 +1195,21 @@ begin
 
     { Reintialize camera and navigation only when level was loaded. }
     if FInfo <> nil then
+    begin
       InitializeCamera;
+      if FPlayer <> nil then
+      begin
+        { Add Player to Items,
+          as the second item (see LoadCore for explanation why),
+          making sure it's not already there (because InitializeCamera
+          may have already added it when UseThirdPerson). }
+        if FPlayer.World = nil then
+        begin
+          Items.Insert(1, FPlayer);
+          FPlayer.LevelChanged;
+        end;
+      end;
+    end;
   end;
 end;
 
@@ -1301,7 +1315,14 @@ begin
     if ThirdPersonNavigation.AvatarHierarchy <> nil then
     begin
       ThirdPersonNavigation.AvatarHierarchy.SetView(InitialPosition, InitialDirection, InitialUp);
-      Items.Add(ThirdPersonNavigation.AvatarHierarchy);
+
+      if (Player <> nil) and (ThirdPersonNavigation.AvatarHierarchy = Player) then
+      begin
+        Items.Insert(1, ThirdPersonNavigation.AvatarHierarchy);
+        Player.LevelChanged;
+      end
+      else
+        Items.Add(ThirdPersonNavigation.AvatarHierarchy);
     end else
     if ThirdPersonNavigation.Avatar <> nil then
     begin

--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -985,7 +985,7 @@ begin
     Items.MainScene.Load(Info.SceneURL);
 
     { Scene must be the first one on Items, this way Items.MoveCollision will
-      use Scene for wall-sliding (see T3DList.MoveCollision implementation). }
+      use Scene for wall-sliding (see TCastleTransform.LocalMoveCollision implementation). }
     Items.Insert(0, Items.MainScene);
 
     InitializeCamera;

--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -336,6 +336,8 @@ type
     function UnloadCore: T3DResourceList;
     function Placeholder(Shape: TShape; PlaceholderName: string): boolean;
     procedure SetPlayer(const Value: TPlayer);
+    { Assigns Camera and Navigation on level loading and setting/change player }
+    procedure InitializeCamera;
     function Items: TCastleRootTransform;
     procedure Update(const SecondsPassed: Single);
   protected
@@ -957,122 +959,6 @@ var
     Logic.PlaceholdersEnd;
   end;
 
-  { Assign Camera and Navigation, knowing Items.MainScene and Player.
-    We need to assign Camera early, as initial Camera also is used
-    when placing initial resources on the level (to determine their
-    initial direction, World.GravityUp etc.) }
-  procedure InitializeCamera;
-  var
-    InitialPosition: TVector3;
-    InitialDirection: TVector3;
-    InitialUp: TVector3;
-    GravityUp: TVector3;
-    Radius, PreferredHeight: Single;
-    ProjectionNear: Single;
-    NavigationNode: TNavigationInfoNode;
-    WalkNavigation: TCastleWalkNavigation;
-    ThirdPersonNavigation: TCastleThirdPersonNavigation;
-  begin
-    if Items.MainScene.ViewpointStack.Top <> nil then
-      Items.MainScene.ViewpointStack.Top.GetView(InitialPosition,
-        InitialDirection, InitialUp, GravityUp) else
-    begin
-      InitialPosition := DefaultX3DCameraPosition[cvVrml2_X3d];
-      InitialDirection := DefaultX3DCameraDirection;
-      InitialUp := DefaultX3DCameraUp;
-      GravityUp := DefaultX3DGravityUp;
-    end;
-
-    NavigationNode := Items.MainScene.NavigationInfoStack.Top;
-
-    // calculate Radius
-    Radius := 0;
-    if (NavigationNode <> nil) and
-       (NavigationNode.FdAvatarSize.Count >= 1) then
-      Radius := NavigationNode.FdAvatarSize.Items[0];
-    // If radius not specified, or invalid (<0), calculate it
-    if Radius <= 0 then
-      Radius := Items.MainScene.BoundingBox.AverageSize(false, 1) * WorldBoxSizeToRadius;
-    Assert(Radius > 0, 'Navigation Radius must be > 0');
-
-    // calculate ProjectionNear
-    ProjectionNear := Radius * RadiusToProjectionNear;
-    Viewport.Camera.ProjectionNear := ProjectionNear;
-
-    if (NavigationNode <> nil) and
-      (NavigationNode.FdAvatarSize.Count >= 2) then
-      PreferredHeight := NavigationNode.FdAvatarSize.Items[1]
-    else
-      PreferredHeight := Max(TCastleNavigation.DefaultPreferredHeight, Radius * RadiusToPreferredHeightMin);
-    CorrectPreferredHeight(PreferredHeight, Radius,
-      TCastleWalkNavigation.DefaultCrouchHeight, TCastleWalkNavigation.DefaultHeadBobbing);
-
-    WalkNavigation := nil;
-    ThirdPersonNavigation := nil;
-    if Player <> nil then
-    begin
-      if Player.UseThirdPerson then
-        ThirdPersonNavigation := Player.ThirdPersonNavigation
-      else
-        WalkNavigation := Player.WalkNavigation;
-    end else
-      { If you don't initialize Player (like for castle1 background level
-        or castle-view-level or lets_take_a_walk) then just create a camera. }
-      WalkNavigation := TCastleWalkNavigation.Create(Self);
-
-    { initialize some navigation settings of player }
-    if Player <> nil then
-    begin
-      Player.DefaultPreferredHeight := PreferredHeight;
-      if NavigationNode <> nil then
-        Player.DefaultMoveHorizontalSpeed := NavigationNode.FdSpeed.Value else
-        Player.DefaultMoveHorizontalSpeed := 1.0;
-      Player.DefaultMoveVerticalSpeed := 20;
-    end else
-    if WalkNavigation <> nil then
-    begin
-      { if you use TCastlePlayer, then it will automatically update navigation
-        speed properties. But if not (when Player = nil), we have to set them
-        explicitly here. }
-      WalkNavigation.PreferredHeight := PreferredHeight;
-      if NavigationNode <> nil then
-        WalkNavigation.MoveHorizontalSpeed := NavigationNode.FdSpeed.Value else
-        WalkNavigation.MoveHorizontalSpeed := 1.0;
-      WalkNavigation.MoveVerticalSpeed := 20;
-    end;
-
-    Viewport.Camera.Init(InitialPosition, InitialDirection, InitialUp, GravityUp);
-    // will be overridden by ThirdPersonNavigation.Init, possibly
-
-    if WalkNavigation <> nil then
-    begin
-      WalkNavigation.PreferredHeight := PreferredHeight;
-      WalkNavigation.Radius := Radius;
-      WalkNavigation.CorrectPreferredHeight;
-      WalkNavigation.CancelFalling;
-
-      Viewport.Navigation := WalkNavigation;
-    end else
-    begin
-      Viewport.Navigation := ThirdPersonNavigation;
-
-      { Use InitialXxx vectors to position avatar, camera will be derived from it.
-        Also add the avatar to Items (avatar needs to be part of hierarchy when
-        ThirdPersonNavigation.Init is called). }
-      if ThirdPersonNavigation.AvatarHierarchy <> nil then
-      begin
-        ThirdPersonNavigation.AvatarHierarchy.SetView(InitialPosition, InitialDirection, InitialUp);
-        Items.Add(ThirdPersonNavigation.AvatarHierarchy);
-      end else
-      if ThirdPersonNavigation.Avatar <> nil then
-      begin
-        ThirdPersonNavigation.Avatar.SetView(InitialPosition, InitialDirection, InitialUp);
-        Items.Add(ThirdPersonNavigation.Avatar);
-      end;
-      ThirdPersonNavigation.Init;
-    end;
-  end;
-
 var
   Options: TPrepareResourcesOptions;
   ShapeList: TShapeList;
@@ -1292,12 +1178,12 @@ end;
 
 procedure TLevel.SetPlayer(const Value: TPlayer);
 begin
-  if (not (csDestroying in ComponentState)) and
+{  if (not (csDestroying in ComponentState)) and
      (Value <> nil) and
      (FInfo <> nil) then
     { Setting Player not allowed now, as Load() would not have a chance to properly
       process it, e.g. setting Player.Navigation as Viewport.Navigation. }
-    raise EInternalError.Create('Do not assign TLevel.Player after calling TLevel.Load');
+    raise EInternalError.Create('Do not assign TLevel.Player after calling TLevel.Load');}
 
   if FPlayer <> Value then
   begin
@@ -1310,6 +1196,122 @@ begin
       FPlayer.InternalLevel := Self;
     end;
     Viewport.AvoidNavigationCollisions := Value;
+  end;
+  { Reintialize camera and navigation only when level was loaded. }
+  if FInfo <> nil then
+    InitializeCamera;
+end;
+
+procedure TLevel.InitializeCamera;
+var
+  InitialPosition: TVector3;
+  InitialDirection: TVector3;
+  InitialUp: TVector3;
+  GravityUp: TVector3;
+  Radius, PreferredHeight: Single;
+  ProjectionNear: Single;
+  NavigationNode: TNavigationInfoNode;
+  WalkNavigation: TCastleWalkNavigation;
+  ThirdPersonNavigation: TCastleThirdPersonNavigation;
+begin
+  if Items.MainScene.ViewpointStack.Top <> nil then
+    Items.MainScene.ViewpointStack.Top.GetView(InitialPosition,
+      InitialDirection, InitialUp, GravityUp) else
+  begin
+    InitialPosition := DefaultX3DCameraPosition[cvVrml2_X3d];
+    InitialDirection := DefaultX3DCameraDirection;
+    InitialUp := DefaultX3DCameraUp;
+    GravityUp := DefaultX3DGravityUp;
+  end;
+
+  NavigationNode := Items.MainScene.NavigationInfoStack.Top;
+
+  // calculate Radius
+  Radius := 0;
+  if (NavigationNode <> nil) and
+     (NavigationNode.FdAvatarSize.Count >= 1) then
+    Radius := NavigationNode.FdAvatarSize.Items[0];
+  // If radius not specified, or invalid (<0), calculate it
+  if Radius <= 0 then
+    Radius := Items.MainScene.BoundingBox.AverageSize(false, 1) * WorldBoxSizeToRadius;
+  Assert(Radius > 0, 'Navigation Radius must be > 0');
+
+  // calculate ProjectionNear
+  ProjectionNear := Radius * RadiusToProjectionNear;
+  Viewport.Camera.ProjectionNear := ProjectionNear;
+
+  if (NavigationNode <> nil) and
+    (NavigationNode.FdAvatarSize.Count >= 2) then
+    PreferredHeight := NavigationNode.FdAvatarSize.Items[1]
+  else
+    PreferredHeight := Max(TCastleNavigation.DefaultPreferredHeight, Radius * RadiusToPreferredHeightMin);
+  CorrectPreferredHeight(PreferredHeight, Radius,
+    TCastleWalkNavigation.DefaultCrouchHeight, TCastleWalkNavigation.DefaultHeadBobbing);
+
+  WalkNavigation := nil;
+  ThirdPersonNavigation := nil;
+  if Player <> nil then
+  begin
+    if Player.UseThirdPerson then
+      ThirdPersonNavigation := Player.ThirdPersonNavigation
+    else
+      WalkNavigation := Player.WalkNavigation;
+  end else
+    { If you don't initialize Player (like for castle1 background level
+      or castle-view-level or lets_take_a_walk) then just create a camera. }
+    WalkNavigation := TCastleWalkNavigation.Create(Self);
+
+  { initialize some navigation settings of player }
+  if Player <> nil then
+  begin
+    Player.DefaultPreferredHeight := PreferredHeight;
+    if NavigationNode <> nil then
+      Player.DefaultMoveHorizontalSpeed := NavigationNode.FdSpeed.Value else
+      Player.DefaultMoveHorizontalSpeed := 1.0;
+    Player.DefaultMoveVerticalSpeed := 20;
+  end else
+  if WalkNavigation <> nil then
+  begin
+    { if you use TCastlePlayer, then it will automatically update navigation
+      speed properties. But if not (when Player = nil), we have to set them
+      explicitly here. }
+    WalkNavigation.PreferredHeight := PreferredHeight;
+    if NavigationNode <> nil then
+      WalkNavigation.MoveHorizontalSpeed := NavigationNode.FdSpeed.Value else
+      WalkNavigation.MoveHorizontalSpeed := 1.0;
+    WalkNavigation.MoveVerticalSpeed := 20;
+  end;
+
+
+  // will be overridden by ThirdPersonNavigation.Init, possibly
+  Viewport.Camera.Init(InitialPosition, InitialDirection, InitialUp, GravityUp);
+
+  if WalkNavigation <> nil then
+  begin
+    WalkNavigation.PreferredHeight := PreferredHeight;
+    WalkNavigation.Radius := Radius;
+    WalkNavigation.CorrectPreferredHeight;
+    WalkNavigation.CancelFalling;
+
+    Viewport.Navigation := WalkNavigation;
+  end else
+  begin
+    Viewport.Navigation := ThirdPersonNavigation;
+
+    { Use InitialXxx vectors to position avatar, camera will be derived from it.
+      Also add the avatar to Items (avatar needs to be part of hierarchy when
+      ThirdPersonNavigation.Init is called). }
+    if ThirdPersonNavigation.AvatarHierarchy <> nil then
+    begin
+      ThirdPersonNavigation.AvatarHierarchy.SetView(InitialPosition, InitialDirection, InitialUp);
+      Items.Add(ThirdPersonNavigation.AvatarHierarchy);
+    end else
+    if ThirdPersonNavigation.Avatar <> nil then
+    begin
+      ThirdPersonNavigation.Avatar.SetView(InitialPosition, InitialDirection, InitialUp);
+      Items.Add(ThirdPersonNavigation.Avatar);
+    end;
+    ThirdPersonNavigation.Init;
   end;
 end;
 

--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -1193,7 +1193,7 @@ begin
     end;
     Viewport.AvoidNavigationCollisions := Value;
 
-    { Reintialize camera and navigation only when level was loaded. }
+    { Reinitialize camera and navigation only when level was loaded. }
     if FInfo <> nil then
     begin
       InitializeCamera;

--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -1178,13 +1178,6 @@ end;
 
 procedure TLevel.SetPlayer(const Value: TPlayer);
 begin
-{  if (not (csDestroying in ComponentState)) and
-     (Value <> nil) and
-     (FInfo <> nil) then
-    { Setting Player not allowed now, as Load() would not have a chance to properly
-      process it, e.g. setting Player.Navigation as Viewport.Navigation. }
-    raise EInternalError.Create('Do not assign TLevel.Player after calling TLevel.Load');}
-
   if FPlayer <> Value then
   begin
     if FPlayer <> nil then

--- a/tests/code/testcastlelevels.pas
+++ b/tests/code/testcastlelevels.pas
@@ -25,11 +25,13 @@ type
   published
     { Test that TLevel.Load works even when GL context is not ready yet }
     procedure TestLoadLevelWithoutGLContext;
+    { Test setting/destroying Player after TLevel.Load }
+    procedure TestSetDestroyPlayerAfterLevelLoad;
   end;
 
 implementation
 
-uses CastleApplicationProperties, CastleViewport, CastleLevels;
+uses CastleApplicationProperties, CastleViewport, CastleLevels, CastlePlayer;
 
 procedure TTestCastleLevels.TestLoadLevelWithoutGLContext;
 var
@@ -46,6 +48,34 @@ begin
 
   Level.Free;
   Viewport.Free;
+end;
+
+procedure TTestCastleLevels.TestSetDestroyPlayerAfterLevelLoad;
+var
+  Level: TLevel;
+  Viewport: TCastleViewport;
+  Player: TPlayer;
+begin
+  Player := TPlayer.Create(nil);
+  Viewport := TCastleViewport.Create(nil);
+
+  Level := TLevel.Create(nil);
+  Level.Viewport := Viewport;
+  Levels.LoadFromFiles('data/game/level_without_loading_image');
+  Level.Load('level_without_loading_image');
+
+  Level.Player := Player;
+  FreeAndNil(Player);
+
+  Player := TPlayer.Create(nil);
+  Level.Player := Player;
+
+  //Level.Load('level_without_loading_image');
+  FreeAndNil(Player);
+  Player := TPlayer.Create(nil);
+  Level.Player := Player;
+  Level.Free;
+  Player.Free;
 end;
 
 initialization

--- a/tests/code/testcastlelevels.pas
+++ b/tests/code/testcastlelevels.pas
@@ -44,6 +44,7 @@ begin
 
   Level := TLevel.Create(nil);
   Level.Viewport := Viewport;
+  Levels.LoadFromFiles('data/game/level_without_loading_image');
   Level.Load('level_without_loading_image');
 
   Level.Free;


### PR DESCRIPTION
This PR fix Player recreation issue. 

Trello issues:
- https://trello.com/c/VhnXB66N/60-fix-frogger3d-crashing-regression
- https://trello.com/c/oXmF5Pda/61-castle-game-regression

This fix simply reinitialize the camera/navigation after changing the Player. This works ok for level restart. 

I played with Frogger a bit longer and made an extra fix to fix problems when destroying an object causes changes to the camera settings, and then it is notified of these changes. What can cause SEGFAULT. Simply way to see this is change the order of creation/adding Player, and Level to scene (in Frogger3D) like this: 

```
  FpsPlayer := TPlayer.Create(SceneManager);
  //SceneManager.Items.Add(FpsPlayer);
  //SceneManager.Player := FpsPlayer;
  FpsPlayer.Blocked := true; // do not allow to move player in this game

  SceneManager.LoadLevel('1');
  SceneManager.Items.Add(FpsPlayer);
  SceneManager.Player := FpsPlayer;
```
I think that such behaviour is even easier to meet in larger projects and not only when using Player/Level api.

