### PR TITLE
Allows to set transform feedback varyings

### DIFF
--- a/src/images/opengl/castleglshaders.pas
+++ b/src/images/opengl/castleglshaders.pas
@@ -314,7 +314,7 @@ type
     procedure DetachAllShaders;
 
     { Specify values to record in transform feedback buffers.
-      This must be called before @link(Link) method }
+      This must be called before @link(Link) method. }
     procedure SetTransformFeedbackVaryings(const Varyings: array of PChar; const IsSingleBufferMode: Boolean = True);
 
     { Link the program, this should be done after attaching all shaders

--- a/src/images/opengl/castleglshaders.pas
+++ b/src/images/opengl/castleglshaders.pas
@@ -247,8 +247,6 @@ type
 
   TLocationCache = {$ifdef CASTLE_OBJFPC}specialize{$endif} TDictionary<String, TGLint>;
 
-  TGLSLTransformFeedbackVaryingArray = array of PChar;
-
   { Easily handle program in GLSL (OpenGL Shading Language). }
   TGLSLProgram = class
   private

--- a/src/images/opengl/castleglshaders.pas
+++ b/src/images/opengl/castleglshaders.pas
@@ -1808,6 +1808,8 @@ begin;
     end else
       raise EGLSLTransformFeedbackError.Create('Transform feedback not supported by your OpenGL version');
   end;
+  {$else}
+  raise EGLSLTransformFeedbackError.Create('Transform feedback not supported by OpenGLES 2.0');
   {$endif}
 end;
 


### PR DESCRIPTION
This PR allows to set transform feedback varyings before linking a GLSL program.
This will be ignored if OpenGL ES is detected, and raise EGLSLTransformFeedbackError if OpenGL version is < 3.0