### PR TITLE
Add lazarus-ide as alternative Lazarus executable name

### DIFF
--- a/tools/common-code/toolcompilerinfo.pas
+++ b/tools/common-code/toolcompilerinfo.pas
@@ -142,7 +142,7 @@ begin
     Result := FindExeLazarus('lazarus-ide'); //new possible lazarus executable name on Liux if installed from official binaries
     if Result = '' then
       // Note: FormProject using this message also for ErrorBox, so make sure it looks sensible.
-      raise EExecutableNotFound.Create('Cannot find "lazarus" program. Make sure it is installed, and available on environment variable $PATH. If you use the CGE editor, you can also set Lazarus location in "Preferences".');
+      raise EExecutableNotFound.Create('Cannot find "lazarus" or "lazarus-ide" program. Make sure it is installed, and available on environment variable $PATH. If you use the CGE editor, you can also set Lazarus location in "Preferences".');
   end;
 end;
 

--- a/tools/common-code/toolcompilerinfo.pas
+++ b/tools/common-code/toolcompilerinfo.pas
@@ -138,8 +138,12 @@ function FindExeLazarusIDE: String;
 begin
   Result := FindExeLazarus('lazarus');
   if Result = '' then
-    // Note: FormProject using this message also for ErrorBox, so make sure it looks sensible.
-    raise EExecutableNotFound.Create('Cannot find "lazarus" program. Make sure it is installed, and available on environment variable $PATH. If you use the CGE editor, you can also set Lazarus location in "Preferences".');
+  begin
+    Result := FindExeLazarus('lazarus-ide'); //new possible lazarus executable name on Liux if installed from official binaries
+    if Result = '' then
+      // Note: FormProject using this message also for ErrorBox, so make sure it looks sensible.
+      raise EExecutableNotFound.Create('Cannot find "lazarus" program. Make sure it is installed, and available on environment variable $PATH. If you use the CGE editor, you can also set Lazarus location in "Preferences".');
+  end;
 end;
 
 end.


### PR DESCRIPTION
Summary: On Linux (at least on Debian) official Lazarus+FPC binaries no longer create `lazarus` executable, but `lazarus-ide` in `/usr/bin/`.

Tested and working for me, however, might need confirmation from the original reporter.

Should fix https://github.com/castle-engine/castle-engine/issues/210 Also we've been discussing the issue on Discord.