### PR TITLE
Undo for property editor

### DIFF
--- a/src/lcl/castlepropedits_color.inc
+++ b/src/lcl/castlepropedits_color.inc
@@ -57,7 +57,7 @@ begin
       if Color[3] = 0 then
         Color[3] := 1;
       ColorPersistent.Value := Color;
-      Modified(GetName);
+      Modified;
     end;
   finally FreeAndNil(Dialog) end;
 end;
@@ -82,7 +82,7 @@ var
 begin
   ColorPersistent := (GetObjectValue as TCastleColorPersistent);
   ColorPersistent.Value := HexToColor(NewValue);
-  Modified(GetName);
+  Modified;
 end;
 
 { TCastleColorRGBPropertyEditor ------------------------------------------------- }
@@ -121,7 +121,7 @@ begin
       RedGreenBlue(Dialog.Color, ColorByte.Data[0], ColorByte.Data[1], ColorByte.Data[2]);
       Color := Vector3(ColorByte);
       ColorPersistent.Value := Color;
-      Modified(GetName);
+      Modified;
     end;
   finally FreeAndNil(Dialog) end;
 end;
@@ -146,5 +146,5 @@ var
 begin
   ColorPersistent := (GetObjectValue as TCastleColorRGBPersistent);
   ColorPersistent.Value := HexToColorRGB(NewValue);
-  Modified(GetName);
+  Modified;
 end;

--- a/src/lcl/castlepropedits_color.inc
+++ b/src/lcl/castlepropedits_color.inc
@@ -57,6 +57,7 @@ begin
       if Color[3] = 0 then
         Color[3] := 1;
       ColorPersistent.Value := Color;
+      Modified(GetName);
     end;
   finally FreeAndNil(Dialog) end;
 end;
@@ -81,6 +82,7 @@ var
 begin
   ColorPersistent := (GetObjectValue as TCastleColorPersistent);
   ColorPersistent.Value := HexToColor(NewValue);
+  Modified(GetName);
 end;
 
 { TCastleColorRGBPropertyEditor ------------------------------------------------- }
@@ -119,6 +121,7 @@ begin
       RedGreenBlue(Dialog.Color, ColorByte.Data[0], ColorByte.Data[1], ColorByte.Data[2]);
       Color := Vector3(ColorByte);
       ColorPersistent.Value := Color;
+      Modified(GetName);
     end;
   finally FreeAndNil(Dialog) end;
 end;
@@ -143,4 +146,5 @@ var
 begin
   ColorPersistent := (GetObjectValue as TCastleColorRGBPersistent);
   ColorPersistent.Value := HexToColorRGB(NewValue);
+  Modified(GetName);
 end;

--- a/src/lcl/castlepropedits_exposetransforms.inc
+++ b/src/lcl/castlepropedits_exposetransforms.inc
@@ -91,7 +91,7 @@ begin
         SetPtrValue(SelectionList);
       finally FreeAndNil(SelectionList) end;
     end;
-    Modified(GetName);
+    Modified;
   finally FreeAndNil(D) end;
 end;
 

--- a/src/lcl/castlepropedits_exposetransforms.inc
+++ b/src/lcl/castlepropedits_exposetransforms.inc
@@ -91,6 +91,7 @@ begin
         SetPtrValue(SelectionList);
       finally FreeAndNil(SelectionList) end;
     end;
+    Modified(GetName);
   finally FreeAndNil(D) end;
 end;
 

--- a/src/lcl/castlepropedits_vector.inc
+++ b/src/lcl/castlepropedits_vector.inc
@@ -56,7 +56,7 @@ var
 begin
   VectorPersistent := (GetObjectValue as TCastleVector2Persistent);
   VectorPersistent.Value := Vector2FromStr(NewValue);
-  Modified(GetName);
+  Modified;
 end;
 
 { TCastleVector3PropertyEditor ------------------------------------------------- }
@@ -138,5 +138,5 @@ var
 begin
   VectorPersistent := (GetObjectValue as TCastleVector4Persistent);
   VectorPersistent.Value := Vector4FromStr(NewValue);
