### PR TITLE
Load TMX files (Tiled Maps) by TStream/BaseUrl pair

### DIFF
--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -315,8 +315,11 @@ type
     FTilesets: TTilesetList;
     FProperties: TPropertyList;
     FLayers: TLayerList;
+    { Load TMX file from stream. }
     procedure LoadTMXFile(const Stream: TStream; const BaseUrl_: String); overload;
+    { Load TMX file by URL. }
     procedure LoadTMXFile(const AURL: String); overload;
+    { Load TMX file internally from XMLDocument instance. }
     procedure LoadTMXFileInternal(var Doc: TXMLDocument);
   public
     property Layers: TLayerList read FLayers;
@@ -1069,13 +1072,11 @@ end;
 
 procedure TTiledMap.LoadTMXFileInternal(var Doc: TXMLDocument);
 var
-  //Doc: TXMLDocument;
   TmpStr: string;
   I: TXMLElementIterator;
   NewLayer: TLayer;
   NewTileset: TTileset;
 begin
-  //Doc := URLReadXML(AURL);
   try
     // Parse map attributes
     Check(LowerCase(Doc.DocumentElement.TagName) = 'map',

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -19,6 +19,9 @@
 
 type
   { Loading and manipulating "Tiled" map files (http://mapeditor.org). }
+
+  { TTiledMap }
+
   TTiledMap = class
   public
     type
@@ -312,7 +315,9 @@ type
     FTilesets: TTilesetList;
     FProperties: TPropertyList;
     FLayers: TLayerList;
-    procedure LoadTMXFile(const AURL: string);
+    procedure LoadTMXFile(const Stream: TStream; const BaseUrl_: String); overload;
+    procedure LoadTMXFile(const AURL: String); overload;
+    procedure LoadTMXFileInternal(var Doc: TXMLDocument);
   public
     property Layers: TLayerList read FLayers;
     { Map orientation. }
@@ -345,7 +350,8 @@ type
     property RenderOrder: TMapRenderOrder read FRenderOrder;
     { Constructor.
       @param(AURL URL to Tiled (TMX) file.) }
-    constructor Create(const AURL: string);
+    constructor Create(const Stream: TStream; const BaseUrl_: String); overload;
+    constructor Create(const AURL: string); overload;
     destructor Destroy; override;
 
     { Is the given tile number valid.
@@ -1045,15 +1051,31 @@ end;
 
 { TTiledMap ------------------------------------------------------------------ }
 
-procedure TTiledMap.LoadTMXFile(const AURL: string);
+procedure TTiledMap.LoadTMXFile(const Stream: TStream; const BaseUrl_: String);
 var
   Doc: TXMLDocument;
+begin
+  ReadXMLFile(Doc, Stream, BaseUrl_);
+  LoadTMXFileInternal(Doc);
+end;
+
+procedure TTiledMap.LoadTMXFile(const AURL: String);
+var
+  Doc: TXMLDocument;
+begin
+  Doc := URLReadXML(AURL);
+  LoadTMXFileInternal(Doc);
+end;
+
+procedure TTiledMap.LoadTMXFileInternal(var Doc: TXMLDocument);
+var
+  //Doc: TXMLDocument;
   TmpStr: string;
   I: TXMLElementIterator;
   NewLayer: TLayer;
   NewTileset: TTileset;
 begin
-  Doc := URLReadXML(AURL);
+  //Doc := URLReadXML(AURL);
   try
     // Parse map attributes
     Check(LowerCase(Doc.DocumentElement.TagName) = 'map',
@@ -1135,6 +1157,17 @@ begin
   finally
     FreeAndNil(Doc);
   end;
+end;
+
+constructor TTiledMap.Create(const Stream: TStream; const BaseUrl_: String);
+begin
+  FTilesets := TTilesetList.Create;
+  FProperties := TPropertyList.Create;
+  FLayers := TLayerList.Create(true);
+  BaseUrl := BaseUrl_;
+
+  //Load TMX
+  LoadTMXFile(Stream, BaseUrl_);
 end;
 
 constructor TTiledMap.Create(const AURL: string);

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -1162,6 +1162,8 @@ end;
 
 constructor TTiledMap.Create(const Stream: TStream; const BaseUrl_: String);
 begin
+  inherited Create;
+
   FTilesets := TTilesetList.Create;
   FProperties := TPropertyList.Create;
   FLayers := TLayerList.Create(true);
@@ -1172,14 +1174,20 @@ begin
 end;
 
 constructor TTiledMap.Create(const AURL: string);
+var
+  StreamOptions: TStreamOptions;
+  Gzipped: boolean;
+  Stream: TStream;
 begin
-  FTilesets := TTilesetList.Create;
-  FProperties := TPropertyList.Create;
-  FLayers := TLayerList.Create(true);
-  BaseUrl := AURL;
-
-  //Load TMX
-  LoadTMXFile(AURL);
+  // calculate Stream from AURL, automatically gunzip if extension says it
+  StreamOptions := [];
+  URIMimeType(AURL, Gzipped);
+  if Gzipped then
+    Include(StreamOptions, soGzip);
+  Stream := Download(AURL, StreamOptions);
+  try
+    Create(Stream, AURL);
+  finally FreeAndNil(Stream) end;
 end;
 
 destructor TTiledMap.Destroy;

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -1,5 +1,5 @@
 {
-  Copyright 2015-2018 Tomasz Wojtyś, Michalis Kamburelis.
+  Copyright 2015-2021 Tomasz Wojtyś, Michalis Kamburelis.
 
   This file is part of "Castle Game Engine".
 
@@ -19,9 +19,6 @@
 
 type
   { Loading and manipulating "Tiled" map files (http://mapeditor.org). }
-
-  { TTiledMap }
-
   TTiledMap = class
   public
     type
@@ -316,11 +313,11 @@ type
     FProperties: TPropertyList;
     FLayers: TLayerList;
     { Load TMX file from stream. }
-    procedure LoadTMXFile(const Stream: TStream; const BaseUrl_: String); overload;
+    procedure LoadTMXFile(const Stream: TStream; const ABaseUrl: String); overload;
     { Load TMX file by URL. }
     procedure LoadTMXFile(const AURL: String); overload;
     { Load TMX file internally from XMLDocument instance. }
-    procedure LoadTMXFileInternal(var Doc: TXMLDocument);
+    procedure LoadTMXFileInternal(const Doc: TXMLDocument);
   public
     property Layers: TLayerList read FLayers;
     { Map orientation. }
@@ -353,7 +350,7 @@ type
     property RenderOrder: TMapRenderOrder read FRenderOrder;
     { Constructor.
       @param(AURL URL to Tiled (TMX) file.) }
-    constructor Create(const Stream: TStream; const BaseUrl_: String); overload;
+    constructor Create(const Stream: TStream; const ABaseUrl: String); overload;
     constructor Create(const AURL: string); overload;
     destructor Destroy; override;
 
@@ -1054,12 +1051,14 @@ end;
 
 { TTiledMap ------------------------------------------------------------------ }
 
-procedure TTiledMap.LoadTMXFile(const Stream: TStream; const BaseUrl_: String);
+procedure TTiledMap.LoadTMXFile(const Stream: TStream; const ABaseUrl: String);
 var
   Doc: TXMLDocument;
 begin
-  ReadXMLFile(Doc, Stream, BaseUrl_);
-  LoadTMXFileInternal(Doc);
+  ReadXMLFile(Doc, Stream, ABaseUrl);
+  try
+    LoadTMXFileInternal(Doc);
+  finally FreeAndNil(Doc) end;
 end;
 
 procedure TTiledMap.LoadTMXFile(const AURL: String);
@@ -1067,110 +1066,108 @@ var
   Doc: TXMLDocument;
 begin
   Doc := URLReadXML(AURL);
-  LoadTMXFileInternal(Doc);
+  try
+    LoadTMXFileInternal(Doc);
+  finally FreeAndNil(Doc) end;
 end;
 
-procedure TTiledMap.LoadTMXFileInternal(var Doc: TXMLDocument);
+procedure TTiledMap.LoadTMXFileInternal(const Doc: TXMLDocument);
 var
   TmpStr: string;
   I: TXMLElementIterator;
   NewLayer: TLayer;
   NewTileset: TTileset;
 begin
+  // Parse map attributes
+  Check(LowerCase(Doc.DocumentElement.TagName) = 'map',
+    'Root element of TMX file must be <map>');
+  if Doc.DocumentElement.AttributeString('version', TmpStr) then
+    FVersion := TmpStr;
+  if Doc.DocumentElement.AttributeString('orientation', TmpStr) then
+    case TmpStr of
+      'orthogonal': FOrientation := moOrthogonal;
+      'isometric': FOrientation := moIsometric;
+      'staggered': FOrientation := moIsometricStaggered;
+      'hexagonal': FOrientation := moHexagonal;
+    end;
+  if Doc.DocumentElement.AttributeString('width', TmpStr) then
+    FWidth := StrToInt(TmpStr);
+  if Doc.DocumentElement.AttributeString('height', TmpStr) then
+    FHeight := StrToInt(TmpStr);
+  if Doc.DocumentElement.AttributeString('tilewidth', TmpStr) then
+    FTileWidth := StrToInt(TmpStr);
+  if Doc.DocumentElement.AttributeString('tileheight', TmpStr) then
+    FTileHeight := StrToInt(TmpStr);
+  if Doc.DocumentElement.AttributeString('hexsidelength', TmpStr) then
+    FHexSideLength := StrToInt(TmpStr);
+  if Doc.DocumentElement.AttributeString('staggeraxis', TmpStr) then
+    case TmpStr of
+      'x': FStaggerAxis := saX;
+      'y': FStaggerAxis := saY;
+      else WritelnWarning('Invalid staggeraxis "%s" in Tiled map file (TMX)', [TmpStr]);
+    end;
+  if Doc.DocumentElement.AttributeString('staggerindex', TmpStr) then
+    case TmpStr of
+      'odd': FStaggerIndex := siOdd;
+      'even': FStaggerIndex := siEven;
+      else WritelnWarning('Invalid staggerindex "%s" in Tiled map file (TMX)', [TmpStr]);
+    end;
+  if Doc.DocumentElement.AttributeString('backgroundcolor', TmpStr) then
+    FBackgroundColor := TiledToColor(TmpStr);
+  if Doc.DocumentElement.AttributeString('renderorder', TmpStr) then
+    case TmpStr of
+      'right-down': FRenderOrder := mroRightDown;
+      'right-up': FRenderOrder := mroRightUp;
+      'left-down': FRenderOrder := mroLeftDown;
+      'left-up': FRenderOrder := mroLeftUp;
+    end;
+  // Parse map children
+  I := TXMLElementIterator.Create(Doc.DocumentElement);
   try
-    // Parse map attributes
-    Check(LowerCase(Doc.DocumentElement.TagName) = 'map',
-      'Root element of TMX file must be <map>');
-    if Doc.DocumentElement.AttributeString('version', TmpStr) then
-      FVersion := TmpStr;
-    if Doc.DocumentElement.AttributeString('orientation', TmpStr) then
-      case TmpStr of
-        'orthogonal': FOrientation := moOrthogonal;
-        'isometric': FOrientation := moIsometric;
-        'staggered': FOrientation := moIsometricStaggered;
-        'hexagonal': FOrientation := moHexagonal;
+    while I.GetNext do
+    begin
+      case LowerCase(I.Current.TagName) of
+        'tileset':
+          begin
+            NewTileset := TTileset.Create;
+            NewTileset.Load(I.Current, BaseUrl);
+            FTilesets.Add(NewTileset);
+          end;
+        'layer':
+          begin
+            NewLayer := TLayer.Create;
+            NewLayer.Load(I.Current, BaseUrl);
+            FLayers.Add(NewLayer);
+          end;
+        'objectgroup':
+          begin
+            NewLayer := TObjectGroupLayer.Create;
+            NewLayer.Load(I.Current, BaseUrl);
+            FLayers.Add(NewLayer);
+          end;
+        'imagelayer':
+          begin
+            NewLayer := TImageLayer.Create;
+            NewLayer.Load(I.Current, BaseUrl);
+            FLayers.Add(NewLayer);
+          end;
+        'properties': FProperties.Load(I.Current, BaseUrl);
       end;
-    if Doc.DocumentElement.AttributeString('width', TmpStr) then
-      FWidth := StrToInt(TmpStr);
-    if Doc.DocumentElement.AttributeString('height', TmpStr) then
-      FHeight := StrToInt(TmpStr);
-    if Doc.DocumentElement.AttributeString('tilewidth', TmpStr) then
-      FTileWidth := StrToInt(TmpStr);
-    if Doc.DocumentElement.AttributeString('tileheight', TmpStr) then
-      FTileHeight := StrToInt(TmpStr);
-    if Doc.DocumentElement.AttributeString('hexsidelength', TmpStr) then
-      FHexSideLength := StrToInt(TmpStr);
-    if Doc.DocumentElement.AttributeString('staggeraxis', TmpStr) then
-      case TmpStr of
-        'x': FStaggerAxis := saX;
-        'y': FStaggerAxis := saY;
-        else WritelnWarning('Invalid staggeraxis "%s" in Tiled map file (TMX)', [TmpStr]);
-      end;
-    if Doc.DocumentElement.AttributeString('staggerindex', TmpStr) then
-      case TmpStr of
-        'odd': FStaggerIndex := siOdd;
-        'even': FStaggerIndex := siEven;
-        else WritelnWarning('Invalid staggerindex "%s" in Tiled map file (TMX)', [TmpStr]);
-      end;
-    if Doc.DocumentElement.AttributeString('backgroundcolor', TmpStr) then
-      FBackgroundColor := TiledToColor(TmpStr);
-    if Doc.DocumentElement.AttributeString('renderorder', TmpStr) then
-      case TmpStr of
-        'right-down': FRenderOrder := mroRightDown;
-        'right-up': FRenderOrder := mroRightUp;
-        'left-down': FRenderOrder := mroLeftDown;
-        'left-up': FRenderOrder := mroLeftUp;
-      end;
-    // Parse map children
-    I := TXMLElementIterator.Create(Doc.DocumentElement);
-    try
-      while I.GetNext do
-      begin
-        case LowerCase(I.Current.TagName) of
-          'tileset':
-            begin
-              NewTileset := TTileset.Create;
-              NewTileset.Load(I.Current, BaseUrl);
-              FTilesets.Add(NewTileset);
-            end;
-          'layer':
-            begin
-              NewLayer := TLayer.Create;
-              NewLayer.Load(I.Current, BaseUrl);
-              FLayers.Add(NewLayer);
-            end;
-          'objectgroup':
-            begin
-              NewLayer := TObjectGroupLayer.Create;
-              NewLayer.Load(I.Current, BaseUrl);
-              FLayers.Add(NewLayer);
-            end;
-          'imagelayer':
-            begin
-              NewLayer := TImageLayer.Create;
-              NewLayer.Load(I.Current, BaseUrl);
-              FLayers.Add(NewLayer);
-            end;
-          'properties': FProperties.Load(I.Current, BaseUrl);
-        end;
-      end;
-    finally FreeAndNil(I) end;
-  finally
-    FreeAndNil(Doc);
-  end;
+    end;
+  finally FreeAndNil(I) end;
 end;
 
-constructor TTiledMap.Create(const Stream: TStream; const BaseUrl_: String);
+constructor TTiledMap.Create(const Stream: TStream; const ABaseUrl: String);
 begin
   inherited Create;
 
   FTilesets := TTilesetList.Create;
   FProperties := TPropertyList.Create;
   FLayers := TLayerList.Create(true);
-  BaseUrl := BaseUrl_;
+  BaseUrl := ABaseUrl;
 
   //Load TMX
-  LoadTMXFile(Stream, BaseUrl_);
+  LoadTMXFile(Stream, ABaseUrl);
 end;
 
 constructor TTiledMap.Create(const AURL: string);


### PR DESCRIPTION
- this is needed/preparation for loading x3d nodes (see PR #241)
- this prevents redundant loading code for TMX files (here and for x3d nodes)