### PR TITLE
Fix gizmo size in 2D (ptOrthographic)

### DIFF
--- a/tools/castle-editor/code/visualizetransform.pas
+++ b/tools/castle-editor/code/visualizetransform.pas
@@ -339,7 +339,8 @@ begin
     Camera := World.MainCamera;
 
     if Camera.ProjectionType = ptOrthographic then
-      GizmoScale := 0.001 * Camera.Orthographic.EffectiveHeight
+      { We just want gizmo is about 15% of effective height }
+      GizmoScale := 0.15 * Camera.Orthographic.EffectiveHeight
     else
       GizmoScale := 0.25 {TODO:* Camera.Perspective.EffeectiveFieldOfViewVertical};
 
@@ -382,7 +383,10 @@ begin
 
     // get the distance, on screen in pixels, of a 1 unit in 3D around gizmo
     OneDistance := PointsDistance(ZeroProjected, OneProjected);
-    if IsZero(OneDistance) then
+
+    if Camera.ProjectionType = ptOrthographic then
+          ScaleUniform := WorldToLocalDistance(GizmoScale)
+    else if IsZero(OneDistance) then
       ScaleUniform := 1
     else
       ScaleUniform := GizmoScale / OneDistance;


### PR DESCRIPTION
In 2D gizmos can be really big. I changed algorithm to set scale about 15% of effective height. I also make them not grow/decrease when scale is changed - I think its more handy. Tested on platformer and 2d game template.

Before:

![obraz](https://user-images.githubusercontent.com/18555708/114381693-aff8a700-9b8b-11eb-905b-74d462514fff.png)


After:
![obraz](https://user-images.githubusercontent.com/18555708/114381513-7c1d8180-9b8b-11eb-8412-2536cefb5dda.png)

![obraz](https://user-images.githubusercontent.com/18555708/114381613-9bb4aa00-9b8b-11eb-970d-14049d8f33ce.png)