-  Modified(GetName);
+  Modified;
 end;

--- a/src/lcl/castlepropedits_vector.inc
+++ b/src/lcl/castlepropedits_vector.inc
@@ -56,6 +56,7 @@ var
 begin
   VectorPersistent := (GetObjectValue as TCastleVector2Persistent);
   VectorPersistent.Value := Vector2FromStr(NewValue);
+  Modified(GetName);
 end;
 
 { TCastleVector3PropertyEditor ------------------------------------------------- }
@@ -137,4 +138,5 @@ var
 begin
   VectorPersistent := (GetObjectValue as TCastleVector4Persistent);
   VectorPersistent.Value := Vector4FromStr(NewValue);
+  Modified(GetName);
 end;

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -2029,13 +2029,14 @@ begin
 end;
 
 procedure TDesignFrame.PropertyEditorModified(Sender: TObject);
-var
-  Sel: TComponent;
 begin
   if Sender is TPropertyEditor then
   begin
     if TPropertyEditor(Sender).PropCount = 1 then
       RecordUndo((TPropertyEditor(Sender).GetComponent(0) as TComponent).Name + ': change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
+    else
+    if TPropertyEditor(Sender).PropCount > 1 then
+      RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue + ' in multiple components', ucHigh)
     else
       RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
   end else

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -278,6 +278,7 @@ type
       var aShow: Boolean);
     procedure MarkModified;
     procedure PropertyGridModified(Sender: TObject);
+    procedure PropertyEditorModified(Sender: TObject);
     { Is Child selectable and visible in hierarchy. }
     class function Selectable(const Child: TComponent): Boolean; static;
     { Is Child deletable by user (this implies it is also selectable). }
@@ -1178,6 +1179,7 @@ begin
 
   // Allows object inspectors to find matching components, e.g. when editing Viewport.Items.MainScene
   PropertyEditorHook.LookupRoot := DesignOwner;
+  PropertyEditorHook.AddHandlerModified(@PropertyEditorModified);
 
   UpdateDesign;
   OnUpdateFormCaption(Self);
@@ -2024,6 +2026,24 @@ begin
   end;
 
   MarkModified;
+end;
+
+procedure TDesignFrame.PropertyEditorModified(Sender: TObject);
+var
+  Sel: TComponent;
+begin
+  Sel := SelectedComponent;
+  if Sender is TPropertyEditor then
+  begin
+    if Sel <> nil then
+      RecordUndo(Sel.Name + ': change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
+    else
+      RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucLow)
+  end else
+    if Sel <> nil then
+      RecordUndo(Sel.Name + ': modify property', ucLow)
+    else
+      RecordUndo('Modify property', ucLow)
 end;
 
 procedure TDesignFrame.RecordUndo(const UndoComment: String;

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -2038,7 +2038,7 @@ begin
     if TPropertyEditor(Sender).PropCount > 1 then
       RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue + ' in multiple components', ucHigh)
     else
-      RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
+      RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh);
   end else
     raise EInternalError.Create('PropertyEditorModified can only be called with TPropertyEditor as a Sender.');
 end;

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -2032,11 +2032,10 @@ procedure TDesignFrame.PropertyEditorModified(Sender: TObject);
 var
   Sel: TComponent;
 begin
-  Sel := SelectedComponent;
   if Sender is TPropertyEditor then
   begin
