### PR TITLE
Save castle editor window state

### DIFF
--- a/tools/castle-editor/code/formproject.lfm
+++ b/tools/castle-editor/code/formproject.lfm
@@ -11,6 +11,8 @@ object ProjectForm: TProjectForm
   OnCloseQuery = FormCloseQuery
   OnCreate = FormCreate
   OnDestroy = FormDestroy
+  OnHide = FormHide
+  OnShow = FormShow
   Position = poMainFormCenter
   ShowInTaskBar = stAlways
   LCLVersion = '2.0.8.0'

--- a/tools/castle-editor/code/formproject.pas
+++ b/tools/castle-editor/code/formproject.pas
@@ -440,6 +440,7 @@ begin
   UserConfig.SetValue('ProjectForm_Left', Left);
   UserConfig.SetValue('ProjectForm_Top', Top);
   UserConfig.SetValue('ProjectForm_WindowState', WindowStateToStr(WindowState));
+  UserConfig.SetValue('ProjectForm_PageControlBottom.Height', PageControlBottom.Height);
   UserConfig.Save;
 end;
 
@@ -465,6 +466,7 @@ begin
   Left := UserConfig.GetValue('ProjectForm_Left', 546);
   Top := UserConfig.GetValue('ProjectForm_Top', 273);
   WindowState := StrToWindowState(UserConfig.GetValue('ProjectForm_WindowState', 'wsNormal'));
+  PageControlBottom.Height := UserConfig.GetValue('ProjectForm_PageControlBottom.Height', 224);
 end;
 
 procedure TProjectForm.ListOutputClick(Sender: TObject);

--- a/tools/castle-editor/code/formproject.pas
+++ b/tools/castle-editor/code/formproject.pas
@@ -461,15 +461,28 @@ procedure TProjectForm.FormShow(Sender: TObject);
     end;
   end;
 
+var
+  NewWidth, NewHeight, NewLeft, NewTop, NewControlHeight: Integer;
 begin
   if UserConfig.GetValue('ProjectForm_Saved', false) then
   begin
-    Width := UserConfig.GetInteger('ProjectForm_Width');
-    Height := UserConfig.GetInteger('ProjectForm_Height');
-    Left := UserConfig.GetInteger('ProjectForm_Left');
-    Top := UserConfig.GetInteger('ProjectForm_Top');
-    WindowState := StrToWindowState(UserConfig.GetStringNonEmpty('ProjectForm_WindowState'));
-    PageControlBottom.Height := UserConfig.GetInteger('ProjectForm_PageControlBottom.Height');
+    NewWidth := UserConfig.GetValue('ProjectForm_Width', -MaxInt);
+    NewHeight := UserConfig.GetValue('ProjectForm_Height', -MaxInt);
+    NewLeft := UserConfig.GetValue('ProjectForm_Left', -MaxInt);
+    NewTop := UserConfig.GetValue('ProjectForm_Top', -MaxInt);
+    NewControlHeight := UserConfig.GetValue('ProjectForm_PageControlBottom.Height', -MaxInt);
+    WindowState := StrToWindowState(UserConfig.GetValue('ProjectForm_WindowState', 'wsNormal'));
+    if (NewWidth + NewLeft <= Screen.Width + 32) and (NewWidth > 128) and
+       (NewHeight + NewTop <= Screen.Height + 32) and (NewHeight > 128) and
+       (NewControlHeight < NewHeight) and (NewControlHeight >= 0) and
+       (NewLeft > -32) and (NewTop > -32) then
+    begin
+      Width := NewWidth;
+      Height := NewHeight;
+      Left := NewLeft;
+      Top := NewTop;
+      PageControlBottom.Height := NewControlHeight;
+    end;
   end;
 end;
 
@@ -613,6 +626,8 @@ begin
 end;
 
 procedure TProjectForm.DesignExistenceChanged;
+var
+  NewPanelRightWidth, NewPanelLeftWidth: Integer;
 begin
   MenuItemSaveAsDesign.Enabled := Design <> nil;
   MenuItemSaveDesign.Enabled := Design <> nil;
