### PR TITLE
Message boxes should not leave keys in false/strange pressed state.

### DIFF
--- a/src/window/castlemessages.pas
+++ b/src/window/castlemessages.pas
@@ -397,7 +397,11 @@ begin
         for update would be large. }
       Application.ProcessMessage(false, true)
     until State.Answered;
-  finally FreeAndNil(SavedMode) end;
+  finally
+    FreeAndNil(SavedMode);
+    { Message boxes should not leave the keys in false/strange pressed state. }
+    Window.Pressed.Clear;
+  end;
 
   State.Stop;
 end;


### PR DESCRIPTION
This also fixes Frogger3d  "Enter key case" but also can help in other places.

Just all keys states are cleared after process messages loop quits. So keys state are correct after message box is closed.

Merging this before https://github.com/castle-engine/castle-engine/pull/220 will "hide" Frogger3d bug.