-    if Sel <> nil then
-      RecordUndo(Sel.Name + ': change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
+    if TPropertyEditor(Sender).PropCount = 1 then
+      RecordUndo((TPropertyEditor(Sender).GetComponent(0) as TComponent).Name + ': change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
     else
       RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
   end else

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -2040,10 +2040,7 @@ begin
     else
       RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
   end else
-    if Sel <> nil then
-      RecordUndo(Sel.Name + ': modify property', ucLow)
-    else
-      RecordUndo('Modify property', ucLow)
+    raise EInternalError.Create('PropertyEditorModified can only be called with TPropertyEditor as a Sender.');
 end;
 
 procedure TDesignFrame.RecordUndo(const UndoComment: String;

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -1966,10 +1966,10 @@ const
 var
   ToValue: String;
 begin
-  if CharsPos(UnreadableChars, ModifiedValue) = 0 then
-    ToValue := ''
+  if (Length(ModifiedValue) < 24) and (CharsPos(UnreadableChars, ModifiedValue) = 0) then
+    ToValue := ' to ' + ModifiedValue
   else
-    ToValue := ' to ' + ModifiedValue;
+    ToValue := '';
 
   if SelectedCount = 1 then // By this we guarantee that Sel <> nil
     Result := 'Change ' + Sel.Name + '.' + ModifiedProperty + ToValue

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -1981,7 +1981,6 @@ procedure TDesignFrame.PropertyGridModified(Sender: TObject);
 var
   Sel: TComponent;
   UI: TCastleUserInterface;
-  SenderRowName, SenderRowValue, UndoDescription: String;
 begin
   { Workaround possible ControlsTree.Selected = nil when the user deselects
     the currently edited component by clicking somewhere else.
@@ -2030,7 +2029,13 @@ begin
     end else
       { Sender is nil when PropertyGridModified is called
         by ModifiedOutsideObjectInspector. }
-      RecordUndo(UndoDescription, ucLow);
+      if Sel <> nil then
+        RecordUndo('Change ' + Sel.Name, ucLow)
+      else
+      if ControlsTree.SelectionCount > 1 then
+        RecordUndo('Change multiple components', ucLow)
+      else
+        RecordUndo('', ucLow)
   end;
 
   MarkModified;

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -1966,8 +1966,11 @@ const
 var
   ToValue: String;
 begin
-  //if CharsPos(UnreadableChars, SenderRowValue) = 0 then
-  ToValue := ' to ' + ModifiedValue;
+  if CharsPos(UnreadableChars, ModifiedValue) = 0 then
+    ToValue := ''
+  else
+    ToValue := ' to ' + ModifiedValue;
+
   if SelectedCount = 1 then // By this we guarantee that Sel <> nil
     Result := 'Change ' + Sel.Name + '.' + ModifiedProperty + ToValue
   else

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -2038,7 +2038,7 @@ begin
     if Sel <> nil then
       RecordUndo(Sel.Name + ': change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
     else
-      RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucLow)
+      RecordUndo('Change ' + TPropertyEditor(Sender).GetName + ' to ' + TPropertyEditor(Sender).GetValue, ucHigh)
   end else
     if Sel <> nil then
       RecordUndo(Sel.Name + ': modify property', ucLow)

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -279,6 +279,18 @@ type
     procedure MarkModified;
     function UndoMessageModified(const Sel: TComponent;
       const ModifiedProperty, ModifiedValue: String; const SelectedCount: Integer): String;
+    { PropertyGridModified and PropertyEditorModified are called when
+      something changes in the design.
+      PropertyGridModified and PropertyEditorModified are both called when
+      something changes within Object Inspector basic features
+      (such as editing string, boolean, enum or numeric values)
+      In this case PropertyEditorModified usually comes first.
+      In case something changed outside of Object inspector (e.g. drag-and-drops,
+      rename components in treeview, add components, etc.)
+      only PropertyGridModified is called
+      In case a custom dialog is used to change a value
+      (e.g. a Color picker, TStrings editor, Open File dialogue, etc.)
+      then only PropertyEditorModified is called. }
     procedure PropertyGridModified(Sender: TObject);
     procedure PropertyEditorModified(Sender: TObject);
     { Is Child selectable and visible in hierarchy. }


### PR DESCRIPTION
Record Undo for TPropertyEditor values changes, including changing of the values through dialogue windows.

Fixes https://trello.com/c/oQu2Od2d/56-undo-in-editor-changing-colors-or-maybe-all-vectors-is-not-recorded-as-undo-item
Fixes https://trello.com/c/alED6w0E/123-minor-bug-changing-url-of-castleimagecontrol-doesnt-record-undo