### PR TITLE
Fixed Kraft crash when rigid body touches sensor (trigger) and sensor was created before rigid body

### DIFF
--- a/src/physics/kraft/kraft.pas
+++ b/src/physics/kraft/kraft.pas
@@ -31099,7 +31099,8 @@ begin
      // Skip contacts that have been added to an island already and we can safely skip contacts if these didn't actually collide with anything,
      // and skip also sensors
      if ((ContactPair^.Flags*[kcfColliding,kcfInIsland])=[kcfColliding]) and
-        not ((ksfSensor in ContactPair^.Shapes[0].fFlags) or
+        not ((krbfSensor in ContactPairEdge^.OtherRigidBody.fFlags) or
+             (ksfSensor in ContactPair^.Shapes[0].fFlags) or
              (ksfSensor in ContactPair^.Shapes[1].fFlags)) then begin
       ContactPair^.Flags:=ContactPair^.Flags+[kcfInIsland];
       Island.AddContactPair(ContactPair);


### PR DESCRIPTION
This PR fix crash in Kraft sensor (our trigger) when you create `TRigidBody` after trigger (`TRigidBody` with `Trigger = True`) and make them collide.

Can be tested with https://github.com/and3md/cge-platformer-demo but you need my [platformer_fixes CGE branch](https://github.com/and3md/castle-engine/tree/platformer_fixes) to compile.