### PR TITLE
Log a warning in case TCastleConfig.Save is called before config file URL is known

### DIFF
--- a/src/files/castlexmlconfig.pas
+++ b/src/files/castlexmlconfig.pas
@@ -1125,7 +1125,9 @@ begin
   FOnSave.ExecuteAll(Self);
   Flush; // use ancestor method to save
   if URL <> '' then
-    WritelnLog('Config', 'Saving configuration to "%s"', [URL]);
+    WriteLnLog('Config', 'Saving configuration to "%s"', [URL])
+  else
+    WriteLnWarning('Config', 'Configuration was not saved, because no URL is specified. Call TCastleConfig.Load before calling TCastleConfig.Save.');
 end;
 
 procedure TCastleConfig.Save(const Stream: TStream);


### PR DESCRIPTION
Makes a clear warning in case TCastleConfig.Save is called before TCastleConfig.Load and thus nothing was saved.

Fixes https://trello.com/c/QSqKyIwu/120-if-userconfigload-is-not-called-userconfigsave-doesnt-save-anything