@@ -629,8 +644,14 @@ begin
 
   if (Design <> nil) and UserConfig.GetValue('ProjectForm_DesignSaved', false) then
   begin
-    Design.PanelRight.Width := UserConfig.GetInteger('ProjectForm_Design.PanelRight.Width');
-    Design.PanelLeft.Width := UserConfig.GetInteger('ProjectForm_Design.PanelLeft.Width');
+    NewPanelRightWidth := UserConfig.GetValue('ProjectForm_Design.PanelRight.Width', -MaxInt);
+    NewPanelLeftWidth := UserConfig.GetValue('ProjectForm_Design.PanelLeft.Width', -MaxInt);
+    if (NewPanelRightWidth >= 0) and (NewPanelLeftWidth >= 0) and
+      (NewPanelRightWidth + NewPanelLeftWidth <= Width) then
+    begin
+      Design.PanelRight.Width := NewPanelRightWidth;
+      Design.PanelLeft.Width := NewPanelLeftWidth;
+    end;
   end;
 
   LabelNoDesign.Visible := Design = nil;

--- a/tools/castle-editor/code/formproject.pas
+++ b/tools/castle-editor/code/formproject.pas
@@ -433,6 +433,7 @@ procedure TProjectForm.FormHide(Sender: TObject);
   end;
 
 begin
+  UserConfig.SetValue('ProjectForm_Saved', true);
   UserConfig.SetValue('ProjectForm_Width', Width);
   UserConfig.SetValue('ProjectForm_Height', Height);
   UserConfig.SetValue('ProjectForm_Left', Left);
@@ -441,6 +442,7 @@ begin
   UserConfig.SetValue('ProjectForm_PageControlBottom.Height', PageControlBottom.Height);
   if Design <> nil then
   begin
+    UserConfig.SetValue('ProjectForm_DesignSaved', true);
     UserConfig.SetValue('ProjectForm_Design.PanelRight.Width', Design.PanelRight.Width);
     UserConfig.SetValue('ProjectForm_Design.PanelLeft.Width', Design.PanelLeft.Width);
   end;
@@ -460,12 +462,15 @@ procedure TProjectForm.FormShow(Sender: TObject);
   end;
 
 begin
-  Width := UserConfig.GetValue('ProjectForm_Width', 1142);
-  Height := UserConfig.GetValue('ProjectForm_Height', 632);
-  Left := UserConfig.GetValue('ProjectForm_Left', 546);
-  Top := UserConfig.GetValue('ProjectForm_Top', 273);
-  WindowState := StrToWindowState(UserConfig.GetValue('ProjectForm_WindowState', 'wsNormal'));
-  PageControlBottom.Height := UserConfig.GetValue('ProjectForm_PageControlBottom.Height', 224);
+  if UserConfig.GetValue('ProjectForm_Saved', false) then
+  begin
+    Width := UserConfig.GetInteger('ProjectForm_Width');
+    Height := UserConfig.GetInteger('ProjectForm_Height');
+    Left := UserConfig.GetInteger('ProjectForm_Left');
+    Top := UserConfig.GetInteger('ProjectForm_Top');
+    WindowState := StrToWindowState(UserConfig.GetStringNonEmpty('ProjectForm_WindowState'));
+    PageControlBottom.Height := UserConfig.GetInteger('ProjectForm_PageControlBottom.Height');
+  end;
 end;
 
 procedure TProjectForm.ListOutputClick(Sender: TObject);
@@ -577,6 +582,7 @@ begin
   begin
     UserConfig.SetValue('ProjectForm_Design.PanelRight.Width', Design.PanelRight.Width);
     UserConfig.SetValue('ProjectForm_Design.PanelLeft.Width', Design.PanelLeft.Width);
+    UserConfig.SetValue('ProjectForm_DesignSaved', true);
     UserConfig.Save;
     FreeAndNil(Design);
     DesignExistenceChanged;
@@ -621,10 +627,10 @@ begin
   UpdateUndo(nil);
   UpdateRenameItem(nil);
 
-  if Design <> nil then
+  if (Design <> nil) and UserConfig.GetValue('ProjectForm_DesignSaved', false) then
   begin
