### PR TITLE
Rename TMouseButton into TCastleMouseButton

### DIFF
--- a/examples/2d_dragon_spine_game/code/gameinitialize.pas
+++ b/examples/2d_dragon_spine_game/code/gameinitialize.pas
@@ -356,7 +356,7 @@ begin
   if Event.IsKey(keyEscape) then
     Application.Terminate;
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     if Viewport.PositionToWorldPlane(Event.Position, true, 0, WorldPosition) then
     begin

--- a/examples/2d_standard_ui/dragging_test/gamestatemain.pas
+++ b/examples/2d_standard_ui/dragging_test/gamestatemain.pas
@@ -110,7 +110,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     Dragging := true;
     if MouseLook then
@@ -127,7 +127,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     Dragging := false;
     if MouseLook then

--- a/examples/2d_standard_ui/zombie_fighter/gamestateplay.pas
+++ b/examples/2d_standard_ui/zombie_fighter/gamestateplay.pas
@@ -163,7 +163,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     Triangle := Viewport.TriangleHit;
     if (Triangle <> nil) and // we clicked on something that has triangle information (e.g. because it has Spatial with ssDynamicCollisions)

--- a/examples/2d_standard_ui/zombie_fighter_alternative_short_lived_states/gamestateplay.pas
+++ b/examples/2d_standard_ui/zombie_fighter_alternative_short_lived_states/gamestateplay.pas
@@ -161,7 +161,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     Triangle := Viewport.TriangleHit;
     if (Triangle <> nil) and // we clicked on something that has triangle information (e.g. because it has Spatial with ssDynamicCollisions)

--- a/examples/3d_rendering_processing/detect_scene_clicks.lpr
+++ b/examples/3d_rendering_processing/detect_scene_clicks.lpr
@@ -60,7 +60,7 @@ procedure WindowPress(Container: TUIContainer; const Event: TInputPressRelease);
 var
   TopMostScene: TCastleTransform;
 begin
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     TopMostScene := Viewport.TransformUnderMouse;
     if TopMostScene <> nil then

--- a/examples/audio/doppler_demo/doppler_demo.lpr
+++ b/examples/audio/doppler_demo/doppler_demo.lpr
@@ -64,7 +64,7 @@ end;
 
 procedure Motion(Container: TUIContainer; const Event: TInputMotion);
 begin
-  if mbLeft in Event.Pressed then
+  if buttonLeft in Event.Pressed then
   begin
     SoundPosition := Vector3(Event.Position[0], Event.Position[1], 0);
     if Sound <> nil then

--- a/examples/fixed_camera_game/code/gamestateintro.pas
+++ b/examples/fixed_camera_game/code/gamestateintro.pas
@@ -189,7 +189,7 @@ begin
     TUIState.Current := StateMainMenu;
     Result := true;
   end else
-  if Event.IsMouseButton(mbLeft) or Event.IsKey(keySpace) then
+  if Event.IsMouseButton(buttonLeft) or Event.IsKey(keySpace) then
   begin
     NextIntroPart;
     Result := true;

--- a/examples/fixed_camera_game/code/gamestateplay.pas
+++ b/examples/fixed_camera_game/code/gamestateplay.pas
@@ -150,7 +150,7 @@ begin
       end;
     itMouseButton:
       begin
-        if Event.MouseButton = mbLeft then
+        if Event.MouseButton = buttonLeft then
         begin
           if Viewport.MouseRayHit <> nil then
             Player.WantsToWalk(Viewport.MouseRayHit.Last.Point);

--- a/examples/fps_game/gameinitialize.pas
+++ b/examples/fps_game/gameinitialize.pas
@@ -416,8 +416,8 @@ procedure CreatePlayer;
     Player.GrowSpeed := 10.0;
     Player.FallSpeed := 10.0;
 
-    Player.ThirdPersonNavigation.Input_CameraCloser.Assign(keyNone, keyNone, '', false, mbLeft, mwUp);
-    Player.ThirdPersonNavigation.Input_CameraFurther.Assign(keyNone, keyNone, '', false, mbLeft, mwDown);
+    Player.ThirdPersonNavigation.Input_CameraCloser.Assign(keyNone, keyNone, '', false, buttonLeft, mwUp);
+    Player.ThirdPersonNavigation.Input_CameraFurther.Assign(keyNone, keyNone, '', false, buttonLeft, mwDown);
     Player.ThirdPersonNavigation.CrouchSpeed := 2;
     Player.ThirdPersonNavigation.MoveSpeed := 4;
     Player.ThirdPersonNavigation.RunSpeed := 8;
@@ -632,7 +632,7 @@ begin
   PlayerInput_DropItem.Assign(keyR);
   if not ApplicationProperties.TouchDevice then
     // allow shooting by clicking or pressing Ctrl key
-    PlayerInput_Attack.Assign(keyCtrl, keyNone, '', true, mbLeft);
+    PlayerInput_Attack.Assign(keyCtrl, keyNone, '', true, buttonLeft);
 
   { Allow using type="MedKit" inside resource.xml files,
     to define our MedKit item. }

--- a/examples/library/lazarus_library_tester/cge_dynlib_tester_form.pas
+++ b/examples/library/lazarus_library_tester/cge_dynlib_tester_form.pas
@@ -71,11 +71,11 @@ type
       Shift: TShiftState);
     procedure OpenGLControl1KeyUp(Sender: TObject; var Key: Word;
       Shift: TShiftState);
