### PR TITLE
Add basic rendering functionality for TiledObject primitives (Polygon, Polyline, Point, Rectangle)

### DIFF
--- a/src/ui/opengl/castletiledmap.pas
+++ b/src/ui/opengl/castletiledmap.pas
@@ -34,7 +34,7 @@ uses
   Classes, SysUtils, DOM, XMLRead, base64, zstream, Generics.Collections,
   CastleVectors, CastleColors, CastleUtils, CastleURIUtils, CastleXMLUtils,
   CastleLog, CastleStringUtils, CastleUIControls, CastleGLImages,
-  CastleRectangles, CastleClassUtils;
+  CastleRectangles, CastleClassUtils, CastleRenderOptions;
 
 {$define read_interface}
 {$I castletiledmap_map.inc}

--- a/src/ui/opengl/castletiledmap_control.inc
+++ b/src/ui/opengl/castletiledmap_control.inc
@@ -223,20 +223,29 @@ var
   Lay: TTiledMap.TLayer;              // ObjectGroupLayer
   TiledObj: TTiledMap.TTiledObject;   // one TiledObject
   TiledObjPoints: array of TVector2;  // holds points of TiledObject as array of TVector2
-  ScaleX, ScaleY: Single;
+
+  function ScaleX: Single;
+  begin
+    { Denominator corresponds to width of object layer in pixels. }
+    Result := RenderRect.Width / (Map.Width * Map.TileWidth);
+  end;
+
+  function ScaleY: Single;
+  begin
+    { Denominator corresponds to height of object layer in pixels. }
+    Result := RenderRect.Height / (Map.Height * Map.TileHeight);
+  end;
 
   { Converts all TVector2's from a TVector2List to and array of TVector2.
     ArrIndex is the index of a TVector2 in the array, ListIndex is the TVector2
     in the list. }
-  procedure ConvertAndScalePoints(ArrIndex, ListIndex: Cardinal);
+  procedure ConvertAndScalePoints(const ArrIndex, ListIndex: Cardinal);
   begin
     { Convert and scale X coordinates. }
-    ScaleX := RenderRect.Width / Width;
-    TiledObjPoints[ArrIndex].X := RenderRect.LeftBottom.X + ScaleX *
+    TiledObjPoints[ArrIndex].X := RenderRect.Left + ScaleX *
       (Lay.OffsetX + TiledObj.X + TiledObj.Points.Items[ListIndex].X);
     { Convert and scale Y coordinates and change ref. system (top-left
       origin to bottom-left origin). }
-    ScaleY := RenderRect.Height / Height;
     TiledObjPoints[ArrIndex].Y := RenderRect.Top - ScaleY *
       (Lay.OffsetY + TiledObj.Y + TiledObj.Points.Items[ListIndex].Y);
   end;
@@ -272,10 +281,8 @@ var
     TiledObjPoint: array[0..0] of TVector2;   // array with 1 element
   begin
     { Prepare point. }
-    ScaleX := RenderRect.Width / Width;
-    TiledObjPoint[0].X := RenderRect.LeftBottom.X + ScaleX *
+    TiledObjPoint[0].X := RenderRect.Left + ScaleX *
       (Lay.OffsetX + TiledObj.X);
-    ScaleY := RenderRect.Height / Height;
     TiledObjPoint[0].Y := RenderRect.Top - ScaleY *
       (Lay.OffsetY + TiledObj.Y);
     { Draw point TiledObject. }
@@ -288,12 +295,10 @@ var
     TiledObjRect: TFloatRectangle;
   begin
     { Prepare rectangle. }
-    ScaleX := RenderRect.Width / Width;
-    TiledObjRect.Left := RenderRect.LeftBottom.X + ScaleX *
+    TiledObjRect.Left := RenderRect.Left + ScaleX *
       (Lay.OffsetX + TiledObj.X);
     TiledObjRect.Width := ScaleX * TiledObj.Width;
 
-    ScaleY := RenderRect.Height / Height;
     TiledObjRect.Bottom := RenderRect.Top - ScaleY *
       (Lay.OffsetY + TiledObj.Y + TiledObj.Height);
     TiledObjRect.Height := ScaleY * TiledObj.Height;

--- a/src/ui/opengl/castletiledmap_control.inc
+++ b/src/ui/opengl/castletiledmap_control.inc
@@ -244,14 +244,14 @@ var
   { Prepare and render TiledObject polyline and polygon. }
   procedure RenderPolylinePolygon;
   var
