### PR TITLE
Change color of expandable properties from gray to black.

### DIFF
--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -977,6 +977,7 @@ constructor TDesignFrame.Create(TheOwner: TComponent);
     Result.PreferredSplitterX := 150;
     Result.ValueFont.Bold := true;
     Result.ShowGutter := false;
+    Result.ReadOnlyColor := clWindowText;
   end;
 
 begin


### PR DESCRIPTION
Gray color in UI often means that something is unavailable or not editable. My mind automatically filters them out and finding them is even harder. So this PR change color from gray to black. I also experimented with clNavy but triangle indicator highlight them enough and that is consistent with Lazarus.

Before:
![obraz](https://user-images.githubusercontent.com/18555708/114364248-7fa80d00-9b79-11eb-80b0-c5f8befd2c71.png)

After:
![obraz](https://user-images.githubusercontent.com/18555708/114364307-8f275600-9b79-11eb-90e2-1c517dabbb30.png)