-    procedure OpenGLControl1MouseDown(Sender: TObject; Button: TMouseButton;
+    procedure OpenGLControl1MouseDown(Sender: TObject; Button: Controls.TMouseButton;
       Shift: TShiftState; X, Y: Integer);
     procedure OpenGLControl1MouseMove(Sender: TObject; Shift: TShiftState; X,
       Y: Integer);
-    procedure OpenGLControl1MouseUp(Sender: TObject; Button: TMouseButton;
+    procedure OpenGLControl1MouseUp(Sender: TObject; Button: Controls.TMouseButton;
       Shift: TShiftState; X, Y: Integer);
     procedure OpenGLControl1MouseWheel(Sender: TObject; Shift: TShiftState;
       WheelDelta: Integer; MousePos: TPoint; var Handled: Boolean);
@@ -159,10 +159,10 @@ begin
   { TODO }
 end;
 
-procedure TForm1.OpenGLControl1MouseDown(Sender: TObject; Button: TMouseButton;
+procedure TForm1.OpenGLControl1MouseDown(Sender: TObject; Button: Controls.TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 begin
-  CGE_MouseDown(x, OpenGLControl1.Height - 1 - y, Button=mbLeft, 0);
+  CGE_MouseDown(x, OpenGLControl1.Height - 1 - y, Button=Controls.mbLeft, 0);
 end;
 
 procedure TForm1.OpenGLControl1MouseMove(Sender: TObject; Shift: TShiftState;
@@ -171,10 +171,10 @@ begin
   CGE_Motion(x, OpenGLControl1.Height - 1 - y, 0);
 end;
 
-procedure TForm1.OpenGLControl1MouseUp(Sender: TObject; Button: TMouseButton;
+procedure TForm1.OpenGLControl1MouseUp(Sender: TObject; Button: Controls.TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 begin
-  CGE_MouseUp(x, OpenGLControl1.Height - 1 - y, Button=mbLeft, 0, true);
+  CGE_MouseUp(x, OpenGLControl1.Height - 1 - y, Button=Controls.mbLeft, 0, true);
 end;
 
 procedure TForm1.OpenGLControl1MouseWheel(Sender: TObject; Shift: TShiftState;

--- a/examples/library/lazarus_library_tester/cge_dynlib_tester_form.pas
+++ b/examples/library/lazarus_library_tester/cge_dynlib_tester_form.pas
@@ -71,11 +71,11 @@ type
       Shift: TShiftState);
     procedure OpenGLControl1KeyUp(Sender: TObject; var Key: Word;
       Shift: TShiftState);
-    procedure OpenGLControl1MouseDown(Sender: TObject; Button: Controls.TMouseButton;
+    procedure OpenGLControl1MouseDown(Sender: TObject; Button: TMouseButton;
       Shift: TShiftState; X, Y: Integer);
     procedure OpenGLControl1MouseMove(Sender: TObject; Shift: TShiftState; X,
       Y: Integer);
-    procedure OpenGLControl1MouseUp(Sender: TObject; Button: Controls.TMouseButton;
+    procedure OpenGLControl1MouseUp(Sender: TObject; Button: TMouseButton;
       Shift: TShiftState; X, Y: Integer);
     procedure OpenGLControl1MouseWheel(Sender: TObject; Shift: TShiftState;
       WheelDelta: Integer; MousePos: TPoint; var Handled: Boolean);
@@ -159,7 +159,7 @@ begin
   { TODO }
 end;
 
-procedure TForm1.OpenGLControl1MouseDown(Sender: TObject; Button: Controls.TMouseButton;
+procedure TForm1.OpenGLControl1MouseDown(Sender: TObject; Button: TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 begin
   CGE_MouseDown(x, OpenGLControl1.Height - 1 - y, Button=mbLeft, 0);
@@ -171,7 +171,7 @@ begin
   CGE_Motion(x, OpenGLControl1.Height - 1 - y, 0);
 end;
 
-procedure TForm1.OpenGLControl1MouseUp(Sender: TObject; Button: Controls.TMouseButton;
+procedure TForm1.OpenGLControl1MouseUp(Sender: TObject; Button: TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 begin
   CGE_MouseUp(x, OpenGLControl1.Height - 1 - y, Button=mbLeft, 0, true);

--- a/examples/physics/physics_2d_game_sopwith/gameinitialize.pas
+++ b/examples/physics/physics_2d_game_sopwith/gameinitialize.pas
@@ -279,13 +279,13 @@ end;
 
 procedure WindowPress(Container: TUIContainer; const Event: TInputPressRelease);
 begin
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
     UpdatePlanePosition(Event.Position);
 end;
 
 procedure WindowMotion(Container: TUIContainer; const Event: TInputMotion);
 begin
-  if mbLeft in Event.Pressed then
+  if buttonLeft in Event.Pressed then
     UpdatePlanePosition(Event.Position);
 end;
 

--- a/examples/physics/physics_3d_demo/gameinitialize.pas
+++ b/examples/physics/physics_3d_demo/gameinitialize.pas
@@ -195,7 +195,7 @@ begin
   if Event.IsKey(keyF6) then
     Viewport.Items.EnablePhysics := not Viewport.Items.EnablePhysics;
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     RigidBody := TRigidBody.Create(BoxTemplate);
 

--- a/examples/physics/physics_3d_demo/gameinitialize.pas
+++ b/examples/physics/physics_3d_demo/gameinitialize.pas
@@ -206,7 +206,7 @@ begin
     Spawn(BoxTemplate, BoxCollider, RigidBody);
   end;
 
-  if Event.IsMouseButton(mbRight) then
+  if Event.IsMouseButton(buttonRight) then
   begin
     RigidBody := TRigidBody.Create(SphereTemplate);
 

--- a/examples/third_person_camera/gamestateplay.pas
+++ b/examples/third_person_camera/gamestateplay.pas
@@ -123,8 +123,8 @@ begin
     In particular assign some keys that are not assigned by default. }
   ThirdPersonNavigation.Input_LeftStrafe.Assign(keyQ);
   ThirdPersonNavigation.Input_RightStrafe.Assign(keyE);
-  ThirdPersonNavigation.Input_CameraCloser.Assign(keyNone, keyNone, '', false, mbLeft, mwUp);
-  ThirdPersonNavigation.Input_CameraFurther.Assign(keyNone, keyNone, '', false, mbLeft, mwDown);
+  ThirdPersonNavigation.Input_CameraCloser.Assign(keyNone, keyNone, '', false, buttonLeft, mwUp);
+  ThirdPersonNavigation.Input_CameraFurther.Assign(keyNone, keyNone, '', false, buttonLeft, mwDown);
   ThirdPersonNavigation.MouseLook := true; // by default use mouse look
   ThirdPersonNavigation.Init;
 end;

--- a/examples/third_person_camera/gamestateplay.pas
+++ b/examples/third_person_camera/gamestateplay.pas
@@ -141,7 +141,7 @@ procedure TStatePlay.Update(const SecondsPassed: Single; var HandleInput: Boolea
   (*
   procedure UpdateAimAvatar;
   begin
-    if mbRight in Container.MousePressed then
+    if buttonRight in Container.MousePressed then
       ThirdPersonNavigation.AimAvatar := aaHorizontal
     else
       ThirdPersonNavigation.AimAvatar := aaNone;
@@ -228,7 +228,7 @@ begin
     Exit(true);
   end;
 
-  if Event.IsMouseButton(mbRight) then
+  if Event.IsMouseButton(buttonRight) then
   begin
     CheckboxAimAvatar.Checked := not CheckboxAimAvatar.Checked;
     ChangeCheckboxAimAvatar(CheckboxAimAvatar); // update ThirdPersonNavigation.AimAvatar

--- a/examples/third_person_camera/gamestateplay.pas
+++ b/examples/third_person_camera/gamestateplay.pas
@@ -186,7 +186,7 @@ begin
     not handled in children controls.
   }
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     SoundEngine.Sound(SoundEngine.SoundFromName('shoot_sound'));
 

--- a/examples/tiled/map_viewer/gameinitialize.pas
+++ b/examples/tiled/map_viewer/gameinitialize.pas
@@ -108,7 +108,7 @@ end;
 procedure TEventsHandler.MapMotion(const Sender: TInputListener;
   const Event: TInputMotion; var Handled: Boolean);
 begin
-  if mbLeft in Event.Pressed then
+  if buttonLeft in Event.Pressed then
   begin
     TiledMap.Origin := TiledMap.Origin -
       (Event.Position - Event.OldPosition) / TiledMap.Scale;

--- a/examples/tiled/strategy_game_demo/gamestateplay.pas
+++ b/examples/tiled/strategy_game_demo/gamestateplay.pas
@@ -213,7 +213,7 @@ procedure TStatePlay.MapPress(const Sender: TInputListener;
 var
   UnitUnderMouse: TUnit;
 begin
-  if Event.IsMouseButton(mbLeft) and TileUnderMouseExists then
+  if Event.IsMouseButton(buttonLeft) and TileUnderMouseExists then
   begin
     Handled := true;
     UnitUnderMouse := UnitsOnMap[TileUnderMouse];

--- a/examples/tiled/strategy_game_demo/gamestatewin.pas
+++ b/examples/tiled/strategy_game_demo/gamestatewin.pas
@@ -58,7 +58,7 @@ function TStateWin.Press(const Event: TInputPressRelease): Boolean;
 begin
   Result := inherited;
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     TUIState.Current := StateMainMenu;
     Exit(ExclusiveEvents);

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -1261,7 +1261,7 @@ type
       read FMouseButtonMove write FMouseButtonMove default mbMiddle;
     { Drag with this mouse button to zoom the model (look closer / further). }
     property MouseButtonZoom: TCastleMouseButton
-      read FMouseButtonZoom write FMouseButtonZoom default mbRight;
+      read FMouseButtonZoom write FMouseButtonZoom default buttonRight;
 
     { Current rotation of the model.
       Rotation is done around ModelBox middle (with @link(Translation) added). }
@@ -3090,7 +3090,7 @@ begin
 
   FMouseButtonRotate := buttonLeft;
   FMouseButtonMove := mbMiddle;
-  FMouseButtonZoom := mbRight;
+  FMouseButtonZoom := buttonRight;
 
   for I := 0 to 2 do
     for B := false to true do
@@ -3716,9 +3716,9 @@ begin
   if (buttonLeft in Container.MousePressed) and (ModsDown = []) then
     DraggingMouseButton := buttonLeft
   else
-  if ((mbRight in Container.MousePressed) and (ModsDown = [])) or
+  if ((buttonRight in Container.MousePressed) and (ModsDown = [])) or
      ((buttonLeft in Container.MousePressed) and (ModsDown = [mkCtrl])) then
-    DraggingMouseButton := mbRight
+    DraggingMouseButton := buttonRight
   else
   if ((mbMiddle in Container.MousePressed) and (ModsDown = [])) or
      ((buttonLeft in Container.MousePressed) and (ModsDown = [mkShift])) then
@@ -4890,7 +4890,7 @@ procedure TCastleWalkNavigation.Update(const SecondsPassed: Single;
       if Abs(Delta[0]) > Tolerance then
         RotateHorizontal(-Delta[0] * SecondsPassed * MouseDraggingHorizontalRotationSpeed); { rotate }
     end
-    else if mbRight in Container.MousePressed then
+    else if buttonRight in Container.MousePressed then
     begin
       if Delta[0] < -Tolerance then
       begin
@@ -5005,7 +5005,7 @@ begin
     { mouse dragging navigation }
     if (MouseDraggingStarted <> -1) and
        ReallyEnableMouseDragging and
-       ((buttonLeft in Container.MousePressed) or (mbRight in Container.MousePressed)) and
+       ((buttonLeft in Container.MousePressed) or (buttonRight in Container.MousePressed)) and
        { Enable dragging only when no modifiers (except Input_Run,
          which must be allowed to enable running) are pressed.
          This allows application to handle e.g. ctrl + dragging

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -1255,7 +1255,7 @@ type
       )
     }
     property MouseButtonRotate: TCastleMouseButton
-      read FMouseButtonRotate write FMouseButtonRotate default mbLeft;
+      read FMouseButtonRotate write FMouseButtonRotate default buttonLeft;
     { Drag with this mouse button to move the model. }
     property MouseButtonMove: TCastleMouseButton
       read FMouseButtonMove write FMouseButtonMove default mbMiddle;
@@ -3088,7 +3088,7 @@ begin
   FPinchGestureRecognizer := TCastlePinchPanGestureRecognizer.Create;
   FPinchGestureRecognizer.OnGestureChanged := @OnGestureRecognized;
 
-  FMouseButtonRotate := mbLeft;
+  FMouseButtonRotate := buttonLeft;
   FMouseButtonMove := mbMiddle;
   FMouseButtonZoom := mbRight;
 
@@ -3126,7 +3126,7 @@ begin
   FInput_StopRotating := TInputShortcut.Create(Self);
    Input_StopRotating.Name := 'Input_StopRotating';
    Input_StopRotating.SetSubComponent(true);
-   Input_StopRotating.Assign(keySpace, keyNone, '', true, mbLeft);
+   Input_StopRotating.Assign(keySpace, keyNone, '', true, buttonLeft);
 end;
 
 destructor TCastleExamineNavigation.Destroy;
@@ -3713,15 +3713,15 @@ begin
 
   { Look at Container.MousePressed and ModsDown to determine
     which mouse button is "dragging" now. }
-  if (mbLeft in Container.MousePressed) and (ModsDown = []) then
-    DraggingMouseButton := mbLeft
+  if (buttonLeft in Container.MousePressed) and (ModsDown = []) then
+    DraggingMouseButton := buttonLeft
   else
   if ((mbRight in Container.MousePressed) and (ModsDown = [])) or
-     ((mbLeft in Container.MousePressed) and (ModsDown = [mkCtrl])) then
+     ((buttonLeft in Container.MousePressed) and (ModsDown = [mkCtrl])) then
     DraggingMouseButton := mbRight
   else
   if ((mbMiddle in Container.MousePressed) and (ModsDown = [])) or
-     ((mbLeft in Container.MousePressed) and (ModsDown = [mkShift])) then
+     ((buttonLeft in Container.MousePressed) and (ModsDown = [mkShift])) then
     DraggingMouseButton := mbMiddle
   else
     Exit;
@@ -4880,7 +4880,7 @@ procedure TCastleWalkNavigation.Update(const SecondsPassed: Single;
     else
       MoveSizeY := (Abs(Delta[1]) - Tolerance) * MouseDraggingMoveSpeed;
 
-    if mbLeft in Container.MousePressed then
+    if buttonLeft in Container.MousePressed then
     begin
       if Delta[1] < -Tolerance then
         MoveHorizontal(-MoveSizeY * SecondsPassed, 1); { forward }
@@ -5005,7 +5005,7 @@ begin
     { mouse dragging navigation }
     if (MouseDraggingStarted <> -1) and
        ReallyEnableMouseDragging and
-       ((mbLeft in Container.MousePressed) or (mbRight in Container.MousePressed)) and
+       ((buttonLeft in Container.MousePressed) or (mbRight in Container.MousePressed)) and
        { Enable dragging only when no modifiers (except Input_Run,
          which must be allowed to enable running) are pressed.
          This allows application to handle e.g. ctrl + dragging

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -1154,7 +1154,7 @@ type
       FInput_Home: TInputShortcut;
       FInput_StopRotating: TInputShortcut;
 
-      FMouseButtonRotate, FMouseButtonMove, FMouseButtonZoom: TMouseButton;
+      FMouseButtonRotate, FMouseButtonMove, FMouseButtonZoom: TCastleMouseButton;
 
     procedure SetRotationsAnim(const Value: TVector3);
     function GetRotations: TQuaternion;
@@ -1254,13 +1254,13 @@ type
           pressing middle mouse button.)
       )
     }
-    property MouseButtonRotate: TMouseButton
+    property MouseButtonRotate: TCastleMouseButton
       read FMouseButtonRotate write FMouseButtonRotate default mbLeft;
     { Drag with this mouse button to move the model. }
-    property MouseButtonMove: TMouseButton
+    property MouseButtonMove: TCastleMouseButton
       read FMouseButtonMove write FMouseButtonMove default mbMiddle;
     { Drag with this mouse button to zoom the model (look closer / further). }
-    property MouseButtonZoom: TMouseButton
+    property MouseButtonZoom: TCastleMouseButton
       read FMouseButtonZoom write FMouseButtonZoom default mbRight;
 
     { Current rotation of the model.
@@ -3686,7 +3686,7 @@ var
   end;
 
 var
-  DraggingMouseButton: TMouseButton;
+  DraggingMouseButton: TCastleMouseButton;
 begin
   Result := inherited;
   if Result then Exit;

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -1258,7 +1258,7 @@ type
       read FMouseButtonRotate write FMouseButtonRotate default buttonLeft;
     { Drag with this mouse button to move the model. }
     property MouseButtonMove: TCastleMouseButton
-      read FMouseButtonMove write FMouseButtonMove default mbMiddle;
+      read FMouseButtonMove write FMouseButtonMove default buttonMiddle;
     { Drag with this mouse button to zoom the model (look closer / further). }
     property MouseButtonZoom: TCastleMouseButton
       read FMouseButtonZoom write FMouseButtonZoom default buttonRight;
@@ -3089,7 +3089,7 @@ begin
   FPinchGestureRecognizer.OnGestureChanged := @OnGestureRecognized;
 
   FMouseButtonRotate := buttonLeft;
-  FMouseButtonMove := mbMiddle;
+  FMouseButtonMove := buttonMiddle;
   FMouseButtonZoom := buttonRight;
 
   for I := 0 to 2 do
@@ -3720,9 +3720,9 @@ begin
      ((buttonLeft in Container.MousePressed) and (ModsDown = [mkCtrl])) then
     DraggingMouseButton := buttonRight
   else
-  if ((mbMiddle in Container.MousePressed) and (ModsDown = [])) or
+  if ((buttonMiddle in Container.MousePressed) and (ModsDown = [])) or
      ((buttonLeft in Container.MousePressed) and (ModsDown = [mkShift])) then
-    DraggingMouseButton := mbMiddle
+    DraggingMouseButton := buttonMiddle
   else
     Exit;
 

--- a/src/3d/castlecameras_default_examine_mouse_buttons.txt
+++ b/src/3d/castlecameras_default_examine_mouse_buttons.txt
@@ -19,28 +19,28 @@ vrweb:
 - rotating: mbMiddle
 - moving closer/further: mbRight (like in Blender: down closer, up further,
   horizontal doesn't matter)
-- moving left/right/down/up: mbLeft
+- moving left/right/down/up: buttonLeft
 
 GIMP normalmap 3d preview:
-- rotating: mbLeft
+- rotating: buttonLeft
 - moving closer/further: mbRight (like in Blender: down closer, up further,
   horizontal doesn't matter)
 - no moving left/right/down/up.
 
 My thoughts and conclusions:
 - rotating seems most natural in Examine mode (that's where this navigation
-  mode is the most comfortable), so it should be on mbLeft (like normalmap)
+  mode is the most comfortable), so it should be on buttonLeft (like normalmap)
   with no modifiers (like Blender).
 - moving closer/further: 2nd most important action in Examine mode, IMO.
   Goes to mbRight. For people with 1 mouse button, and for Blender analogy,
-  it's also on Ctrl + mbLeft.
+  it's also on Ctrl + buttonLeft.
 - moving left/right/down/up: mbMiddle.
   For people with no middle button, and Blender analogy, it's also on
-  Shift + mbLeft.
+  Shift + buttonLeft.
 
 This achieves a couple of nice goals:
-- everything is available with only mbLeft, for people with 1 mouse button.
-- Blender analogy: you can say to just switch "mbMiddle" to "mbLeft",
+- everything is available with only buttonLeft, for people with 1 mouse button.
+- Blender analogy: you can say to just switch "mbMiddle" to "buttonLeft",
   and it works the same
 - OTOH, for people with 3 mouse buttons, that do not catch the fact that
   keyboard modifiers change the navigation, also each mb (without modifier)

--- a/src/3d/castlecameras_default_examine_mouse_buttons.txt
+++ b/src/3d/castlecameras_default_examine_mouse_buttons.txt
@@ -10,13 +10,13 @@ Let's check what others use:
 
 Blender:
 - rotating: on bmMiddle
-- moving left/right/down/up: on Shift + mbMiddle
-- moving closer/further: on Ctrl + mbMiddle
+- moving left/right/down/up: on Shift + buttonMiddle
+- moving closer/further: on Ctrl + buttonMiddle
   (moving down brings closer, up brings further; horizontal move ignored)
 Both Shift and Ctrl pressed do nothing.
 
 vrweb:
-- rotating: mbMiddle
+- rotating: buttonMiddle
 - moving closer/further: buttonRight (like in Blender: down closer, up further,
   horizontal doesn't matter)
 - moving left/right/down/up: buttonLeft
@@ -34,13 +34,13 @@ My thoughts and conclusions:
 - moving closer/further: 2nd most important action in Examine mode, IMO.
   Goes to buttonRight. For people with 1 mouse button, and for Blender analogy,
   it's also on Ctrl + buttonLeft.
-- moving left/right/down/up: mbMiddle.
+- moving left/right/down/up: buttonMiddle.
   For people with no middle button, and Blender analogy, it's also on
   Shift + buttonLeft.
 
 This achieves a couple of nice goals:
 - everything is available with only buttonLeft, for people with 1 mouse button.
-- Blender analogy: you can say to just switch "mbMiddle" to "buttonLeft",
+- Blender analogy: you can say to just switch "buttonMiddle" to "buttonLeft",
   and it works the same
 - OTOH, for people with 3 mouse buttons, that do not catch the fact that
   keyboard modifiers change the navigation, also each mb (without modifier)

--- a/src/3d/castlecameras_default_examine_mouse_buttons.txt
+++ b/src/3d/castlecameras_default_examine_mouse_buttons.txt
@@ -17,13 +17,13 @@ Both Shift and Ctrl pressed do nothing.
 
 vrweb:
 - rotating: mbMiddle
-- moving closer/further: mbRight (like in Blender: down closer, up further,
+- moving closer/further: buttonRight (like in Blender: down closer, up further,
   horizontal doesn't matter)
 - moving left/right/down/up: buttonLeft
 
 GIMP normalmap 3d preview:
 - rotating: buttonLeft
-- moving closer/further: mbRight (like in Blender: down closer, up further,
+- moving closer/further: buttonRight (like in Blender: down closer, up further,
   horizontal doesn't matter)
 - no moving left/right/down/up.
 
@@ -32,7 +32,7 @@ My thoughts and conclusions:
   mode is the most comfortable), so it should be on buttonLeft (like normalmap)
   with no modifiers (like Blender).
 - moving closer/further: 2nd most important action in Examine mode, IMO.
-  Goes to mbRight. For people with 1 mouse button, and for Blender analogy,
+  Goes to buttonRight. For people with 1 mouse button, and for Blender analogy,
   it's also on Ctrl + buttonLeft.
 - moving left/right/down/up: mbMiddle.
   For people with no middle button, and Blender analogy, it's also on

--- a/src/base/castleapplicationproperties.pas
+++ b/src/base/castleapplicationproperties.pas
@@ -100,7 +100,7 @@ type
           on a touch device.)
 
         @item(The only "mouse button" you will ever see pressed
-          on a touch device is mbLeft.)
+          on a touch device is buttonLeft.)
 
         @item(On the other hand, touch devices support multitouch, exposed by
           @link(TUIContainer.Touches) and @link(TUIContainer.TouchesCount).

--- a/src/game/castleplayer.pas
+++ b/src/game/castleplayer.pas
@@ -1603,18 +1603,18 @@ initialization
   PlayerInput_Crouch.Assign(keyC);
 
   PlayerInput_Attack := TInputShortcut.Create(nil, 'Attack', 'attack', igBasic);
-  PlayerInput_Attack.Assign(keyCtrl, keyNone, '', false, mbLeft);
+  PlayerInput_Attack.Assign(keyCtrl, keyNone, '', false, buttonLeft);
   PlayerInput_Attack.GroupOrder := -100; { before other (player) shortcuts }
   PlayerInput_InventoryShow := TInputShortcut.Create(nil, 'Inventory show / hide', 'inventory_toggle', igItems);
-  PlayerInput_InventoryShow.Assign(keyNone, keyNone, '', false, mbLeft);
+  PlayerInput_InventoryShow.Assign(keyNone, keyNone, '', false, buttonLeft);
   PlayerInput_InventoryPrevious := TInputShortcut.Create(nil, 'Select previous item', 'inventory_previous', igItems);
-  PlayerInput_InventoryPrevious.Assign(keyLeftBracket, keyNone, '', false, mbLeft, mwUp);
+  PlayerInput_InventoryPrevious.Assign(keyLeftBracket, keyNone, '', false, buttonLeft, mwUp);
   PlayerInput_InventoryNext := TInputShortcut.Create(nil, 'Select next item', 'inventory_next', igItems);
-  PlayerInput_InventoryNext.Assign(keyRightBracket, keyNone, '', false, mbLeft, mwDown);
+  PlayerInput_InventoryNext.Assign(keyRightBracket, keyNone, '', false, buttonLeft, mwDown);
   PlayerInput_UseItem := TInputShortcut.Create(nil, 'Use (or equip) selected item', 'item_use', igItems);
-  PlayerInput_UseItem.Assign(keyEnter, keyNone, '', false, mbLeft);
+  PlayerInput_UseItem.Assign(keyEnter, keyNone, '', false, buttonLeft);
   PlayerInput_DropItem := TInputShortcut.Create(nil, 'Drop selected item', 'item_drop', igItems);
-  PlayerInput_DropItem.Assign(keyNone, keyNone, '', false, mbLeft);
+  PlayerInput_DropItem.Assign(keyNone, keyNone, '', false, buttonLeft);
   PlayerInput_CancelFlying := TInputShortcut.Create(nil, 'Cancel flying spell', 'cancel_flying', igOther);
-  PlayerInput_CancelFlying.Assign(keyNone, keyNone, '', false, mbLeft);
+  PlayerInput_CancelFlying.Assign(keyNone, keyNone, '', false, buttonLeft);
 end.

--- a/src/lcl/castlecontrol.pas
+++ b/src/lcl/castlecontrol.pas
@@ -196,9 +196,9 @@ type
     procedure KeyDown(var Key: Word; Shift: TShiftState); override;
     procedure UTF8KeyPress(var UTF8Key: TUTF8Char); override;
     procedure KeyUp(var Key: Word; Shift: TShiftState); override;
-    procedure MouseDown(Button: TMouseButton;
+    procedure MouseDown(Button: Controls.TMouseButton;
       Shift:TShiftState; X,Y:Integer); override;
-    procedure MouseUp(Button: TMouseButton;
+    procedure MouseUp(Button: Controls.TMouseButton;
       Shift:TShiftState; X,Y:Integer); override;
     procedure MouseMove(Shift: TShiftState; NewX, NewY: Integer); override;
     function DoMouseWheel(Shift: TShiftState; WheelDelta: Integer; MousePos: TPoint): Boolean; override;
@@ -1089,7 +1089,7 @@ begin
       Key := 0; // handled
 end;
 
-procedure TCastleControlBase.MouseDown(Button: TMouseButton;
+procedure TCastleControlBase.MouseDown(Button: Controls.TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 var
   MyButton: TCastleMouseButton;
@@ -1108,7 +1108,7 @@ begin
       ModifiersDown(Container.Pressed)));
 end;
 
-procedure TCastleControlBase.MouseUp(Button: TMouseButton;
+procedure TCastleControlBase.MouseUp(Button: Controls.TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 var
   MyButton: TCastleMouseButton;

--- a/src/lcl/castlecontrol.pas
+++ b/src/lcl/castlecontrol.pas
@@ -196,9 +196,9 @@ type
     procedure KeyDown(var Key: Word; Shift: TShiftState); override;
     procedure UTF8KeyPress(var UTF8Key: TUTF8Char); override;
     procedure KeyUp(var Key: Word; Shift: TShiftState); override;
-    procedure MouseDown(Button: Controls.TMouseButton;
+    procedure MouseDown(Button: TMouseButton;
       Shift:TShiftState; X,Y:Integer); override;
-    procedure MouseUp(Button: Controls.TMouseButton;
+    procedure MouseUp(Button: TMouseButton;
       Shift:TShiftState; X,Y:Integer); override;
     procedure MouseMove(Shift: TShiftState; NewX, NewY: Integer); override;
     function DoMouseWheel(Shift: TShiftState; WheelDelta: Integer; MousePos: TPoint): Boolean; override;
@@ -230,7 +230,7 @@ type
     function Pressed: TKeysPressed;
     { Mouse buttons currently pressed.
       See @link(TUIContainer.MousePressed) for details. }
-    function MousePressed: CastleKeysMouse.TMouseButtons;
+    function MousePressed: TCastleMouseButtons;
     procedure ReleaseAllKeysAndMouse;
 
     { Current mouse position.
@@ -1089,10 +1089,10 @@ begin
       Key := 0; // handled
 end;
 
-procedure TCastleControlBase.MouseDown(Button: Controls.TMouseButton;
+procedure TCastleControlBase.MouseDown(Button: TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 var
-  MyButton: CastleKeysMouse.TMouseButton;
+  MyButton: TCastleMouseButton;
 begin
   FMousePosition := Vector2(X, Height - 1 - Y);
 
@@ -1108,10 +1108,10 @@ begin
       ModifiersDown(Container.Pressed)));
 end;
 
-procedure TCastleControlBase.MouseUp(Button: Controls.TMouseButton;
+procedure TCastleControlBase.MouseUp(Button: TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 var
-  MyButton: CastleKeysMouse.TMouseButton;
+  MyButton: TCastleMouseButton;
 begin
   FMousePosition := Vector2(X, Height - 1 - Y);
 
@@ -1245,7 +1245,7 @@ begin
     Mouse.CursorPos := NewCursorPos;
 end;
 
-function TCastleControlBase.MousePressed: CastleKeysMouse.TMouseButtons;
+function TCastleControlBase.MousePressed: TCastleMouseButtons;
 begin
   Result := Container.MousePressed;
 end;

--- a/src/lcl/castlelclutils.pas
+++ b/src/lcl/castlelclutils.pas
@@ -89,7 +89,7 @@ procedure KeyCastleToLCL(const Key: TKey; KeyString: String;
   but beware --- the order of values in my type is different (buttonMiddle
   is in the middle in my type)). }
 function MouseButtonLCLToCastle(
-  const MouseButton: TMouseButton;
+  const MouseButton: Controls.TMouseButton;
   out MyMouseButton: TCastleMouseButton): boolean;
 
 const
@@ -465,7 +465,7 @@ begin
 end;
 
 function MouseButtonLCLToCastle(
-  const MouseButton: TMouseButton;
+  const MouseButton: Controls.TMouseButton;
   out MyMouseButton: TCastleMouseButton): boolean;
 begin
   Result := true;

--- a/src/lcl/castlelclutils.pas
+++ b/src/lcl/castlelclutils.pas
@@ -470,7 +470,7 @@ function MouseButtonLCLToCastle(
 begin
   Result := true;
   case MouseButton of
-    Controls.mbLeft  : MyMouseButton := CastleKeysMouse.mbLeft;
+    Controls.mbLeft  : MyMouseButton := CastleKeysMouse.buttonLeft;
     Controls.mbRight : MyMouseButton := CastleKeysMouse.mbRight;
     Controls.mbMiddle: MyMouseButton := CastleKeysMouse.mbMiddle;
     Controls.mbExtra1: MyMouseButton := CastleKeysMouse.mbExtra1;

--- a/src/lcl/castlelclutils.pas
+++ b/src/lcl/castlelclutils.pas
@@ -471,7 +471,7 @@ begin
   Result := true;
   case MouseButton of
     Controls.mbLeft  : MyMouseButton := CastleKeysMouse.buttonLeft;
-    Controls.mbRight : MyMouseButton := CastleKeysMouse.mbRight;
+    Controls.mbRight : MyMouseButton := CastleKeysMouse.buttonRight;
     Controls.mbMiddle: MyMouseButton := CastleKeysMouse.mbMiddle;
     Controls.mbExtra1: MyMouseButton := CastleKeysMouse.mbExtra1;
     Controls.mbExtra2: MyMouseButton := CastleKeysMouse.mbExtra2;

--- a/src/lcl/castlelclutils.pas
+++ b/src/lcl/castlelclutils.pas
@@ -473,8 +473,8 @@ begin
     Controls.mbLeft  : MyMouseButton := CastleKeysMouse.buttonLeft;
     Controls.mbRight : MyMouseButton := CastleKeysMouse.buttonRight;
     Controls.mbMiddle: MyMouseButton := CastleKeysMouse.buttonMiddle;
-    Controls.mbExtra1: MyMouseButton := CastleKeysMouse.mbExtra1;
-    Controls.mbExtra2: MyMouseButton := CastleKeysMouse.mbExtra2;
+    Controls.mbExtra1: MyMouseButton := CastleKeysMouse.buttonExtra1;
+    Controls.mbExtra2: MyMouseButton := CastleKeysMouse.buttonExtra2;
     {$ifndef COMPILER_CASE_ANALYSIS}
     else Result := false;
     {$endif}

--- a/src/lcl/castlelclutils.pas
+++ b/src/lcl/castlelclutils.pas
@@ -86,7 +86,7 @@ procedure KeyCastleToLCL(const Key: TKey; KeyString: String;
   CastleKeysMouse.TCastleMouseButton.
 
   (By coincidence, my type name and values are the same as used by LCL;
-  but beware --- the order of values in my type is different (mbMiddle
+  but beware --- the order of values in my type is different (buttonMiddle
   is in the middle in my type)). }
 function MouseButtonLCLToCastle(
   const MouseButton: TMouseButton;
@@ -472,7 +472,7 @@ begin
   case MouseButton of
     Controls.mbLeft  : MyMouseButton := CastleKeysMouse.buttonLeft;
     Controls.mbRight : MyMouseButton := CastleKeysMouse.buttonRight;
-    Controls.mbMiddle: MyMouseButton := CastleKeysMouse.mbMiddle;
+    Controls.mbMiddle: MyMouseButton := CastleKeysMouse.buttonMiddle;
     Controls.mbExtra1: MyMouseButton := CastleKeysMouse.mbExtra1;
     Controls.mbExtra2: MyMouseButton := CastleKeysMouse.mbExtra2;
     {$ifndef COMPILER_CASE_ANALYSIS}

--- a/src/lcl/castlelclutils.pas
+++ b/src/lcl/castlelclutils.pas
@@ -83,14 +83,14 @@ procedure KeyCastleToLCL(const Key: TKey; KeyString: String;
 { @groupEnd }
 
 { Convert Lazarus Controls.TMouseButton value to Castle Game Engine
-  CastleKeysMouse.TMouseButton.
+  CastleKeysMouse.TCastleMouseButton.
 
   (By coincidence, my type name and values are the same as used by LCL;
   but beware --- the order of values in my type is different (mbMiddle
   is in the middle in my type)). }
 function MouseButtonLCLToCastle(
-  const MouseButton: Controls.TMouseButton;
-  out MyMouseButton: CastleKeysMouse.TMouseButton): boolean;
+  const MouseButton: TMouseButton;
+  out MyMouseButton: TCastleMouseButton): boolean;
 
 const
   CursorCastleToLCL: array [TMouseCursor] of TCursor =
@@ -465,8 +465,8 @@ begin
 end;
 
 function MouseButtonLCLToCastle(
-  const MouseButton: Controls.TMouseButton;
-  out MyMouseButton: CastleKeysMouse.TMouseButton): boolean;
+  const MouseButton: TMouseButton;
+  out MyMouseButton: TCastleMouseButton): boolean;
 begin
   Result := true;
   case MouseButton of

--- a/src/ui/castleinputs.pas
+++ b/src/ui/castleinputs.pas
@@ -188,7 +188,7 @@ type
       const AKey2: TKey = keyNone;
       AKeyString: String = '';
       const AMouseButtonUse: boolean = false;
-      const AMouseButton: TCastleMouseButton = mbLeft;
+      const AMouseButton: TCastleMouseButton = buttonLeft;
       const AMouseWheel: TMouseWheelDirection = mwNone);
 
     { Set keys/mouse buttons of this shortcut.
@@ -199,7 +199,7 @@ type
       const AKey2: TKey = keyNone;
       AKeyString: String = '';
       const AMouseButtonUse: boolean = false;
-      const AMouseButton: TCastleMouseButton = mbLeft;
+      const AMouseButton: TCastleMouseButton = buttonLeft;
       const AMouseWheel: TMouseWheelDirection = mwNone);
 
     { Make this input impossible to activate by the user.
@@ -507,7 +507,7 @@ begin
   FDefaultMouseButtonUse := AMouseButtonUse;
   FDefaultMouseButton := AMouseButton;
   FDefaultMouseButton2Use := false; // not set by parameters, just reset
-  FDefaultMouseButton2 := mbLeft; // not set by parameters, just reset
+  FDefaultMouseButton2 := buttonLeft; // not set by parameters, just reset
   FDefaultMouseWheel := AMouseWheel;
   MakeDefault;
 end;
@@ -529,7 +529,7 @@ begin
   FMouseButtonUse := AMouseButtonUse;
   FMouseButton := AMouseButton;
   FDefaultMouseButton2Use := false; // not set by parameters, just reset
-  FDefaultMouseButton2 := mbLeft; // not set by parameters, just reset
+  FDefaultMouseButton2 := buttonLeft; // not set by parameters, just reset
   FMouseWheel := AMouseWheel;
   Changed;
 end;
@@ -568,9 +568,9 @@ begin
   FKey2 := keyNone;
   FKeyString := '';
   FMouseButtonUse := false;
-  FMouseButton := mbLeft;
+  FMouseButton := buttonLeft;
   FMouseButton2Use := false;
-  FMouseButton2 := mbLeft;
+  FMouseButton2 := buttonLeft;
   FMouseWheel := mwNone;
 
   if ClearAlsoDefaultState then
@@ -579,9 +579,9 @@ begin
     FDefaultKey2 := keyNone;
     FDefaultKeyString := '';
     FDefaultMouseButtonUse := false;
-    FDefaultMouseButton := mbLeft;
+    FDefaultMouseButton := buttonLeft;
     FDefaultMouseButton2Use := false;
-    FDefaultMouseButton2 := mbLeft;
+    FDefaultMouseButton2 := buttonLeft;
     FDefaultMouseWheel := mwNone;
   end;
 

--- a/src/ui/castleinputs.pas
+++ b/src/ui/castleinputs.pas
@@ -111,9 +111,9 @@ type
     FKey2: TKey;
     FKeyString: String;
     FMouseButtonUse: boolean;
-    FMouseButton: TMouseButton;
+    FMouseButton: TCastleMouseButton;
     FMouseButton2Use: boolean;
-    FMouseButton2: TMouseButton;
+    FMouseButton2: TCastleMouseButton;
     FMouseWheel: TMouseWheelDirection;
     FCaption: string;
     FGroup: TInputGroup;
@@ -126,9 +126,9 @@ type
     FDefaultKey2: TKey;
     FDefaultKeyString: String;
     FDefaultMouseButtonUse: boolean;
-    FDefaultMouseButton: TMouseButton;
+    FDefaultMouseButton: TCastleMouseButton;
     FDefaultMouseButton2Use: boolean;
-    FDefaultMouseButton2: TMouseButton;
+    FDefaultMouseButton2: TCastleMouseButton;
     FDefaultMouseWheel: TMouseWheelDirection;
 
     procedure SetKey1(const Value: TKey);
@@ -137,9 +137,9 @@ type
     function GetCharacter: Char;
     procedure SetCharacter(const AValue: Char);
     procedure SetMouseButtonUse(const Value: boolean);
-    procedure SetMouseButton(const Value: TMouseButton);
+    procedure SetMouseButton(const Value: TCastleMouseButton);
     procedure SetMouseButton2Use(const Value: boolean);
-    procedure SetMouseButton2(const Value: TMouseButton);
+    procedure SetMouseButton2(const Value: TCastleMouseButton);
     procedure SetMouseWheel(const Value: TMouseWheelDirection);
   protected
     { Called always right after the key/character/mouse
@@ -188,7 +188,7 @@ type
       const AKey2: TKey = keyNone;
       AKeyString: String = '';
       const AMouseButtonUse: boolean = false;
-      const AMouseButton: TMouseButton = mbLeft;
+      const AMouseButton: TCastleMouseButton = mbLeft;
       const AMouseWheel: TMouseWheelDirection = mwNone);
 
     { Set keys/mouse buttons of this shortcut.
@@ -199,7 +199,7 @@ type
       const AKey2: TKey = keyNone;
       AKeyString: String = '';
       const AMouseButtonUse: boolean = false;
-      const AMouseButton: TMouseButton = mbLeft;
+      const AMouseButton: TCastleMouseButton = mbLeft;
       const AMouseWheel: TMouseWheelDirection = mwNone);
 
     { Make this input impossible to activate by the user.
@@ -210,7 +210,7 @@ type
     { Given a set of currently pressed keys and mouse buttons,
       decide whether this input is currently pressed. }
     function IsPressed(Pressed: TKeysPressed;
-      const MousePressed: TMouseButtons): boolean; overload;
+      const MousePressed: TCastleMouseButtons): boolean; overload;
 
     { Looking at Container's currently pressed keys and mouse buttons,
       decide whether this input is currently pressed. }
@@ -221,7 +221,7 @@ type
     function IsKey(const Key: TKey; AKeyString: String): boolean;
 
     { Check does given mouse button correspond to this input shortcut. }
-    function IsMouseButton(const AMouseButton: TMouseButton): boolean;
+    function IsMouseButton(const AMouseButton: TCastleMouseButton): boolean;
 
     function IsMouseWheel(const AMouseWheel: TMouseWheelDirection): boolean;
 
@@ -239,7 +239,7 @@ type
       IsMouseButton or IsMouseWheel methods. It's sometimes more comfortable
       to use this instead of taking care of them separately. }
     function IsEvent(const AKey: TKey; AKeyString: String;
-      const AMousePress: boolean; const AMouseButton: TMouseButton;
+      const AMousePress: boolean; const AMouseButton: TCastleMouseButton;
       const AMouseWheel: TMouseWheelDirection): boolean; overload;
     function IsEvent(const Event: TInputPressRelease): boolean; overload;
 
@@ -324,14 +324,14 @@ type
       if you don't want to use this.
       @groupBegin }
     property MouseButtonUse: boolean read FMouseButtonUse write SetMouseButtonUse;
-    property MouseButton: TMouseButton read FMouseButton write SetMouseButton;
+    property MouseButton: TCastleMouseButton read FMouseButton write SetMouseButton;
     { @groupEnd }
 
     { Alternative mouse shortcut for given command. You can set MouseButton2Use to @false
       if you don't want to use this.
       @groupBegin }
     property MouseButton2Use: boolean read FMouseButton2Use write SetMouseButton2Use;
-    property MouseButton2: TMouseButton read FMouseButton2 write SetMouseButton2;
+    property MouseButton2: TCastleMouseButton read FMouseButton2 write SetMouseButton2;
     { @groupEnd }
 
     { Mouse wheel to activate this command. Note that mouse wheels cannot be
@@ -356,11 +356,11 @@ type
       read FDefaultKeyString write FDefaultKeyString;
     property DefaultMouseButtonUse: boolean
       read FDefaultMouseButtonUse write FDefaultMouseButtonUse;
-    property DefaultMouseButton: TMouseButton
+    property DefaultMouseButton: TCastleMouseButton
       read FDefaultMouseButton write FDefaultMouseButton;
     property DefaultMouseButton2Use: boolean
       read FDefaultMouseButton2Use write FDefaultMouseButton2Use;
-    property DefaultMouseButton2: TMouseButton
+    property DefaultMouseButton2: TCastleMouseButton
       read FDefaultMouseButton2 write FDefaultMouseButton2;
     property DefaultMouseWheel: TMouseWheelDirection
       read FDefaultMouseWheel write FDefaultMouseWheel;
@@ -494,7 +494,7 @@ procedure TInputShortcut.Assign(const AKey1: TKey;
   const AKey2: TKey;
   AKeyString: String;
   const AMouseButtonUse: boolean;
-  const AMouseButton: TMouseButton;
+  const AMouseButton: TCastleMouseButton;
   const AMouseWheel: TMouseWheelDirection);
 begin
   // only for backward compatibility (when this parameter was Char) convert #0 to ''
@@ -516,7 +516,7 @@ procedure TInputShortcut.AssignCurrent(const AKey1: TKey;
   const AKey2: TKey;
   AKeyString: String;
   const AMouseButtonUse: boolean;
-  const AMouseButton: TMouseButton;
+  const AMouseButton: TCastleMouseButton;
   const AMouseWheel: TMouseWheelDirection);
 begin
   // only for backward compatibility (when this parameter was Char) convert #0 to ''
@@ -591,7 +591,7 @@ begin
 end;
 
 function TInputShortcut.IsPressed(Pressed: TKeysPressed;
-  const MousePressed: TMouseButtons): boolean;
+  const MousePressed: TCastleMouseButtons): boolean;
 begin
   Result :=
     ( (Pressed <> nil) and (Pressed.Keys[Key1] or
@@ -617,7 +617,7 @@ begin
     ( (KeyString <> '') and (KeyString = AKeyString) );
 end;
 
-function TInputShortcut.IsMouseButton(const AMouseButton: TMouseButton): boolean;
+function TInputShortcut.IsMouseButton(const AMouseButton: TCastleMouseButton): boolean;
 begin
   Result :=
     ( MouseButtonUse  and (AMouseButton = MouseButton) ) or
@@ -630,7 +630,7 @@ begin
 end;
 
 function TInputShortcut.IsEvent(const AKey: TKey; AKeyString: String;
-  const AMousePress: boolean; const AMouseButton: TMouseButton;
+  const AMousePress: boolean; const AMouseButton: TCastleMouseButton;
   const AMouseWheel: TMouseWheelDirection): boolean;
 begin
   // only for backward compatibility (when this parameter was Char) convert #0 to ''
@@ -737,7 +737,7 @@ begin
   Changed;
 end;
 
-procedure TInputShortcut.SetMouseButton(const Value: TMouseButton);
+procedure TInputShortcut.SetMouseButton(const Value: TCastleMouseButton);
 begin
   FMouseButton := Value;
   Changed;
@@ -749,7 +749,7 @@ begin
   Changed;
 end;
 
-procedure TInputShortcut.SetMouseButton2(const Value: TMouseButton);
+procedure TInputShortcut.SetMouseButton2(const Value: TCastleMouseButton);
 begin
   FMouseButton2 := Value;
   Changed;
@@ -834,11 +834,11 @@ begin
     ConfigPath + Name + '/key2', DefaultKey2);
   MouseButtonUse := Config.GetValue(
     ConfigPath + Name + '/mouse_button_use', DefaultMouseButtonUse);
-  MouseButton := TMouseButton(Config.GetValue(
+  MouseButton := TCastleMouseButton(Config.GetValue(
     ConfigPath + Name + '/mouse_button', Ord(DefaultMouseButton)));
   MouseButton2Use := Config.GetValue(
     ConfigPath + Name + '/mouse_button_use2', DefaultMouseButton2Use);
-  MouseButton2 := TMouseButton(Config.GetValue(
+  MouseButton2 := TCastleMouseButton(Config.GetValue(
     ConfigPath + Name + '/mouse_button2', Ord(DefaultMouseButton2)));
   MouseWheel := TMouseWheelDirection(Config.GetValue(
     ConfigPath + Name + '/mouse_wheel', Ord(DefaultMouseWheel)));

--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -374,7 +374,7 @@ type
   TCharactersBooleans = array [Char] of Boolean;
   PCharactersBooleans = ^TCharactersBooleans;
 
-  TCastleMouseButton = (buttonLeft, mbMiddle, mbRight, mbExtra1, mbExtra2);
+  TCastleMouseButton = (buttonLeft, mbMiddle, buttonRight, mbExtra1, mbExtra2);
   TCastleMouseButtons = set of TCastleMouseButton;
 
   { Look of the mouse cursor.

--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -376,6 +376,9 @@ type
 
   TCastleMouseButton = (buttonLeft, buttonMiddle, buttonRight, buttonExtra1, buttonExtra2);
   TCastleMouseButtons = set of TCastleMouseButton;
+  
+  TMouseButton = TCastleMouseButton deprecated 'use TCastleMouseButton';
+  TMouseButtons = TCastleMouseButtons deprecated 'use TCastleMouseButtons';
 
 const
   mbLeft   = buttonLeft deprecated 'Use buttonLeft';

--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -374,7 +374,7 @@ type
   TCharactersBooleans = array [Char] of Boolean;
   PCharactersBooleans = ^TCharactersBooleans;
 
-  TCastleMouseButton = (mbLeft, mbMiddle, mbRight, mbExtra1, mbExtra2);
+  TCastleMouseButton = (buttonLeft, mbMiddle, mbRight, mbExtra1, mbExtra2);
   TCastleMouseButtons = set of TCastleMouseButton;
 
   { Look of the mouse cursor.
@@ -657,7 +657,7 @@ type
     KeyRepeated: boolean;
 
     { When EventType is itMouseButton, this is the mouse button pressed or released.
-      Always mbLeft for touch device press/release events.
+      Always buttonLeft for touch device press/release events.
 
       CastleWindow notes (but relevant also to other interfaces, like Lazarus
       component, although in that case it's beyond our control):

--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -374,7 +374,7 @@ type
   TCharactersBooleans = array [Char] of Boolean;
   PCharactersBooleans = ^TCharactersBooleans;
 
-  TCastleMouseButton = (buttonLeft, mbMiddle, buttonRight, mbExtra1, mbExtra2);
+  TCastleMouseButton = (buttonLeft, buttonMiddle, buttonRight, mbExtra1, mbExtra2);
   TCastleMouseButtons = set of TCastleMouseButton;
 
   { Look of the mouse cursor.

--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -374,8 +374,8 @@ type
   TCharactersBooleans = array [Char] of Boolean;
   PCharactersBooleans = ^TCharactersBooleans;
 
-  TMouseButton = (mbLeft, mbMiddle, mbRight, mbExtra1, mbExtra2);
-  TMouseButtons = set of TMouseButton;
+  TCastleMouseButton = (mbLeft, mbMiddle, mbRight, mbExtra1, mbExtra2);
+  TCastleMouseButtons = set of TCastleMouseButton;
 
   { Look of the mouse cursor.
     Used for various properties:
@@ -425,7 +425,7 @@ type
     mcResizeBottomRight
   );
 const
-  MouseButtonStr: array [TMouseButton] of string = (
+  MouseButtonStr: array [TCastleMouseButton] of string = (
     'left', 'middle', 'right', 'extra1', 'extra2');
 
 type
@@ -667,7 +667,7 @@ type
       outside of this control), until user releases all mouse buttons.
       Note that this means that mouse positions may be outside
       of [0..Width - 1, 0..Height - 1] range. }
-    MouseButton: TMouseButton;
+    MouseButton: TCastleMouseButton;
 
     { When EventType is itMouseButton, this is the finger index pressed or
       released on a touch device. Always 0 for normal mouse events. }
@@ -716,7 +716,7 @@ type
     function IsKey(const AKey: TKey): boolean; overload;
     function IsKey(AKeyString: String): boolean; overload;
     { @groupEnd }
-    function IsMouseButton(const AMouseButton: TMouseButton): boolean;
+    function IsMouseButton(const AMouseButton: TCastleMouseButton): boolean;
     function IsMouseWheel(const AMouseWheel: TMouseWheelDirection): boolean;
 
     { Textual description of this event. }
@@ -733,7 +733,7 @@ type
   { Motion (movement) of mouse or a finger on a touch device. }
   TInputMotion = object
     OldPosition, Position: TVector2;
-    Pressed: TMouseButtons;
+    Pressed: TCastleMouseButtons;
     FingerIndex: TFingerIndex;
   end;
 
@@ -743,7 +743,7 @@ function InputKey(const Position: TVector2; const Key: TKey;
   const KeyString: string;
   const ModifiersDown: TModifierKeys = []): TInputPressRelease;
 function InputMouseButton(const Position: TVector2;
-  const MouseButton: TMouseButton; const FingerIndex: TFingerIndex;
+  const MouseButton: TCastleMouseButton; const FingerIndex: TFingerIndex;
   const ModifiersDown: TModifierKeys = []): TInputPressRelease;
 function InputMouseWheel(const Position: TVector2;
   const Scroll: Single; const Vertical: boolean;
@@ -752,7 +752,7 @@ function InputMouseWheel(const Position: TVector2;
 
 { Construct TInputMotion. }
 function InputMotion(const OldPosition, Position: TVector2;
-  const Pressed: TMouseButtons; const FingerIndex: TFingerIndex): TInputMotion;
+  const Pressed: TCastleMouseButtons; const FingerIndex: TFingerIndex): TInputMotion;
 
 type
   TCastleConfigKeysMouseHelper = class helper for TCastleConfig
@@ -1270,7 +1270,7 @@ begin
   Result := (AKeystring <> '') and (EventType = itKey) and (KeyString = AKeystring);
 end;
 
-function TInputPressRelease.IsMouseButton(const AMouseButton: TMouseButton): boolean;
+function TInputPressRelease.IsMouseButton(const AMouseButton: TCastleMouseButton): boolean;
 begin
   Result := (EventType = itMouseButton) and (MouseButton = AMouseButton);
 end;
@@ -1329,7 +1329,7 @@ begin
 end;
 
 function InputMouseButton(const Position: TVector2;
-  const MouseButton: TMouseButton; const FingerIndex: TFingerIndex;
+  const MouseButton: TCastleMouseButton; const FingerIndex: TFingerIndex;
   const ModifiersDown: TModifierKeys): TInputPressRelease;
 begin
   FillChar(Result, SizeOf(Result), 0);
@@ -1353,7 +1353,7 @@ begin
 end;
 
 function InputMotion(const OldPosition, Position: TVector2;
-  const Pressed: TMouseButtons; const FingerIndex: TFingerIndex): TInputMotion;
+  const Pressed: TCastleMouseButtons; const FingerIndex: TFingerIndex): TInputMotion;
 begin
   FillChar(Result, SizeOf(Result), 0);
   Result.OldPosition := OldPosition;

--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -374,7 +374,7 @@ type
   TCharactersBooleans = array [Char] of Boolean;
   PCharactersBooleans = ^TCharactersBooleans;
 
-  TCastleMouseButton = (buttonLeft, buttonMiddle, buttonRight, mbExtra1, mbExtra2);
+  TCastleMouseButton = (buttonLeft, buttonMiddle, buttonRight, buttonExtra1, buttonExtra2);
   TCastleMouseButtons = set of TCastleMouseButton;
 
   { Look of the mouse cursor.

--- a/src/ui/castlekeysmouse.pas
+++ b/src/ui/castlekeysmouse.pas
@@ -377,6 +377,14 @@ type
   TCastleMouseButton = (buttonLeft, buttonMiddle, buttonRight, buttonExtra1, buttonExtra2);
   TCastleMouseButtons = set of TCastleMouseButton;
 
+const
+  mbLeft   = buttonLeft deprecated 'Use buttonLeft';
+  mbMiddle = buttonMiddle deprecated 'Use buttonMiddle';
+  mbRight = buttonRight deprecated 'Use buttonRight';
+  mbExtra1 = buttonExtra1 deprecated 'Use buttonExtra1';
+  mbExtra2 = buttonExtra2 deprecated 'Use buttonExtra2';
+
+type
   { Look of the mouse cursor.
     Used for various properties:
     TCastleUserInterface.Cursor, TCastleTransform.Cursor, TCastleWindowBase.Cursor.

--- a/src/ui/opengl/castlecontrols_checkbox.inc
+++ b/src/ui/opengl/castlecontrols_checkbox.inc
@@ -212,7 +212,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if Event.IsMouseButton(mbLeft) or
+  if Event.IsMouseButton(buttonLeft) or
      Event.IsKey(keySpace) or
      Event.IsKey(keyEnter) then
   begin
@@ -228,7 +228,7 @@ begin
   if Result then Exit;
 
   if FPressed and (
-     Event.IsMouseButton(mbLeft) or
+     Event.IsMouseButton(buttonLeft) or
      Event.IsKey(keySpace) or
      Event.IsKey(keyEnter)) then
   begin

--- a/src/ui/opengl/castlecontrols_scrollview.inc
+++ b/src/ui/opengl/castlecontrols_scrollview.inc
@@ -354,7 +354,7 @@ procedure TCastleScrollViewCustom.Update(const SecondsPassed: Single;
   begin
     if ScrollbarVisible then
     begin
-      if mbLeft in Container.MousePressed then
+      if buttonLeft in Container.MousePressed then
       begin
         { note that we update DragSpeed even when DragSinceLastUpdate = 0,
           which means user keeps pressing but doesn't drag }
@@ -436,7 +436,7 @@ begin
     to children (e.g. TCastleButton inside ScrollArea). }
 
   if ScrollBarVisible and
-     Event.IsMouseButton(mbLeft) and
+     Event.IsMouseButton(buttonLeft) and
      ScrollbarFrame.Contains(Event.Position) then
   begin
     if Event.Position[1] < ScrollbarSlider.Bottom then
@@ -511,7 +511,7 @@ begin
   { We do not process mouse button clicks (or touches) here
     (not on an entire TCastleScrollViewCustom area -- the code in PreviewPress
     handles clicks inside ScrollbarFrame only).
-    We only process dragging (with mbLeft) inside TCastleScrollViewCustom.Update
+    We only process dragging (with buttonLeft) inside TCastleScrollViewCustom.Update
     and TCastleScrollViewCustom.Motion.
 
     But we still have to mark the mouse click as "handled" here.
@@ -524,7 +524,7 @@ begin
     (Testcase: show MessageOK or TStateDialogOK on mobile (Android, iOS)
     with a long text (to make scrolling relevant).)  }
 
-  if EnableDragging and Event.IsMouseButton(mbLeft) and ScrollBarVisible then
+  if EnableDragging and Event.IsMouseButton(buttonLeft) and ScrollBarVisible then
     Result := ExclusiveEvents;
 end;
 
@@ -533,7 +533,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     ScrollBarDragging := false;
     Result := ExclusiveEvents;
@@ -556,7 +556,7 @@ begin
     ResetInertialForce;
     Result := ExclusiveEvents;
   end else
-  if EnableDragging and (mbLeft in Event.Pressed) then
+  if EnableDragging and (buttonLeft in Event.Pressed) then
   begin
     Drag := ((Event.Position[1] - Event.OldPosition[1]) / UIScale);
     Scroll := Scroll + Drag;

--- a/src/ui/opengl/castlecontrols_sliders.inc
+++ b/src/ui/opengl/castlecontrols_sliders.inc
@@ -319,7 +319,7 @@ begin
     DoChange;
     Result := ExclusiveEvents;
   end else
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     Value := RoundAndClamp(MapRange(
       XCoordToSliderPosition(Event.Position[0], RenderRect), 0, 1, Min, Max));
@@ -333,7 +333,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if mbLeft in Event.Pressed then
+  if buttonLeft in Event.Pressed then
   begin
     Value := RoundAndClamp(MapRange(
       XCoordToSliderPosition(Event.Position[0], RenderRect), 0, 1, Min, Max));
@@ -466,7 +466,7 @@ begin
     DoChange;
     Result := ExclusiveEvents;
   end else
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     Value := XCoordToValue(Event.Position[0], RenderRect);
     DoChange;
@@ -489,7 +489,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if mbLeft in Event.Pressed then
+  if buttonLeft in Event.Pressed then
   begin
     Value := XCoordToValue(Event.Position[0], RenderRect);
     DoChange;

--- a/src/ui/opengl/castlecontrols_switchcontrol.inc
+++ b/src/ui/opengl/castlecontrols_switchcontrol.inc
@@ -131,7 +131,7 @@ begin
   Result := inherited;
   if Result then Exit;
 
-  if Event.IsMouseButton(mbLeft) or
+  if Event.IsMouseButton(buttonLeft) or
      Event.IsKey(keySpace) or
      Event.IsKey(keyEnter) then
   begin
@@ -146,7 +146,7 @@ begin
   if Result then Exit;
 
   if FPressed and (
-     Event.IsMouseButton(mbLeft) or
+     Event.IsMouseButton(buttonLeft) or
      Event.IsKey(keySpace) or
      Event.IsKey(keyEnter)) then
   begin

--- a/src/ui/opengl/castleuicontrols.pas
+++ b/src/ui/opengl/castleuicontrols.pas
@@ -285,7 +285,7 @@ type
     FCalculatedUIScale: Single; //< set on all children
     FFps: TFramesPerSecond;
     FPressed: TKeysPressed;
-    FMousePressed: CastleKeysMouse.TMouseButtons;
+    FMousePressed: TCastleMouseButtons;
     FMouseLookIgnoreNextMotion: Boolean;
     FMouseLookWaitingForMiddle: Boolean;
     FMouseLookMotionToSubtract: TVector2;
@@ -510,7 +510,7 @@ type
 
       This value is always current, in particular it's already updated
       before we call events @link(OnPress) or @link(OnRelease). }
-    property MousePressed: TMouseButtons read FMousePressed write FMousePressed;
+    property MousePressed: TCastleMouseButtons read FMousePressed write FMousePressed;
 
     { Is the window focused now, which means that keys/mouse events
       are directed to this window. }

--- a/src/ui/opengl/castleuicontrols.pas
+++ b/src/ui/opengl/castleuicontrols.pas
@@ -691,7 +691,7 @@ type
         Result := inherited;
         if Result then Exit;
 
-        if Event.IsMouseButton(mbLeft) then
+        if Event.IsMouseButton(buttonLeft) then
         begin
           Drag := true;
           Cursor := mcForceNone;
@@ -704,7 +704,7 @@ type
         Result := inherited;
         if Result then Exit;
 
-        if Event.IsMouseButton(mbLeft) then
+        if Event.IsMouseButton(buttonLeft) then
         begin
           Drag := false;
           Cursor := mcDefault;
@@ -937,7 +937,7 @@ type
           Exit(ExclusiveEvents); // ExclusiveEvents is true by default
         end;
 
-        if Event.IsMouseButton(mbLeft) then
+        if Event.IsMouseButton(buttonLeft) then
         begin
           // do something in reaction on Enter
           Exit(ExclusiveEvents); // ExclusiveEvents is true by default

--- a/src/window/castleinternalwindowmodes.pas
+++ b/src/window/castleinternalwindowmodes.pas
@@ -414,7 +414,7 @@ constructor TGLMode.Create(AWindow: TCastleWindowBase);
 
   procedure SimulateReleaseAll;
   var
-    Button: TMouseButton;
+    Button: TCastleMouseButton;
     Key: TKey;
     C: char;
     ModifiersDown: TModifierKeys;
@@ -462,7 +462,7 @@ end;
 
 destructor TGLMode.Destroy;
 var
-  btn: TMouseButton;
+  btn: TCastleMouseButton;
 begin
   FreeAndNil(OldState);
 

--- a/src/window/castlewindow.pas
+++ b/src/window/castlewindow.pas
@@ -1043,9 +1043,9 @@ type
         MakeCurrent
         EventPress/EventRelease }
     procedure DoMouseDown(const Position: TVector2;
-      Button: CastleKeysMouse.TMouseButton; const FingerIndex: TFingerIndex = 0);
+      Button: TCastleMouseButton; const FingerIndex: TFingerIndex = 0);
     procedure DoMouseUp(const Position: TVector2;
-      Button: CastleKeysMouse.TMouseButton; const FingerIndex: TFingerIndex = 0;
+      Button: TCastleMouseButton; const FingerIndex: TFingerIndex = 0;
       const TrackReleased: boolean = true);
     procedure DoMouseWheel(const Scroll: Single; const Vertical: boolean);
     procedure DoTimer;
@@ -1901,7 +1901,7 @@ type
 
     { Mouse buttons currently pressed.
       See @link(TUIContainer.MousePressed) for details. }
-    function MousePressed: TMouseButtons;
+    function MousePressed: TCastleMouseButtons;
 
     { Is the window focused now, which means that keys/mouse events
       are directed to this window. }
@@ -3346,7 +3346,7 @@ end;
 procedure TCastleWindowBase.ReleaseAllKeysAndMouse;
 var
   k: TKey;
-  mb: CastleKeysMouse.TMouseButton;
+  mb: TCastleMouseButton;
   {$ifdef CASTLE_WINDOW_USE_PRIVATE_MODIFIERS_DOWN}
   mk: TModifierKey;
   b: boolean;
@@ -3610,7 +3610,7 @@ begin
 end;
 
 procedure TCastleWindowBase.DoMouseDown(const Position: TVector2;
-  Button: CastleKeysMouse.TMouseButton; const FingerIndex: TFingerIndex);
+  Button: TCastleMouseButton; const FingerIndex: TFingerIndex);
 var
   Event: TInputPressRelease;
 begin
@@ -3627,7 +3627,7 @@ begin
 end;
 
 procedure TCastleWindowBase.DoMouseUp(const Position: TVector2;
-  Button: CastleKeysMouse.TMouseButton; const FingerIndex: TFingerIndex;
+  Button: TCastleMouseButton; const FingerIndex: TFingerIndex;
   const TrackReleased: boolean);
 var
   Event: TInputPressRelease;
@@ -4592,7 +4592,7 @@ begin
   Result := FTouches.Count;
 end;
 
-function TCastleWindowBase.MousePressed: TMouseButtons;
+function TCastleWindowBase.MousePressed: TCastleMouseButtons;
 begin
   Result := Container.MousePressed;
 end;

--- a/src/window/castlewindow_android.inc
+++ b/src/window/castlewindow_android.inc
@@ -664,13 +664,13 @@ begin
           aeOpen: OpenContext;
           aeMotionDown:
             if not MainWindow.Closed then
-              MainWindow.DoMouseDown(QEvent.Touch.Position, mbLeft, QEvent.FingerIndex);
+              MainWindow.DoMouseDown(QEvent.Touch.Position, buttonLeft, QEvent.FingerIndex);
           aeMotionUp  :
             if not MainWindow.Closed then
-              MainWindow.DoMouseUp  (QEvent.Touch.Position, mbLeft, QEvent.FingerIndex, false);
+              MainWindow.DoMouseUp  (QEvent.Touch.Position, buttonLeft, QEvent.FingerIndex, false);
           aeMotionMove:
             if not MainWindow.Closed then
-              MainWindow.DoMotion   (InputMotion(QEvent.Touch.OldPosition, QEvent.Touch.Position, [mbLeft], QEvent.FingerIndex));
+              MainWindow.DoMotion   (InputMotion(QEvent.Touch.OldPosition, QEvent.Touch.Position, [buttonLeft], QEvent.FingerIndex));
         end;
       end;
 

--- a/src/window/castlewindow_lcl.inc
+++ b/src/window/castlewindow_lcl.inc
@@ -99,9 +99,9 @@ private
   procedure OpenGLControlUTF8KeyPress(Sender: TObject; var UTF8Key: TUTF8Char);
   procedure OpenGLControlKeyUp(Sender: TObject; var Key: Word;
     Shift: TShiftState);
-  procedure OpenGLControlMouseDown(Sender: TObject; Button: Controls.TMouseButton;
+  procedure OpenGLControlMouseDown(Sender: TObject; Button: TMouseButton;
     Shift: TShiftState; X, Y: Integer);
-  procedure OpenGLControlMouseUp(Sender: TObject; Button: Controls.TMouseButton;
+  procedure OpenGLControlMouseUp(Sender: TObject; Button: TMouseButton;
     Shift: TShiftState; X, Y: Integer);
   procedure OpenGLControlMouseMove(Sender: TObject; Shift: TShiftState; X,
     Y: Integer);
@@ -706,18 +706,18 @@ begin
 end;
 
 procedure TCastleWindowBase.OpenGLControlMouseDown(Sender: TObject;
-  Button: Controls.TMouseButton; Shift: TShiftState; X, Y: Integer);
+  Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
 var
-  MyButton: CastleKeysMouse.TMouseButton;
+  MyButton: TCastleMouseButton;
 begin
   if MouseButtonLCLToCastle(Button, MyButton) then
     DoMouseDown(LeftTopToCastle(X, Y), MyButton, 0);
 end;
 
 procedure TCastleWindowBase.OpenGLControlMouseUp(Sender: TObject;
-  Button: Controls.TMouseButton; Shift: TShiftState; X, Y: Integer);
+  Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
 var
-  MyButton: CastleKeysMouse.TMouseButton;
+  MyButton: TCastleMouseButton;
 begin
   if MouseButtonLCLToCastle(Button, MyButton) then
     DoMouseUp(LeftTopToCastle(X, Y), MyButton, 0);

--- a/src/window/castlewindow_lcl.inc
+++ b/src/window/castlewindow_lcl.inc
@@ -99,9 +99,9 @@ private
   procedure OpenGLControlUTF8KeyPress(Sender: TObject; var UTF8Key: TUTF8Char);
   procedure OpenGLControlKeyUp(Sender: TObject; var Key: Word;
     Shift: TShiftState);
-  procedure OpenGLControlMouseDown(Sender: TObject; Button: TMouseButton;
+  procedure OpenGLControlMouseDown(Sender: TObject; Button: Controls.TMouseButton;
     Shift: TShiftState; X, Y: Integer);
-  procedure OpenGLControlMouseUp(Sender: TObject; Button: TMouseButton;
+  procedure OpenGLControlMouseUp(Sender: TObject; Button: Controls.TMouseButton;
     Shift: TShiftState; X, Y: Integer);
   procedure OpenGLControlMouseMove(Sender: TObject; Shift: TShiftState; X,
     Y: Integer);
@@ -706,7 +706,7 @@ begin
 end;
 
 procedure TCastleWindowBase.OpenGLControlMouseDown(Sender: TObject;
-  Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
+  Button: Controls.TMouseButton; Shift: TShiftState; X, Y: Integer);
 var
   MyButton: TCastleMouseButton;
 begin
@@ -715,7 +715,7 @@ begin
 end;
 
 procedure TCastleWindowBase.OpenGLControlMouseUp(Sender: TObject;
-  Button: TMouseButton; Shift: TShiftState; X, Y: Integer);
+  Button: Controls.TMouseButton; Shift: TShiftState; X, Y: Integer);
 var
   MyButton: TCastleMouseButton;
 begin

--- a/src/window/castlewindow_library.inc
+++ b/src/window/castlewindow_library.inc
@@ -502,7 +502,7 @@ var
 begin
   try
     CheckMainWindow;
-    if (bLeftBtn) then MyButton := buttonLeft else MyButton := mbRight;
+    if (bLeftBtn) then MyButton := buttonLeft else MyButton := buttonRight;
     Application.MainWindow.DoMouseDown(Vector2(X, Y), MyButton, FingerIndex);
   except
     on E: TObject do WritelnWarning('CGEApp_MouseDown', ExceptMessage(E));
@@ -534,7 +534,7 @@ begin
     if bLeftBtn then
       MyButton := buttonLeft
     else
-      MyButton := mbRight;
+      MyButton := buttonRight;
     Application.MainWindow.DoMouseUp(Vector2(X, Y), MyButton, FingerIndex, TrackReleased);
   except
     on E: TObject do WritelnWarning('CGEApp_MouseUp', ExceptMessage(E));

--- a/src/window/castlewindow_library.inc
+++ b/src/window/castlewindow_library.inc
@@ -502,7 +502,7 @@ var
 begin
   try
     CheckMainWindow;
-    if (bLeftBtn) then MyButton := mbLeft else MyButton := mbRight;
+    if (bLeftBtn) then MyButton := buttonLeft else MyButton := mbRight;
     Application.MainWindow.DoMouseDown(Vector2(X, Y), MyButton, FingerIndex);
   except
     on E: TObject do WritelnWarning('CGEApp_MouseDown', ExceptMessage(E));
@@ -532,7 +532,7 @@ begin
   try
     CheckMainWindow;
     if bLeftBtn then
-      MyButton := mbLeft
+      MyButton := buttonLeft
     else
       MyButton := mbRight;
     Application.MainWindow.DoMouseUp(Vector2(X, Y), MyButton, FingerIndex, TrackReleased);

--- a/src/window/castlewindow_library.inc
+++ b/src/window/castlewindow_library.inc
@@ -498,7 +498,7 @@ end;
 
 procedure CGEApp_MouseDown(X, Y: CInt32; bLeftBtn: cBool; FingerIndex: CInt32); cdecl;
 var
-  MyButton: TMouseButton;
+  MyButton: TCastleMouseButton;
 begin
   try
     CheckMainWindow;
@@ -527,7 +527,7 @@ end;
 procedure CGEApp_MouseUp(X, Y: cInt32; bLeftBtn: cBool;
   FingerIndex: CInt32; TrackReleased: cBool); cdecl;
 var
-  MyButton: TMouseButton;
+  MyButton: TCastleMouseButton;
 begin
   try
     CheckMainWindow;

--- a/src/window/gtk/castlewindow_gtk.inc
+++ b/src/window/gtk/castlewindow_gtk.inc
@@ -270,7 +270,7 @@ begin
     to do it type-safe. }
   case bn of
     1: mb := buttonLeft;
-    2: mb := mbMiddle;
+    2: mb := buttonMiddle;
     3: mb := buttonRight;
     8: mb := mbExtra1;
     9: mb := mbExtra2;

--- a/src/window/gtk/castlewindow_gtk.inc
+++ b/src/window/gtk/castlewindow_gtk.inc
@@ -271,7 +271,7 @@ begin
   case bn of
     1: mb := buttonLeft;
     2: mb := mbMiddle;
-    3: mb := mbRight;
+    3: mb := buttonRight;
     8: mb := mbExtra1;
     9: mb := mbExtra2;
     else Exit(false);

--- a/src/window/gtk/castlewindow_gtk.inc
+++ b/src/window/gtk/castlewindow_gtk.inc
@@ -269,7 +269,7 @@ begin
   { No need to implement this using dirty typecasts, it's simple enough
     to do it type-safe. }
   case bn of
-    1: mb := mbLeft;
+    1: mb := buttonLeft;
     2: mb := mbMiddle;
     3: mb := mbRight;
     8: mb := mbExtra1;

--- a/src/window/gtk/castlewindow_gtk.inc
+++ b/src/window/gtk/castlewindow_gtk.inc
@@ -272,8 +272,8 @@ begin
     1: mb := buttonLeft;
     2: mb := buttonMiddle;
     3: mb := buttonRight;
-    8: mb := mbExtra1;
-    9: mb := mbExtra2;
+    8: mb := buttonExtra1;
+    9: mb := buttonExtra2;
     else Exit(false);
   end;
   Result := true;

--- a/src/window/gtk/castlewindow_gtk.inc
+++ b/src/window/gtk/castlewindow_gtk.inc
@@ -262,9 +262,9 @@ begin
 end;
 
 { Converts GDK mouse button number (from GdkEventButton.button)
-  to TMouseButton. Returns false (and does not change mb) if such
-  button number cannot be represented as TMouseButton. }
-function ButtonNumberToMouseButton(bn: guint; out mb: TMouseButton): boolean;
+  to TCastleMouseButton. Returns false (and does not change mb) if such
+  button number cannot be represented as TCastleMouseButton. }
+function ButtonNumberToMouseButton(bn: guint; out mb: TCastleMouseButton): boolean;
 begin
   { No need to implement this using dirty typecasts, it's simple enough
     to do it type-safe. }
@@ -512,7 +512,7 @@ SIGNAL_WINDOW_END;
 
 function signal_button_press_event(AGLAreaGtk: PGtkGLArea; Event: PGdkEventButton;
   data: gpointer): gboolean; cdecl;
-var mb: TMouseButton;
+var mb: TCastleMouseButton;
 SIGNAL_GLAREA_BEGIN
   Result := (Event^._type = GDK_BUTTON_PRESS) and
     ButtonNumberToMouseButton(Event^.button, mb);
@@ -522,7 +522,7 @@ SIGNAL_GLAREA_END;
 
 function signal_button_release_event(AGLAreaGtk: PGtkGLArea; Event: PGdkEventButton;
   data: gpointer): gboolean; cdecl;
-var mb: TMouseButton;
+var mb: TCastleMouseButton;
 SIGNAL_GLAREA_BEGIN
   Result := (Event^._type = GDK_BUTTON_RELEASE) and
     ButtonNumberToMouseButton(Event^.button, mb);

--- a/src/window/unix/castlewindow_xlib.inc
+++ b/src/window/unix/castlewindow_xlib.inc
@@ -591,7 +591,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
     result := true;
     case button of
       Button1 : mbtn := buttonLeft;
-      Button2 : mbtn := mbMiddle;
+      Button2 : mbtn := buttonMiddle;
       Button3 : mbtn := buttonRight;
       else Result := false;
     end;
@@ -624,7 +624,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
     { We could refresh MousePressed now. But no need for now?
     mousePressed:=[];
     if (Button1Mask and event.state) <> 0 then Include(mousePressed, buttonLeft);
-    if (Button2Mask and event.state) <> 0 then Include(mousePressed, mbMiddle);
+    if (Button2Mask and event.state) <> 0 then Include(mousePressed, buttonMiddle);
     if (Button3Mask and event.state) <> 0 then Include(mousePressed, buttonRight);
     }
     DoMotion(InputMotion(MousePosition,

--- a/src/window/unix/castlewindow_xlib.inc
+++ b/src/window/unix/castlewindow_xlib.inc
@@ -586,7 +586,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
     DoResize(xEvent.width, xEvent.height, false);
   end;
 
-  function xbtnToMouseButton(button: Cardinal; var mbtn: TMouseButton): boolean;
+  function xbtnToMouseButton(button: Cardinal; var mbtn: TCastleMouseButton): boolean;
   begin
     result := true;
     case button of
@@ -599,7 +599,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
 
   procedure X_ButtonPress(const xEvent: TXButtonPressedEvent);
   var
-    btn: TMouseButton;
+    btn: TCastleMouseButton;
   begin
     if xbtnToMouseButton(xEvent.button, btn) then
       DoMouseDown(LeftTopToCastle(xEvent.x, xEvent.y), btn, 0) else
@@ -613,7 +613,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
 
   procedure X_ButtonRelease(const xEvent: TXButtonReleasedEvent);
   var
-    btn: TMouseButton;
+    btn: TCastleMouseButton;
   begin
     if xbtnToMouseButton(xEvent.button, btn) then
       DoMouseUp(LeftTopToCastle(xEvent.x, xEvent.y), btn, 0)

--- a/src/window/unix/castlewindow_xlib.inc
+++ b/src/window/unix/castlewindow_xlib.inc
@@ -590,7 +590,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
   begin
     result := true;
     case button of
-      Button1 : mbtn := mbLeft;
+      Button1 : mbtn := buttonLeft;
       Button2 : mbtn := mbMiddle;
       Button3 : mbtn := mbRight;
       else Result := false;
@@ -623,7 +623,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
   begin
     { We could refresh MousePressed now. But no need for now?
     mousePressed:=[];
-    if (Button1Mask and event.state) <> 0 then Include(mousePressed, mbLeft);
+    if (Button1Mask and event.state) <> 0 then Include(mousePressed, buttonLeft);
     if (Button2Mask and event.state) <> 0 then Include(mousePressed, mbMiddle);
     if (Button3Mask and event.state) <> 0 then Include(mousePressed, mbRight);
     }

--- a/src/window/unix/castlewindow_xlib.inc
+++ b/src/window/unix/castlewindow_xlib.inc
@@ -592,7 +592,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
     case button of
       Button1 : mbtn := buttonLeft;
       Button2 : mbtn := mbMiddle;
-      Button3 : mbtn := mbRight;
+      Button3 : mbtn := buttonRight;
       else Result := false;
     end;
   end;
@@ -625,7 +625,7 @@ function TCastleWindowBase.HandleXEvent(const Event: TXEvent): boolean;
     mousePressed:=[];
     if (Button1Mask and event.state) <> 0 then Include(mousePressed, buttonLeft);
     if (Button2Mask and event.state) <> 0 then Include(mousePressed, mbMiddle);
-    if (Button3Mask and event.state) <> 0 then Include(mousePressed, mbRight);
+    if (Button3Mask and event.state) <> 0 then Include(mousePressed, buttonRight);
     }
     DoMotion(InputMotion(MousePosition,
       LeftTopToCastle(xEvent.x, xEvent.y),

--- a/src/window/windows/castlewindow_winapi.inc
+++ b/src/window/windows/castlewindow_winapi.inc
@@ -750,7 +750,7 @@ begin
             FMousePressed := [];
             if (MK_LBUTTON and wParm) <> 0 then Include(FMousePressed, buttonLeft);
             if (MK_MBUTTON and wParm) <> 0 then Include(FMousePressed, mbMiddle);
-            if (MK_RBUTTON and wParm) <> 0 then Include(FMousePressed, mbRight);
+            if (MK_RBUTTON and wParm) <> 0 then Include(FMousePressed, buttonRight);
           but it's not needed (we keep it current anyway in mousedown/up events). }
         DoMotion(InputMotion(MousePosition, LeftTopToCastle(
           TWinParam(lParm).LoSmallint,
@@ -760,10 +760,10 @@ begin
       end;
     WM_LBUTTONDOWN: begin HandleMouseDown(buttonLeft  ); Exit end;
     WM_MBUTTONDOWN: begin HandleMouseDown(mbMiddle); Exit end;
-    WM_RBUTTONDOWN: begin HandleMouseDown(mbRight ); Exit end;
+    WM_RBUTTONDOWN: begin HandleMouseDown(buttonRight ); Exit end;
     WM_LBUTTONUP  : begin HandleMouseUp(buttonLeft  ); Exit end;
     WM_MBUTTONUP  : begin HandleMouseUp(mbMiddle); Exit end;
-    WM_RBUTTONUP  : begin HandleMouseUp(mbRight ); Exit end;
+    WM_RBUTTONUP  : begin HandleMouseUp(buttonRight ); Exit end;
     WM_COMMAND    :
       { If this comes from a menu item, call DoMenuClick }
       if TWinParam(wParm).HiWord = 0 then

--- a/src/window/windows/castlewindow_winapi.inc
+++ b/src/window/windows/castlewindow_winapi.inc
@@ -748,7 +748,7 @@ begin
       begin
         { We could refresh FMousePressed now:
             FMousePressed := [];
-            if (MK_LBUTTON and wParm) <> 0 then Include(FMousePressed, mbLeft);
+            if (MK_LBUTTON and wParm) <> 0 then Include(FMousePressed, buttonLeft);
             if (MK_MBUTTON and wParm) <> 0 then Include(FMousePressed, mbMiddle);
             if (MK_RBUTTON and wParm) <> 0 then Include(FMousePressed, mbRight);
           but it's not needed (we keep it current anyway in mousedown/up events). }
@@ -758,10 +758,10 @@ begin
           MousePressed, 0));
         Exit;
       end;
-    WM_LBUTTONDOWN: begin HandleMouseDown(mbLeft  ); Exit end;
+    WM_LBUTTONDOWN: begin HandleMouseDown(buttonLeft  ); Exit end;
     WM_MBUTTONDOWN: begin HandleMouseDown(mbMiddle); Exit end;
     WM_RBUTTONDOWN: begin HandleMouseDown(mbRight ); Exit end;
-    WM_LBUTTONUP  : begin HandleMouseUp(mbLeft  ); Exit end;
+    WM_LBUTTONUP  : begin HandleMouseUp(buttonLeft  ); Exit end;
     WM_MBUTTONUP  : begin HandleMouseUp(mbMiddle); Exit end;
     WM_RBUTTONUP  : begin HandleMouseUp(mbRight ); Exit end;
     WM_COMMAND    :

--- a/src/window/windows/castlewindow_winapi.inc
+++ b/src/window/windows/castlewindow_winapi.inc
@@ -542,7 +542,7 @@ function TCastleWindowBase.WindowProc(uMsg: UINT; wParm: WPARAM; lParm: LPARAM):
     end;
   end;
 
-  procedure HandleMouseDown(const Button: TMouseButton);
+  procedure HandleMouseDown(const Button: TCastleMouseButton);
   begin
     MaybeCapture;
     DoMouseDown(LeftTopToCastle(
@@ -550,7 +550,7 @@ function TCastleWindowBase.WindowProc(uMsg: UINT; wParm: WPARAM; lParm: LPARAM):
       TWinParam(lParm).HiSmallint), Button, 0);
   end;
 
-  procedure HandleMouseUp(const Button: TMouseButton);
+  procedure HandleMouseUp(const Button: TCastleMouseButton);
   begin
     DoMouseUp(LeftTopToCastle(
       TWinParam(lParm).LoSmallint,

--- a/src/window/windows/castlewindow_winapi.inc
+++ b/src/window/windows/castlewindow_winapi.inc
@@ -749,7 +749,7 @@ begin
         { We could refresh FMousePressed now:
             FMousePressed := [];
             if (MK_LBUTTON and wParm) <> 0 then Include(FMousePressed, buttonLeft);
-            if (MK_MBUTTON and wParm) <> 0 then Include(FMousePressed, mbMiddle);
+            if (MK_MBUTTON and wParm) <> 0 then Include(FMousePressed, buttonMiddle);
             if (MK_RBUTTON and wParm) <> 0 then Include(FMousePressed, buttonRight);
           but it's not needed (we keep it current anyway in mousedown/up events). }
         DoMotion(InputMotion(MousePosition, LeftTopToCastle(
@@ -759,10 +759,10 @@ begin
         Exit;
       end;
     WM_LBUTTONDOWN: begin HandleMouseDown(buttonLeft  ); Exit end;
-    WM_MBUTTONDOWN: begin HandleMouseDown(mbMiddle); Exit end;
+    WM_MBUTTONDOWN: begin HandleMouseDown(buttonMiddle); Exit end;
     WM_RBUTTONDOWN: begin HandleMouseDown(buttonRight ); Exit end;
     WM_LBUTTONUP  : begin HandleMouseUp(buttonLeft  ); Exit end;
-    WM_MBUTTONUP  : begin HandleMouseUp(mbMiddle); Exit end;
+    WM_MBUTTONUP  : begin HandleMouseUp(buttonMiddle); Exit end;
     WM_RBUTTONUP  : begin HandleMouseUp(buttonRight ); Exit end;
     WM_COMMAND    :
       { If this comes from a menu item, call DoMenuClick }

--- a/src/x3d/opengl/castleviewport.pas
+++ b/src/x3d/opengl/castleviewport.pas
@@ -3657,7 +3657,7 @@ var
   R: TRegisteredComponent;
 initialization
   Input_Interact := TInputShortcut.Create(nil, 'Interact (press, open door)', 'interact', igOther);
-  Input_Interact.Assign(keyNone, keyNone, '', true, mbLeft);
+  Input_Interact.Assign(keyNone, keyNone, '', true, buttonLeft);
 
   R := TRegisteredComponent.Create;
   {$warnings off} // using deprecated, to keep reading it from castle-user-interface working

--- a/tools/castle-curves/castle-curves.lpr
+++ b/tools/castle-curves/castle-curves.lpr
@@ -367,7 +367,7 @@ begin
     SelectClosestPoint(Pos);
     StartDragging;
   end else
-  if Event.IsMouseButton(mbRight) then
+  if Event.IsMouseButton(buttonRight) then
     AddNewPoint(Pos) else
   if Event.IsMouseWheel(mwUp) or Event.IsMouseWheel(mwLeft) then
     ChangeZoom(ZoomFactor) else

--- a/tools/castle-curves/castle-curves.lpr
+++ b/tools/castle-curves/castle-curves.lpr
@@ -362,7 +362,7 @@ var
   Pos: TVector2;
 begin
   Pos := Event.Position / SceneZoom;
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     SelectClosestPoint(Pos);
     StartDragging;
@@ -380,7 +380,7 @@ end;
 
 procedure Release(Container: TUIContainer; const Event: TInputPressRelease);
 begin
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     Dragging := false;
     Window.Invalidate;

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -546,7 +546,7 @@ begin
   if Result then Exit;
 
   if (Frame.Mode = moModifyUi) and
-     (Event.IsMouseButton(buttonLeft) or Event.IsMouseButton(mbRight)) then
+     (Event.IsMouseButton(buttonLeft) or Event.IsMouseButton(buttonRight)) then
   begin
     { Left mouse button selects before moving/resizing.
       Right mouse button doesn't. This allows to change the size of the control
@@ -596,7 +596,7 @@ begin
   Result := inherited Press(Event);
   if Result then Exit;
 
-  if (Event.IsMouseButton(buttonLeft) or Event.IsMouseButton(mbRight)) then
+  if (Event.IsMouseButton(buttonLeft) or Event.IsMouseButton(buttonRight)) then
   begin
     DraggingMode := dmNone;
 
@@ -808,8 +808,8 @@ begin
     (maybe can happen e.g. if you Alt+Tab during dragging?),
     reset DraggingMode. }
   if (DraggingMode <> dmNone) and
-     // neither buttonLeft nor mbRight
-     ([buttonLeft, mbRight] * Event.Pressed = []) then
+     // neither buttonLeft nor buttonRight
+     ([buttonLeft, buttonRight] * Event.Pressed = []) then
     DraggingMode := dmNone;
 
   if (Frame.Mode = moModifyUi) and (DraggingMode <> dmNone) then
@@ -1020,7 +1020,7 @@ begin
   BuildComponentsMenu(MenuTreeViewItemAddUserInterface, MenuTreeViewItemAddTransform, @MenuItemAddComponentClick);
   // Input_Interact (for gizmos) reacts to both left and right
   Input_Interact.MouseButton2Use := true;
-  Input_Interact.MouseButton2 := mbRight;
+  Input_Interact.MouseButton2 := buttonRight;
 end;
 
 destructor TDesignFrame.Destroy;

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -546,14 +546,14 @@ begin
   if Result then Exit;
 
   if (Frame.Mode = moModifyUi) and
-     (Event.IsMouseButton(mbLeft) or Event.IsMouseButton(mbRight)) then
+     (Event.IsMouseButton(buttonLeft) or Event.IsMouseButton(mbRight)) then
   begin
     { Left mouse button selects before moving/resizing.
       Right mouse button doesn't. This allows to change the size of the control
       without changing the selected control, e.g. when you want to change
       the size of TCastleScrollView without
       selecting TCastleScrollView.ScrollArea inside. }
-    if Event.IsMouseButton(mbLeft) then
+    if Event.IsMouseButton(buttonLeft) then
       Frame.SelectedUserInterface := HoverUserInterface(Event.Position);
 
     UI := Frame.SelectedUserInterface;
@@ -570,7 +570,7 @@ begin
   end;
 
   if (Frame.Mode in TransformModes) and
-      Event.IsMouseButton(mbLeft) then
+      Event.IsMouseButton(buttonLeft) then
   begin
     T := HoverTransform(Event.Position);
     { Do not change Frame.SelectedTransform in case T is nil,
@@ -596,7 +596,7 @@ begin
   Result := inherited Press(Event);
   if Result then Exit;
 
-  if (Event.IsMouseButton(mbLeft) or Event.IsMouseButton(mbRight)) then
+  if (Event.IsMouseButton(buttonLeft) or Event.IsMouseButton(mbRight)) then
   begin
     DraggingMode := dmNone;
 
@@ -808,8 +808,8 @@ begin
     (maybe can happen e.g. if you Alt+Tab during dragging?),
     reset DraggingMode. }
   if (DraggingMode <> dmNone) and
-     // neither mbLeft nor mbRight
-     ([mbLeft, mbRight] * Event.Pressed = []) then
+     // neither buttonLeft nor mbRight
+     ([buttonLeft, mbRight] * Event.Pressed = []) then
     DraggingMode := dmNone;
 
   if (Frame.Mode = moModifyUi) and (DraggingMode <> dmNone) then

--- a/tools/castle-editor/data/project_templates/2d_game/files/gamestateplay.pas
+++ b/tools/castle-editor/data/project_templates/2d_game/files/gamestateplay.pas
@@ -125,7 +125,7 @@ begin
     not handled in children controls.
   }
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     DragonFlyingTarget := MainViewport.PositionTo2DWorld(Event.Position, true);
     if not DragonFlying then

--- a/tools/castle-editor/data/project_templates/3d_fps_game/files/gamestateplay.pas
+++ b/tools/castle-editor/data/project_templates/3d_fps_game/files/gamestateplay.pas
@@ -99,7 +99,7 @@ begin
     not handled in children controls.
   }
 
-  if Event.IsMouseButton(mbLeft) then
+  if Event.IsMouseButton(buttonLeft) then
   begin
     SoundEngine.Sound(SoundEngine.SoundFromName('shoot_sound'));
 


### PR DESCRIPTION
To avoid conflict between `Controls.TMouseButton` and `CastleKeysMouse.TMouseButtons` which sometimes harms LCL-based apps.

Trello issue: https://trello.com/c/RKstHQN1/80-rename-tmousebutton-into-tcastlemousebutton