### PR TITLE
ClearExceptions(false) on TCastleApplication.CastleEngineInitialize

### DIFF
--- a/src/window/castlewindow.pas
+++ b/src/window/castlewindow.pas
@@ -2963,15 +2963,15 @@ procedure TCastleWindowBase.OpenCore;
 
     {$IFDEF android}
     { Workaround an ARM64 Android-specific bug which manifests on some devices
-      where some "external" exception flags are "injected" into unrelated app
-      when it is launched/initialized
-      Reproduced on Xiaomi MI 9 SE
+      (reproduced on Xiaomi MI 9 SE) that creates a dangling EInvalidOp after calling Theme.Draw.
+      It doesn't seem to interfere with normal porgram workflow,
+      neither it causes any visible graphic glitches in the image rendered by Theme.Draw,
+      but causes ClearExceptions(true) to raise unrelated dangling exceptions,
+      which in turn makes e.g. CastleScript misbehave.
       Also seems to be reproduced outside of Castle Game Engine:
       https://forum.lazarus.freepascal.org/index.php/topic,42933.msg318965.html?#msg318965
-      These do not seem to interfere with normal porgram workflow,
-      but cause ClearExceptions(true) to raise unrelated dangling exceptions,
-      which in turn makes e.g. CastleScript misbehave.
-      It seems that clearing them once is perfectly enough. }
+      It seems that clearing them once per app run is perfectly enough,
+      all subsequent calls to Theme.Draw do not raise the exception. }
     ClearExceptions(false);
     {$ENDIF}
   end;

--- a/src/window/castlewindow.pas
+++ b/src/window/castlewindow.pas
@@ -2960,6 +2960,20 @@ procedure TCastleWindowBase.OpenCore;
 
     // just like TCastleWindowBase.DoRender
     if DoubleBuffer then SwapBuffers else glFlush;
+
+    {$IFDEF android}
+    { Workaround an ARM64 Android-specific bug which manifests on some devices
+      where some "external" exception flags are "injected" into unrelated app
+      when it is launched/initialized
+      Reproduced on Xiaomi MI 9 SE
+      Also seems to be reproduced outside of Castle Game Engine:
+      https://forum.lazarus.freepascal.org/index.php/topic,42933.msg318965.html?#msg318965
+      These do not seem to interfere with normal porgram workflow,
+      but cause ClearExceptions(true) to raise unrelated dangling exceptions,
+      which in turn makes e.g. CastleScript misbehave.
+      It seems that clearing them once is perfectly enough. }
+    ClearExceptions(false);
+    {$ENDIF}
   end;
 
   { Do the job of OpenCore, do not protect from possible exceptions raised inside. }
@@ -4664,20 +4678,6 @@ procedure TCastleApplication.CastleEngineInitialize;
 var
   TimeStart, TimeStart2: TCastleProfilerTime;
 begin
-  {$IFDEF android}
-  { Workaround an ARM64 Android-specific bug which manifests on some devices
-    where some "external" exception flags are "injected" into unrelated app
-    when it is launched/initialized
-    Reproduced on Xiaomi MI 9 SE
-    Also seems to be reproduced outside of Castle Game Engine:
-    https://forum.lazarus.freepascal.org/index.php/topic,42933.msg318965.html?#msg318965
-    These do not seem to interfere with normal porgram workflow,
-    but cause ClearExceptions(true) to raise unrelated dangling exceptions,
-    which in turn makes e.g. CastleScript misbehave.
-    It seems that clearing them once is perfectly enough. }
-  ClearExceptions(false);
-  {$ENDIF}
-
   if Initialized and not InitializedJavaActivity then
     WritelnLog('Android', 'Android Java activity was killed (and now got created from stratch), but native thread survived. Calling only OnInitializeJavaActivity.');
 

--- a/src/window/castlewindow.pas
+++ b/src/window/castlewindow.pas
@@ -4664,6 +4664,20 @@ procedure TCastleApplication.CastleEngineInitialize;
 var
   TimeStart, TimeStart2: TCastleProfilerTime;
 begin
+  {$IFDEF android}
+  { Workaround an ARM64 Android-specific bug which manifests on some devices
+    where some "external" exception flags are "injected" into unrelated app
+    when it is launched/initialized
+    Reproduced on Xiaomi MI 9 SE
+    Also seems to be reproduced outside of Castle Game Engine:
+    https://forum.lazarus.freepascal.org/index.php/topic,42933.msg318965.html?#msg318965
+    These do not seem to interfere with normal porgram workflow,
+    but cause ClearExceptions(true) to raise unrelated dangling exceptions,
+    which in turn makes e.g. CastleScript misbehave.
+    It seems that clearing them once is perfectly enough. }
+  ClearExceptions(false);
+  {$ENDIF}
+
   if Initialized and not InitializedJavaActivity then
     WritelnLog('Android', 'Android Java activity was killed (and now got created from stratch), but native thread survived. Calling only OnInitializeJavaActivity.');
 


### PR DESCRIPTION
This should fix Xiaomi Mi 9 SE ARM64 bug that injects dangling external exceptions into the app. Note that this bug might also be related to the NS bug in TCasScriptExpression.Execute - and the workaround applied may fix it too.

Note that it was NOT TESTED on the Xiaomi phone - it was made based on a workaround that worked on the device.