### PR TITLE
Set AvoidNavigationCollisions only when Player is in Level Items (Fixes Frogger "Enter key" Issue)

### DIFF
--- a/src/game/castlelevels.pas
+++ b/src/game/castlelevels.pas
@@ -869,6 +869,11 @@ begin
   { clear Items, removing everything from previous level }
   Items.Clear;
 
+  { Since the player is removed from Items, we need to remove AvoidNavigationCollisions
+    as well because calling TCastleViewport.CameraRayCollision() will attempt to
+    access Parent from AvoidNavigationCollisions which is nil. }
+  Viewport.AvoidNavigationCollisions := nil;
+
   { free stuff like creatures, items, level logic.
     Note that things not owned by FreeAtUnload, like usual Player and FInternalLogic,
     remain untouched. }
@@ -1043,7 +1048,10 @@ begin
       and it is equal to Player.
     }
     if (Player <> nil) and (Player.World = nil) then
+    begin
       Items.Add(Player);
+      Viewport.AvoidNavigationCollisions := Player;
+    end;
 
     { add FInternalLogic to Items }
     Items.Add(FInternalLogic);
@@ -1191,7 +1199,6 @@ begin
       FPlayer.FreeNotification(Self);
       FPlayer.InternalLevel := Self;
     end;
-    Viewport.AvoidNavigationCollisions := Value;
 
     { Reinitialize camera and navigation only when level was loaded. }
     if FInfo <> nil then
@@ -1206,6 +1213,7 @@ begin
         if FPlayer.World = nil then
         begin
           Items.Insert(1, FPlayer);
+          Viewport.AvoidNavigationCollisions := Value;
           FPlayer.LevelChanged;
         end;
       end;


### PR DESCRIPTION
This fixes problem with level loading after press Enter in `MessageOk()`. This PR fixes this bug at TLevel and TPlayer.

Trello Ticket: https://trello.com/c/iz7uvjKN/79-frogger3d-crash-when-pressing-enter-on-game-over-message-box

## The essence of the problem

The essence of the problem is that removing item from World (Like in `TLevel.UnloadCore`) don't remove `TViewport.AvoidNavigationCollisions`. And next `TCastleTransform.Ray()` is called from: `CastleViewport.CameraRayCollision()` This happen when there are unrelased keys in window when `TProgres.Init()` is called.

Check this functions:
```
function TCastleViewport.CameraRayCollision(const RayOrigin, RayDirection: TVector3): TRayCollision;
begin
  { Both version result in calling WorldRay.
    AvoidNavigationCollisions version adds AvoidNavigationCollisions.Disable/Enable around. }

  if AvoidNavigationCollisions <> nil then
    Result := AvoidNavigationCollisions.Ray(RayOrigin, RayDirection)
  else
    Result := Items.WorldRay(RayOrigin, RayDirection);
end; 

function TCastleTransform.Ray(
  const RayOrigin, RayDirection: TVector3): TRayCollision;
var
  RayOriginWorld, RayDirectionWorld: TVector3;
begin
  RayOriginWorld := UniqueParent.LocalToWorld(RayOrigin);
  RayDirectionWorld := UniqueParent.LocalToWorldDirection(RayDirection);
  Disable;
  try
    Result := World.WorldRay(RayOriginWorld, RayDirectionWorld);
  finally Enable end;
end;
```
## Other ways to fix that

#### Set `AvoidNavigationCollisions` to nil when `TCastleTransform` from `AvoidNavigationCollisions` is removed from world

I think changing the way which `AvoidNavigationCollisions` works can break compatibility in different places. So because we plan go to real physics (kraft) in near future. All this stuff will be deprecated/reimplemented. So it's not worth investing time (I think).

#### Only fix `TCastleViewport.CameraRayCollision`

Something like:
```
if (AvoidNavigationCollisions <> nil) and (AvoidNavigationCollisions.World <> nil) then
    Result := AvoidNavigationCollisions.Ray(RayOrigin, RayDirection)
  else
```
But this will fix only this one function. It might just hide the bigger problem.

## Summary

I will also fix `MessageCore()` and `TProgress` in another PRs so if this fix breaks something what I don't noticed can be closed. Fixing `MessageCore()` will resolve/hide this bug.

## Tests
I tested this solution on frogger3d, fps_game example, and darkest-before-dawn.





