### PR TITLE
Navigation for 2D (TCastle2DNavigation) 

### DIFF
--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -3769,8 +3769,10 @@ begin
       begin
         Size := GoodModelBox.AverageSize;
         Translation := Translation - Vector3(
-          DragMoveSpeed * Size * (Event.OldPosition[0] - Event.Position[0]) / (2*MoveDivConst),
-          DragMoveSpeed * Size * (Event.OldPosition[1] - Event.Position[1]) / (2*MoveDivConst),
+          DragMoveSpeed * Size * (Event.OldPosition[0] - Event.Position[0])
+          / (2 * MoveDivConst),
+          DragMoveSpeed * Size * (Event.OldPosition[1] - Event.Position[1])
+          / (2 * MoveDivConst),
           0);
       end;
     Result := ExclusiveEvents;

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -1387,23 +1387,11 @@ type
   public
     constructor Create(AOwner: TComponent); override;
 
-    { Drag with this mouse button to move the model. }
-    property MouseButtonMove: TCastleMouseButton
-      read FMouseButtonMove write FMouseButtonMove default buttonRight;
-    { Drag with this mouse button to zoom the model (look closer / further). }
-    property MouseButtonZoom: TCastleMouseButton
-      read FMouseButtonZoom write FMouseButtonZoom default buttonMiddle;
-
-    { Optional movement algorithm, moves the camera exactly as many units as
-      the mouse position has changed especially useful in 2D in the editor. }
-    property ExactMovement: Boolean read FExactMovement write FExactMovement default true;
+    property MouseButtonMove default buttonRight;
+    property MouseButtonZoom default buttonMiddle;
+    property ExactMovement default true;
   published
-    { Enable rotating the camera around the model by user input.
-      When @false, no keys / mouse dragging / 3D mouse etc. can cause a rotation.
-
-      Note that this doesn't prevent from rotating by code, e.g. by setting
-      @link(Rotations) property or calling @link(SetView). }
-    property RotationEnabled: Boolean read FRotationEnabled write FRotationEnabled default false;
+    property RotationEnabled default false;
   end;
 
 

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -1378,6 +1378,26 @@ type
       read FRotationAccelerate write SetRotationAccelerate default true;
   end;
 
+  TCastle2DNavigation = class (TCastleExamineNavigation)
+  public
+    constructor Create(AOwner: TComponent); override;
+
+    { Drag with this mouse button to move the model. }
+    property MouseButtonMove: TCastleMouseButton
+      read FMouseButtonMove write FMouseButtonMove default buttonRight;
+    { Drag with this mouse button to zoom the model (look closer / further). }
+    property MouseButtonZoom: TCastleMouseButton
+      read FMouseButtonZoom write FMouseButtonZoom default buttonMiddle;
+  published
+    { Enable rotating the camera around the model by user input.
+      When @false, no keys / mouse dragging / 3D mouse etc. can cause a rotation.
+
+      Note that this doesn't prevent from rotating by code, e.g. by setting
+      @link(Rotations) property or calling @link(SetView). }
+    property RotationEnabled: Boolean read FRotationEnabled write FRotationEnabled default false;
+  end;
+
+
   TCastleWalkNavigation = class;
 
   { What mouse dragging does in TCastleWalkNavigation. }
@@ -2199,6 +2219,17 @@ begin
   {$ifdef CASTLE_REGISTER_ALL_COMPONENTS_IN_LAZARUS}
   RegisterComponents('Castle', [TCastleExamineNavigation, TCastleWalkNavigation]);
   {$endif}
+end;
+
+{ TCastle2DNavigation -------------------------------------------------------- }
+
+constructor TCastle2DNavigation.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+
+  RotationEnabled := false;
+  MouseButtonMove := buttonRight;
+  MouseButtonZoom := buttonMiddle;
 end;
 
 { TCastlePerspective --------------------------------------------------------- }
@@ -5619,5 +5650,6 @@ end;
 
 initialization
   RegisterSerializableComponent(TCastleExamineNavigation, 'Examine Navigation');
+  RegisterSerializableComponent(TCastle2DNavigation, '2D Navigation');
   RegisterSerializableComponent(TCastleWalkNavigation, 'Walk Navigation');
 end.

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -1125,6 +1125,7 @@ type
       FRotationEnabled: Boolean;
       FZoomEnabled: Boolean;
       FDragMoveSpeed, FKeysMoveSpeed: Single;
