### PR TITLE
Clear pressed keys in progress bar. 

### DIFF
--- a/src/window/castlewindowprogress.pas
+++ b/src/window/castlewindowprogress.pas
@@ -116,6 +116,10 @@ begin
     Bar.Background := UsedWindow.SaveScreen;
   Bar.YPosition := BarYPosition;
 
+  { Reset all keys because TGLMode.Create() can do a lot of uneeded things in
+    SimulateReleaseAll(). And probably no one expects the progress bar to
+    try to react to the pressed keys in some way. }
+  UsedWindow.Pressed.Clear;
   SavedMode := TGLMode.CreateReset(UsedWindow, nil, nil, @NoClose);
 
   UsedWindow.Controls.InsertFront(Bar);


### PR DESCRIPTION
This also can fix Frogger3d but I add it more for another reason. The `TProgress` is visible when some long operations are made. So passing the state of the keys may trigger unnecessary responses, especially because of `TGLMode` can do `SimulateReleaseAll()`. 

This PR can also eliminate some of the weaknesses of TGLMode. But in the future (maybe after 7.0) we need totally rebuild TProgressBar (and messageboxes also?). 

## Idea

I understand that TGLMode is supposed to enable state display without affecting the user-defined state stack. At first glance, in addition to the user stack, I would introduce something like `SystemState` that would be prioritized. If `SystemState = nil` then the user states would be used. Otherwise, the system state would take precedence. I don't know the implementation details yet, so it's just an idea. What do you think about it? Can we add something like this to trello?