### PR TITLE
75 bug access violation in castle editor

### DIFF
--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -1823,7 +1823,8 @@ var
   UI: TCastleUserInterface;
 begin
   { Workaround possible ControlsTree.Selected = nil when the user deselects
-    the currently edited component by clicking somewhere else }
+    the currently edited component by clicking somewhere else.
+    See https://trello.com/c/V6v2rBwv/75-bug-access-violation-in-castle-editor . }
   if ControlsTree.Selected = nil then
   begin
     UpdateDesign; // Something has changed, but we don't know what exactly. Maybe it's some component's name? Let's rebuild everything to be safe

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -1822,10 +1822,13 @@ var
   Sel: TComponent;
   UI: TCastleUserInterface;
 begin
+  { Workaround possible ControlsTree.Selected = nil when the user deselects
+    the currently edited component by clicking somewhere else }
   if ControlsTree.Selected = nil then
   begin
-    UpdateDesign;
-    //failing to record Undo here
+    UpdateDesign; // Something has changed, but we don't know what exactly. Maybe it's some component's name? Let's rebuild everything to be safe
+    //if not UndoSystem.ScheduleRecordUndoOnRelease then // We don't care here, this situation is an error, so we're saving what we can
+    RecordUndo('Modify property'); // We're recording a generic Undo message
     Exit;
   end;
   // This knows we have selected *at least one* component.

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -1822,6 +1822,12 @@ var
   Sel: TComponent;
   UI: TCastleUserInterface;
 begin
+  if ControlsTree.Selected = nil then
+  begin
+    UpdateDesign;
+    //failing to record Undo here
+    Exit;
+  end;
   // This knows we have selected *at least one* component.
   // When you modify component Name in PropertyGrid, update it in the ControlsTree.
   Assert(ControlsTree.Selected <> nil);


### PR DESCRIPTION
Workaround bug when we may have `ControlsTree.Selected = nil` in `TDesignFrame.PropertyGridModified` under some circumstances

Trello issue: https://trello.com/c/V6v2rBwv/75-bug-access-violation-in-castle-editor