+      FExactMovement: Boolean;
       { Speed of rotations. Always zero when RotationAccelerate = false.
 
         This could be implemented as a quaternion,
@@ -1248,6 +1249,10 @@ type
 
     { How fast user moves the scene by pressing keys. }
     property KeysMoveSpeed: Single read FKeysMoveSpeed write FKeysMoveSpeed default 1.0;
+
+    { Optional movement algorithm, moves the camera exactly as many units as
+      the mouse position has changed especially useful in 2D in the editor. }
+    property ExactMovement: Boolean read FExactMovement write FExactMovement default false;
 
     property MoveAmount: TVector3 read GetTranslation write SetTranslation;
       deprecated 'use Translation';
@@ -1388,6 +1393,10 @@ type
     { Drag with this mouse button to zoom the model (look closer / further). }
     property MouseButtonZoom: TCastleMouseButton
       read FMouseButtonZoom write FMouseButtonZoom default buttonMiddle;
+
+    { Optional movement algorithm, moves the camera exactly as many units as
+      the mouse position has changed especially useful in 2D in the editor. }
+    property ExactMovement: Boolean read FExactMovement write FExactMovement default true;
   published
     { Enable rotating the camera around the model by user input.
       When @false, no keys / mouse dragging / 3D mouse etc. can cause a rotation.
@@ -2230,6 +2239,7 @@ begin
   RotationEnabled := false;
   MouseButtonMove := buttonRight;
   MouseButtonZoom := buttonMiddle;
+  FExactMovement := true;
 end;
 
 { TCastlePerspective --------------------------------------------------------- }
@@ -3762,7 +3772,7 @@ begin
      (not GoodModelBox.IsEmpty) and
      (MouseButtonMove = DraggingMouseButton) then
   begin
-    if Camera.ProjectionType = ptOrthographic then
+    if (Camera.ProjectionType = ptOrthographic) and ExactMovement then
       Translation := Translation - Vector3(Event.OldPosition[0] - Event.Position[0],
       Event.OldPosition[1] - Event.Position[1], 0) * GetScaleFactor
     else

--- a/src/3d/castlecameras.pas
+++ b/src/3d/castlecameras.pas
@@ -3762,11 +3762,17 @@ begin
      (not GoodModelBox.IsEmpty) and
      (MouseButtonMove = DraggingMouseButton) then
   begin
-    Size := GoodModelBox.AverageSize;
-    Translation := Translation - Vector3(
-      DragMoveSpeed * Size * (Event.OldPosition[0] - Event.Position[0]) / (2*MoveDivConst),
-      DragMoveSpeed * Size * (Event.OldPosition[1] - Event.Position[1]) / (2*MoveDivConst),
-      0);
+    if Camera.ProjectionType = ptOrthographic then
+      Translation := Translation - Vector3(Event.OldPosition[0] - Event.Position[0],
+      Event.OldPosition[1] - Event.Position[1], 0) * GetScaleFactor
+    else
+      begin
+        Size := GoodModelBox.AverageSize;
+        Translation := Translation - Vector3(
+          DragMoveSpeed * Size * (Event.OldPosition[0] - Event.Position[0]) / (2*MoveDivConst),
+          DragMoveSpeed * Size * (Event.OldPosition[1] - Event.Position[1]) / (2*MoveDivConst),
+          0);
+      end;
     Result := ExclusiveEvents;
   end;
 end;

--- a/tools/castle-editor/code/framedesign.lfm
+++ b/tools/castle-editor/code/framedesign.lfm
@@ -1528,6 +1528,10 @@ object DesignFrame: TDesignFrame
       Caption = 'Set Navigation to None (Viewport.Navigation := nil)'
       OnClick = MenuViewportNavigationNoneClick
     end
+    object MenuViewportNavigation2D: TMenuItem
+      Caption = 'Set Navigation to 2D (Viewport.Navigation := TCastle2DNavigation.Create)'
+      OnClick = MenuViewportNavigation2DClick
+    end
     object MenuViewportNavigationExamine: TMenuItem
       Caption = 'Set Navigation to Examine (Viewport.Navigation := TCastleExamineNavigation.Create)'
       OnClick = MenuViewportNavigationExamineClick

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -48,6 +48,7 @@ type
     LabelEventsInfo: TLabel;
     LabelSizeInfo: TLabel;
     LabelSelectedViewport: TLabel;
+    MenuViewportNavigation2D: TMenuItem;
     MenuTreeViewItemRename: TMenuItem;
     MenuTreeViewItemAddTransform: TMenuItem;
     MenuTreeViewItemAddUserInterface: TMenuItem;
@@ -137,6 +138,7 @@ type
     procedure MenuItemViewportSort2DClick(Sender: TObject);
     procedure MenuTreeViewItemPasteClick(Sender: TObject);
     procedure MenuTreeViewPopup(Sender: TObject);
+    procedure MenuViewportNavigation2DClick(Sender: TObject);
     procedure MenuViewportNavigationExamineClick(Sender: TObject);
     procedure MenuViewportNavigationFlyClick(Sender: TObject);
     procedure MenuViewportNavigationNoneClick(Sender: TObject);
@@ -2826,6 +2828,11 @@ begin
     MenuTreeViewItemAddTransform.SetEnabledVisible(false);
   end;
   MenuTreeView.PopupComponent := ControlsTree; // I'm not sure what it means, something like menu owner?
+end;
+
+procedure TDesignFrame.MenuViewportNavigation2DClick(Sender: TObject);
+begin
+  ChangeViewportNavigation(TCastle2DNavigation.Create(DesignOwner));
 end;
 
 procedure TDesignFrame.MenuTreeViewItemDuplicateClick(Sender: TObject);


### PR DESCRIPTION
This PR introduces a new type of navigation adapted to 2D games, and in particular, facilitating work in the editor on 2D games. Just press the right mouse button to easily move the content of the viewport. It's base on `TCastleExamineNavigation`. 

The way the camera works has been changed when `Camera.ProjectionType` is `ptOrthographic` (as we agreed in the interview). But maybe better solution is add property like `PixelPerfectMovement`, to not change the default behaviour of `TCastleExamineNavigation` which can also be useful or can break CGE users games. 