### PR TITLE
Data menu with New Sprite Sheet item

### DIFF
--- a/tools/castle-editor/code/formproject.lfm
+++ b/tools/castle-editor/code/formproject.lfm
@@ -439,6 +439,12 @@ object ProjectForm: TProjectForm
         OnClick = MenuItemBreakProcessClick
       end
     end
+    object MenuItemData: TMenuItem
+      Caption = 'Data'
+      object MenuItemNewCastleSpriteSheet: TMenuItem
+        Action = ActionNewSpriteSheet
+      end
+    end
     object MenuItemHelp: TMenuItem
       Caption = '&Help'
       object MenuItemReferenceOfCurrent: TMenuItem

--- a/tools/castle-editor/code/formproject.pas
+++ b/tools/castle-editor/code/formproject.pas
@@ -32,6 +32,8 @@ type
   TProjectForm = class(TForm)
     ActionNewSpriteSheet: TAction;
     ActionList: TActionList;
+    MenuItemNewCastleSpriteSheet: TMenuItem;
+    MenuItemData: TMenuItem;
     MenuItemNewSpriteSheet: TMenuItem;
     MenuItemSepraratorSLP002: TMenuItem;
     ActionRegenerateProject: TAction;


### PR DESCRIPTION
We talked about that once and I forgot. I couldn't decide Data should be after Code or after Run. Run seems to be related to Code so I added Data after it.

![obraz](https://user-images.githubusercontent.com/18555708/114359523-59cc3980-9b74-11eb-811a-556f20856d2b.png)