-    Design.PanelRight.Width := UserConfig.GetValue('ProjectForm_Design.PanelRight.Width', 326);
-    Design.PanelLeft.Width := UserConfig.GetValue('ProjectForm_Design.PanelLeft.Width', 266);
+    Design.PanelRight.Width := UserConfig.GetInteger('ProjectForm_Design.PanelRight.Width');
+    Design.PanelLeft.Width := UserConfig.GetInteger('ProjectForm_Design.PanelLeft.Width');
   end;
 
   LabelNoDesign.Visible := Design = nil;

--- a/tools/castle-editor/code/formproject.pas
+++ b/tools/castle-editor/code/formproject.pas
@@ -115,6 +115,8 @@ type
     procedure FormCloseQuery(Sender: TObject; var CanClose: boolean);
     procedure FormCreate(Sender: TObject);
     procedure FormDestroy(Sender: TObject);
+    procedure FormHide(Sender: TObject);
+    procedure FormShow(Sender: TObject);
     procedure ListOutputClick(Sender: TObject);
     procedure MenuItemRenameClick(Sender: TObject);
     procedure UpdateUndo(Sender: TObject);
@@ -211,7 +213,7 @@ implementation
 
 uses TypInfo, LCLType,
   CastleXMLUtils, CastleLCLUtils, CastleOpenDocument, CastleURIUtils,
-  CastleFilesUtils, CastleUtils, CastleVectors, CastleColors,
+  CastleFilesUtils, CastleUtils, CastleVectors, CastleColors, CastleConfig,
   CastleScene, CastleViewport, Castle2DSceneManager, CastleCameras,
   CastleTransform, CastleControls, CastleDownload, CastleApplicationProperties,
   CastleLog, CastleComponentSerialize, CastleSceneCore, CastleStringUtils,
@@ -411,10 +413,58 @@ end;
 
 procedure TProjectForm.FormDestroy(Sender: TObject);
 begin
+  FormHide(Self); //to save config properly
   ApplicationProperties.OnWarning.Remove(@WarningNotification);
   ApplicationDataOverride := '';
   FreeProcess;
   FreeAndNil(OutputList);
+end;
+
+procedure TProjectForm.FormHide(Sender: TObject);
+
+  function WindowStateToStr(const AWindowState: TWindowState): String;
+  begin
+    case AWindowState of
+      wsNormal: Result := 'wsNormal';
+      wsMinimized: Result := 'wsMinimized';
+      wsMaximized: Result := 'wsMaximized';
+      wsFullScreen: Result := 'wsFullScreen';
+    end;
+  end;
+
+begin
+  UserConfig.SetValue('ProjectForm_Width', Width);
+  UserConfig.SetValue('ProjectForm_Height', Height);
+  UserConfig.SetValue('ProjectForm_ClientWidth', ClientWidth);
+  UserConfig.SetValue('ProjectForm_ClientHeight', ClientHeight);
+  UserConfig.SetValue('ProjectForm_Left', Left);
+  UserConfig.SetValue('ProjectForm_Top', Top);
+  UserConfig.SetValue('ProjectForm_WindowState', WindowStateToStr(WindowState));
+  UserConfig.Save;
+end;
+
+procedure TProjectForm.FormShow(Sender: TObject);
+
+  function StrToWindowState(const AWindowStateStr: String): TWindowState;
+  begin
+    case AWindowStateStr of
+      'wsNormal': Result := wsNormal;
+      'wsMinimized': Result := wsMinimized;
+      'wsMaximized': Result := wsMaximized;
+      'wsFullScreen': Result := wsFullScreen;
+      else
+        Result := wsNormal;
+    end;
+  end;
+
+begin
+  Width := UserConfig.GetValue('ProjectForm_Width', 1142);
+  Height := UserConfig.GetValue('ProjectForm_Height', 632);
+  ClientWidth := UserConfig.GetValue('ProjectForm_ClientWidth', Width);
+  ClientHeight := UserConfig.GetValue('ProjectForm_ClientHeight', Height);
+  Left := UserConfig.GetValue('ProjectForm_Left', 546);
+  Top := UserConfig.GetValue('ProjectForm_Top', 273);
+  WindowState := StrToWindowState(UserConfig.GetValue('ProjectForm_WindowState', 'wsNormal'));
 end;
 
 procedure TProjectForm.ListOutputClick(Sender: TObject);

