### PR TITLE
Update default Android target API level to 29

### DIFF
--- a/tools/build-tool/code/toolproject.pas
+++ b/tools/build-tool/code/toolproject.pas
@@ -368,7 +368,7 @@ constructor TCastleProject.Create(const APath: string);
     DefautVersionCode = 1;
     { iOS requires version display to be <> '' }
     DefautVersionDisplayValue = '0.1';
-    DefaultAndroidCompileSdkVersion = 28;
+    DefaultAndroidCompileSdkVersion = 29;
     DefaultAndroidTargetSdkVersion = DefaultAndroidCompileSdkVersion;
     { See https://github.com/castle-engine/castle-engine/wiki/Android-FAQ#what-android-devices-are-supported
       for reasons behind this minimal version. }


### PR DESCRIPTION
I changed the default target API level to 29 so the build tool meets the minimum Play Store requirements.

https://developer.android.com/distribute/best-practices/develop/target-sdk

Tested by compiling and running my game, drawing_toy, simple_3d_demo, 2d_dragon_spine_game.