### PR TITLE
Fix ExtractURIPath() to work the same on all platforms

### DIFF
--- a/src/files/castleuriutils.pas
+++ b/src/files/castleuriutils.pas
@@ -1116,7 +1116,7 @@ end;
 
 function ExtractURIPath(const URL: string): string;
 begin
-  Result:= ExtractFilePath(URIDeleteAnchor(URL, true));
+  Result := ExtractFilePath(URIDeleteAnchor(URL, true));
 end;
 
 function URIIncludeSlash(const URL: String): String;

--- a/src/files/castleuriutils.pas
+++ b/src/files/castleuriutils.pas
@@ -1116,7 +1116,7 @@ end;
 
 function ExtractURIPath(const URL: string): string;
 begin
-  Result := ExtractFilePath(URL);
+  Result:= ExtractFilePath(URIDeleteAnchor(URL, true));
 end;
 
 function URIIncludeSlash(const URL: String): String;


### PR DESCRIPTION
Currently on linux it removes filename with anchors (I think works as expected) but on windows its stops on last : in anchor URL.

I used `URIDeleteAnchor` with `RecognizeEvenEscapedHash=true` because GTK2 open dialog sometimes returns paths with # changed to `% code`. So i think this is more secure.