--- a/tools/castle-editor/code/formproject.pas
+++ b/tools/castle-editor/code/formproject.pas
@@ -441,6 +441,14 @@ begin
   UserConfig.SetValue('ProjectForm_Top', Top);
   UserConfig.SetValue('ProjectForm_WindowState', WindowStateToStr(WindowState));
   UserConfig.SetValue('ProjectForm_PageControlBottom.Height', PageControlBottom.Height);
+  UserConfig.SetValue('ProjectForm_PageControlBottom.ClientHeight', PageControlBottom.ClientHeight);
+  if Design <> nil then
+  begin
+    UserConfig.SetValue('ProjectForm_Design.PanelRight.Width', Design.PanelRight.Width);
+    UserConfig.SetValue('ProjectForm_Design.PanelLeft.Width', Design.PanelLeft.Width);
+    UserConfig.SetValue('ProjectForm_Design.PanelRight.ClientWidth', Design.PanelRight.ClientWidth);
+    UserConfig.SetValue('ProjectForm_Design.PanelLeft.ClientWidth', Design.PanelLeft.ClientWidth);
+  end;
   UserConfig.Save;
 end;
 
@@ -467,6 +475,7 @@ begin
   Top := UserConfig.GetValue('ProjectForm_Top', 273);
   WindowState := StrToWindowState(UserConfig.GetValue('ProjectForm_WindowState', 'wsNormal'));
   PageControlBottom.Height := UserConfig.GetValue('ProjectForm_PageControlBottom.Height', 224);
+  PageControlBottom.ClientHeight := UserConfig.GetValue('ProjectForm_PageControlBottom.ClientHeight', PageControlBottom.Height);
 end;
 
 procedure TProjectForm.ListOutputClick(Sender: TObject);
@@ -576,6 +585,11 @@ begin
 
   if ProposeSaveDesign then
   begin
+    UserConfig.SetValue('ProjectForm_Design.PanelRight.Width', Design.PanelRight.Width);
+    UserConfig.SetValue('ProjectForm_Design.PanelLeft.Width', Design.PanelLeft.Width);
+    UserConfig.SetValue('ProjectForm_Design.PanelRight.ClientWidth', Design.PanelRight.ClientWidth);
+    UserConfig.SetValue('ProjectForm_Design.PanelLeft.ClientWidth', Design.PanelLeft.ClientWidth);
+    UserConfig.Save;
     FreeAndNil(Design);
     DesignExistenceChanged;
   end;
@@ -618,6 +632,14 @@ begin
 
   UpdateUndo(nil);
   UpdateRenameItem(nil);
+
+  if Design <> nil then
+  begin
+    Design.PanelRight.Width := UserConfig.GetValue('ProjectForm_Design.PanelRight.Width', 326);
+    Design.PanelLeft.Width := UserConfig.GetValue('ProjectForm_Design.PanelLeft.Width', 266);
+    Design.PanelRight.ClientWidth := UserConfig.GetValue('ProjectForm_Design.PanelRight.ClientWidth', Design.PanelRight.Width);
+    Design.PanelLeft.ClientWidth := UserConfig.GetValue('ProjectForm_Design.PanelLeft.ClientWidth', Design.PanelLeft.Width);
+  end;
 
   LabelNoDesign.Visible := Design = nil;
 end;

--- a/tools/castle-editor/code/formproject.pas
+++ b/tools/castle-editor/code/formproject.pas
@@ -435,19 +435,14 @@ procedure TProjectForm.FormHide(Sender: TObject);
 begin
   UserConfig.SetValue('ProjectForm_Width', Width);
   UserConfig.SetValue('ProjectForm_Height', Height);