-    i: Cardinal;
+    I: Cardinal;
   begin
     { Prepare points for DrawPrimitive2D function. Convert from vector list
       to array of vectors. }
     SetLength(TiledObjPoints, TiledObj.Points.Count);
-    for i := 0 to High(TiledObjPoints) do
+    for I := 0 to High(TiledObjPoints) do
     begin
-      ConvertAndScalePoints(i, i);
+      ConvertAndScalePoints(I, I);
     end;
 
     { If TiledObject is a polygon, for rendering of last line, a point has to be

--- a/src/ui/opengl/castletiledmap_control.inc
+++ b/src/ui/opengl/castletiledmap_control.inc
@@ -198,7 +198,7 @@ constructor TCastleTiledMapControl.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
   ClipChildren := true;
-  FObjectsVisible := false;
+  FObjectsVisible := true; // Reverse back to false later: for testing only
   FScale := 1;
   FSmoothScaling := false;
   FSmoothScalingSafeBorder := false;
@@ -220,15 +220,110 @@ end;
 
 procedure TCastleTiledMapControl.RenderObjects;
 var
-  Lay: TTiledMap.TLayer;
+  Lay: TTiledMap.TLayer;              // ObjectGroupLayer
+  TiledObj: TTiledMap.TTiledObject;   // one TiledObject
+  TiledObjPoints: array of TVector2;  // holds points of TiledObject as array of TVector2
+  ScaleX, ScaleY: Single;
+
+  { Converts all TVector2's from a TVector2List to and array of TVector2.
+    ArrIndex is the index of a TVector2 in the array, ListIndex is the TVector2
+    in the list. }
+  procedure ConvertAndScalePoints(ArrIndex, ListIndex: Cardinal);
+  begin
+    { Convert and scale X coordinates. }
+    ScaleX := RenderRect.Width / Width;
+    TiledObjPoints[ArrIndex].X := RenderRect.LeftBottom.X + ScaleX *
+      (Lay.OffsetX + TiledObj.X + TiledObj.Points.Items[ListIndex].X);
+    { Convert and scale Y coordinates and change ref. system (top-left
+      origin to bottom-left origin). }
+    ScaleY := RenderRect.Height / Height;
+    TiledObjPoints[ArrIndex].Y := RenderRect.Top - ScaleY *
+      (Lay.OffsetY + TiledObj.Y + TiledObj.Points.Items[ListIndex].Y);
+  end;
+
+  { Prepare and render TiledObject polyline and polygon. }
+  procedure RenderPolylinePolygon;
+  var
+    i: Cardinal;
+  begin
+    { Prepare points for DrawPrimitive2D function. Convert from vector list
+      to array of vectors. }
+    SetLength(TiledObjPoints, TiledObj.Points.Count);
+    for i := 0 to High(TiledObjPoints) do
+    begin
+      ConvertAndScalePoints(i, i);
+    end;
+
+    { If TiledObject is a polygon, for rendering of last line, a point has to be
+      added manually to close the polygon. }
+    if TiledObj.Primitive = topPolygon then
+    begin
+      SetLength(TiledObjPoints, TiledObj.Points.Count+1);
+      ConvertAndScalePoints(High(TiledObjPoints), 0);
+    end;
+
+    { Draw polygon or polyline TiledObject. }
+    DrawPrimitive2D(pmLineStrip, TiledObjPoints, Orange, bsSrcAlpha,
+      bdOneMinusSrcAlpha, false, 1, 1);
+  end;
+
+  procedure RenderPoint;
+  var
+    TiledObjPoint: array[0..0] of TVector2;   // array with 1 element
+  begin
+    { Prepare point. }
+    ScaleX := RenderRect.Width / Width;
+    TiledObjPoint[0].X := RenderRect.LeftBottom.X + ScaleX *
+      (Lay.OffsetX + TiledObj.X);
+    ScaleY := RenderRect.Height / Height;
+    TiledObjPoint[0].Y := RenderRect.Top - ScaleY *
+      (Lay.OffsetY + TiledObj.Y);
+    { Draw point TiledObject. }
+    DrawPrimitive2D(pmPoints, TiledObjPoint, Orange, bsSrcAlpha,
+      bdOneMinusSrcAlpha, false, 1, 1);
+  end;
+
+  procedure RenderRectangle;
+  var
+    TiledObjRect: TFloatRectangle;
+  begin
+    { Prepare rectangle. }
+    ScaleX := RenderRect.Width / Width;
+    TiledObjRect.Left := RenderRect.LeftBottom.X + ScaleX *
+      (Lay.OffsetX + TiledObj.X);
+    TiledObjRect.Width := ScaleX * TiledObj.Width;
+
+    ScaleY := RenderRect.Height / Height;
+    TiledObjRect.Bottom := RenderRect.Top - ScaleY *
+      (Lay.OffsetY + TiledObj.Y + TiledObj.Height);
+    TiledObjRect.Height := ScaleY * TiledObj.Height;
+
+    { Draw rectangle TiledObject. }
+    DrawRectangleOutline(TiledObjRect, Orange, 1, bsSrcAlpha,
+      bdOneMinusSrcAlpha, false);
+  end;
+
 begin
   { Object groups. }
   for Lay in Map.Layers do
   begin
-    // if Lay is TTiledMap.TObjectGroupLayer then
-    // TODO: draw TObjectGroupLayer here
-    // TODO: when to draw TImageLayer?
+    if Lay is TTiledMap.TObjectGroupLayer and Lay.Visible then
+    begin
+      for TiledObj in (Lay as TTiledMap.TObjectGroupLayer).Objects do
+      begin
+        if TiledObj.Visible then
+        begin
+          case TiledObj.Primitive of
+            topPolyline, topPolygon: RenderPolylinePolygon;
+            topPoint: RenderPoint;
+            topRectangle: RenderRectangle;
+            // TODO: handle ellipse
+          end;
+        end;
+      end;
+    end;
   end;
+  // TODO: when to draw TImageLayer?
 end;
 
 procedure TCastleTiledMapControl.LoadTilesetsImages;

--- a/src/ui/opengl/castletiledmap_control.inc
+++ b/src/ui/opengl/castletiledmap_control.inc
@@ -154,8 +154,8 @@ type
 
     property Scale: Single read FScale write SetScale default 1;
 
-    // TODO: not implemented yet
-    // property ObjectsVisible: Boolean read FObjectsVisible write FObjectsVisible;
+    // TODO: improve implementation (ellipse, images still missing)
+    property ObjectsVisible: Boolean read FObjectsVisible write FObjectsVisible;
 
     { How are images scaled (because of UI scaling, because of @link(Scale)).
       @true means we use nice "bilinear" filter.
@@ -198,7 +198,7 @@ constructor TCastleTiledMapControl.Create(AOwner: TComponent);
 begin
   inherited Create(AOwner);
   ClipChildren := true;
-  FObjectsVisible := true; // Reverse back to false later: for testing only
+  FObjectsVisible := false;
   FScale := 1;
   FSmoothScaling := false;
   FSmoothScalingSafeBorder := false;

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -85,7 +85,8 @@ type
 
       TObjectsDrawOrder = (odoIndex, odoTopDown);
 
-      TTileObjectPrimitive = (topEllipse, topPoligon, topPolyLine);
+      TTileObjectPrimitive = (topRectangle, topPoint, topEllipse, topPolygon,
+        topPolyLine);
 
       { Object definition. }
       TTiledObject = class
@@ -776,16 +777,22 @@ begin
     if TmpStr = '0' then
       Visible := False;
 
+  { Assume rectangle TiledObject first as it is the only element which has no
+    sub-element in TMX file which indicates its primitive type. Will be over-
+    ridden by follwing iteration, if a sub-element exists. }
+  Primitive := topRectangle;
+
   I := TXMLElementIterator.Create(Element);
   try
     while I.GetNext do
     begin
       case LowerCase(I.Current.TagName) of
         'properties': Properties.Load(I.Current, BaseUrl);
+        'point': Primitive := topPoint;
         'ellipse': Primitive := topEllipse;
         'polygon':
           begin
-            Primitive := topPoligon;
+            Primitive := topPolygon;
             ReadPoints(I.Current.AttributeStringDef('points', ''), Points);
           end;
         'polyline':


### PR DESCRIPTION
Hello,

this commit adds 
- rendering functionality for ObjectGroupLayers TiledObjects (polygon, polyline, point, rectangle) from TiledMaps

this commit doen't add
- rendering of ellipses
- rendering of labels of TiledObject

desired TODO feature
- transforming TiledObjects into TCastleUserInterfaces (perhaps based on TCastleShape?)

Let me know, what you think.
Have a nice day,
Matthias