### PR TITLE
76 : Wrap renaming in TreeView in try..except

### DIFF
--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -2171,10 +2171,13 @@ begin
     Sel.Name := Node.Text;
     ModifiedOutsideObjectInspector;
     RecordUndo(UndoComment); // It'd be good if we set "ItemIndex" to index of "name" field, but there doesn't seem to be an easy way to
+  finally
+    { This method must set Node.Text, to cleanup after ControlsTreeEditing + user editing.
+      - If the name was correct, then "Sel.Name := " goes without exception, 
+        and we want to show new name + class name.
+      - If the name was not correct, then "Sel.Name := " raises exception, 
+        and we want to show old name + class name. }
     Node.Text := ComponentCaption(Sel);
-  except
-    Node.Text := ComponentCaption(Sel);
-    raise;
   end;
 end;
 

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -2165,12 +2165,17 @@ var
   UndoComment: String;
   Sel: TComponent;
 begin
-  Sel := TComponent(Node.Data);
-  UndoComment := 'Rename ' + Sel.Name + ' into ' + Node.Text;
-  Sel.Name := Node.Text;
-  ModifiedOutsideObjectInspector;
-  RecordUndo(UndoComment); // It'd be good if we set "ItemIndex" to index of "name" field, but there doesn't seem to be an easy way to
-  Node.Text := ComponentCaption(Sel);
+  try
+    Sel := TComponent(Node.Data);
+    UndoComment := 'Rename ' + Sel.Name + ' into ' + Node.Text;
+    Sel.Name := Node.Text;
+    ModifiedOutsideObjectInspector;
+    RecordUndo(UndoComment); // It'd be good if we set "ItemIndex" to index of "name" field, but there doesn't seem to be an easy way to
+    Node.Text := ComponentCaption(Sel);
+  except
+    Node.Text := ComponentCaption(Sel);
+    raise;
+  end;
 end;
 
 function TDesignFrame.ControlsTreeAllowDrag(const Src, Dst: TTreeNode): Boolean;


### PR DESCRIPTION
Fixes https://trello.com/c/C66HVb5s/76-bug-assigning-wrong-name-for-the-component-renames-it-in-treeview-and-keeps-the-wrong-name