-  UserConfig.SetValue('ProjectForm_ClientWidth', ClientWidth);
-  UserConfig.SetValue('ProjectForm_ClientHeight', ClientHeight);
   UserConfig.SetValue('ProjectForm_Left', Left);
   UserConfig.SetValue('ProjectForm_Top', Top);
   UserConfig.SetValue('ProjectForm_WindowState', WindowStateToStr(WindowState));
   UserConfig.SetValue('ProjectForm_PageControlBottom.Height', PageControlBottom.Height);
-  UserConfig.SetValue('ProjectForm_PageControlBottom.ClientHeight', PageControlBottom.ClientHeight);
   if Design <> nil then
   begin
     UserConfig.SetValue('ProjectForm_Design.PanelRight.Width', Design.PanelRight.Width);
     UserConfig.SetValue('ProjectForm_Design.PanelLeft.Width', Design.PanelLeft.Width);
-    UserConfig.SetValue('ProjectForm_Design.PanelRight.ClientWidth', Design.PanelRight.ClientWidth);
-    UserConfig.SetValue('ProjectForm_Design.PanelLeft.ClientWidth', Design.PanelLeft.ClientWidth);
   end;
   UserConfig.Save;
 end;
@@ -458,24 +453,19 @@ procedure TProjectForm.FormShow(Sender: TObject);
   begin
     case AWindowStateStr of
       'wsNormal': Result := wsNormal;
-      'wsMinimized': Result := wsMinimized;
       'wsMaximized': Result := wsMaximized;
-      'wsFullScreen': Result := wsFullScreen;
       else
-        Result := wsNormal;
+        Result := wsNormal; //treat wsMinimized and any other value as wsNormal
     end;
   end;
 
 begin
   Width := UserConfig.GetValue('ProjectForm_Width', 1142);
   Height := UserConfig.GetValue('ProjectForm_Height', 632);
-  ClientWidth := UserConfig.GetValue('ProjectForm_ClientWidth', Width);
-  ClientHeight := UserConfig.GetValue('ProjectForm_ClientHeight', Height);
   Left := UserConfig.GetValue('ProjectForm_Left', 546);
   Top := UserConfig.GetValue('ProjectForm_Top', 273);
   WindowState := StrToWindowState(UserConfig.GetValue('ProjectForm_WindowState', 'wsNormal'));
   PageControlBottom.Height := UserConfig.GetValue('ProjectForm_PageControlBottom.Height', 224);
-  PageControlBottom.ClientHeight := UserConfig.GetValue('ProjectForm_PageControlBottom.ClientHeight', PageControlBottom.Height);
 end;
 
 procedure TProjectForm.ListOutputClick(Sender: TObject);
@@ -587,8 +577,6 @@ begin
   begin
     UserConfig.SetValue('ProjectForm_Design.PanelRight.Width', Design.PanelRight.Width);
     UserConfig.SetValue('ProjectForm_Design.PanelLeft.Width', Design.PanelLeft.Width);
-    UserConfig.SetValue('ProjectForm_Design.PanelRight.ClientWidth', Design.PanelRight.ClientWidth);
-    UserConfig.SetValue('ProjectForm_Design.PanelLeft.ClientWidth', Design.PanelLeft.ClientWidth);
     UserConfig.Save;
     FreeAndNil(Design);
     DesignExistenceChanged;
@@ -637,8 +625,6 @@ begin
   begin
     Design.PanelRight.Width := UserConfig.GetValue('ProjectForm_Design.PanelRight.Width', 326);
     Design.PanelLeft.Width := UserConfig.GetValue('ProjectForm_Design.PanelLeft.Width', 266);
-    Design.PanelRight.ClientWidth := UserConfig.GetValue('ProjectForm_Design.PanelRight.ClientWidth', Design.PanelRight.Width);
-    Design.PanelLeft.ClientWidth := UserConfig.GetValue('ProjectForm_Design.PanelLeft.ClientWidth', Design.PanelLeft.Width);
   end;
 
   LabelNoDesign.Visible := Design = nil;


### PR DESCRIPTION
Save Castle Editor window state (maximized/minimized, width/height) and some internal parameters (three splitters positions) in UserConfig and load them upon reloading of the Form.

Fixes the first part of https://github.com/castle-engine/castle-engine/issues/216