### PR TITLE
Fix typo in docs

### DIFF
--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -1208,7 +1208,7 @@ type
       So for example query like this works naturally:
       @code(MyTransform.Height(MyTransform.Translation, ...)).
 
-      This ignores the geometry of this 3D object (to not accidentaly collide
+      This ignores the geometry of this 3D object (to not accidentally collide
       with your own geometry), and checks collisions with the rest of the world.
       @groupBegin }
     function Height(const MyPosition: TVector3;
@@ -1225,7 +1225,7 @@ type
       So for example query like this works naturally:
       @code(MyTransform.LineOfSight(MyTransform.Translation, MyTransform.Translation + MyTransform.Direction * 10)).
 
-      This ignores the geometry of this 3D object (to not accidentaly collide
+      This ignores the geometry of this 3D object (to not accidentally collide
       with your own geometry), and checks collisions with the rest of the world. }
     function LineOfSight(const Pos1, Pos2: TVector3): boolean;
 
@@ -1277,7 +1277,7 @@ type
       So for example query like this works naturally:
       @code(MyTransform.Ray(MyTransform.Translation, MyTransform.Direction)).
 
-      This ignores the geometry of this object (to not accidentaly collide
+      This ignores the geometry of this object (to not accidentally collide
       with your own geometry), and checks collisions with the rest of the world. }
     function Ray(const RayOrigin, RayDirection: TVector3): TRayCollision;
 
@@ -1290,7 +1290,7 @@ type
       In case of the overloaded version with Distance parameter,
       the Distance is consistently in the same, parent coordinate system.
 
-      This ignores the geometry of this object (to not accidentaly collide
+      This ignores the geometry of this object (to not accidentally collide
       with your own geometry), and checks collisions with the rest of the world.
 
       This returns the TCastleTransform that is hit (this is the "leaf" TCastleTransform

--- a/src/castlescript/castlescript.pas
+++ b/src/castlescript/castlescript.pas
@@ -2617,7 +2617,7 @@ begin
       would be incorrect: our argument may be a long-lived instance in
       TCasScriptFunction.ExecuteArgumentClasses, that is changed in
       TCasScriptFunction.CoreExecute. With a reference copy here,
-      the CoreExecute would accidentaly change also our cache state,
+      the CoreExecute would accidentally change also our cache state,
       which will cause trouble later.
 
       Testcase: demo_models/castle_script/edit_texture.x3dv,

--- a/src/files/castlefilesutils.pas
+++ b/src/files/castlefilesutils.pas
@@ -1163,7 +1163,7 @@ begin
     { Although GetTempFileName should add some randomization here,
       there's no guarantee. And we really need randomization ---
       we may load ffmpeg output using image %d pattern, so we don't want to
-      accidentaly pick up other images in the temporary directory
+      accidentally pick up other images in the temporary directory
       (e.g. leftovers from previous TRangeScreenShot.BeginCapture). }
     { System.Random, not just Random, to avoid using Random from MacOSAll unit. }
     IntToStr(System.Random(MaxInt)) + '_';

--- a/src/images/castleimages_external_tool.inc
+++ b/src/images/castleimages_external_tool.inc
@@ -68,7 +68,7 @@ begin
            Possibly trying to work within the same OpenGL context
            from 2 different versions of forked process ?
            So it seems like it's TProcess Unix implementation bug,
-           that accidentaly hits also NVidia Linux driver bug.
+           that accidentally hits also NVidia Linux driver bug.
            TODO: investigate more, submit to FPC bug/patch.
 
       First implementation using TProcess:

--- a/src/images/castlevideos.pas
+++ b/src/images/castlevideos.pas
@@ -392,7 +392,7 @@ var
 
   { Maximum number of video frames to read, for TVideo.LoadFromFile.
 
-    This prevents using up all the memory by accidentaly trying to read
+    This prevents using up all the memory by accidentally trying to read
     a long movie. Remember that our current implementation is @bold(not)
     suited for long movies, it will load very slowly and consume a lot of memory.
     See https://castle-engine.io/x3d_implementation_texturing.php

--- a/src/images/opengl/castleglimages_load_2d.inc
+++ b/src/images/opengl/castleglimages_load_2d.inc
@@ -272,7 +272,7 @@ begin
   try
     {$ifndef OpenGLES}
     { Workaround Mesa 7.9-devel bug (at least with Intel DRI,
-      on Ubuntu 10.10, observed on domek): glTexImage2D accidentaly
+      on Ubuntu 10.10, observed on domek): glTexImage2D accidentally
       enables GL_TEXTURE_2D. }
     if GLFeatures.EnableFixedFunction and GLVersion.Mesa then
       glPushAttrib(GL_ENABLE_BIT);

--- a/src/x3d/opengl/castlerendererinternaltextureenv.pas
+++ b/src/x3d/opengl/castlerendererinternaltextureenv.pas
@@ -320,7 +320,7 @@ procedure ModeFromString(const S: string;
     begin
       { LS = '' means that mode list was too short.
         X3D spec says explicitly that default mode is "MODULATE"
-        in this case. (Accidentaly, this also will accept
+        in this case. (Accidentally, this also will accept
         explict "" string as "MODULATE" --- not a worry, we don't
         have to produce error messages for all possible invalid VRMLs...). }
 

--- a/src/x3d/opengl/castleviewport.pas
+++ b/src/x3d/opengl/castleviewport.pas
@@ -1688,7 +1688,7 @@ begin
 
   { update the cursor, since 3D object under the cursor possibly changed.
 
-    Accidentaly, this also workarounds the problem of TCastleViewport:
+    Accidentally, this also workarounds the problem of TCastleViewport:
     when the 3D object stayed the same but it's Cursor value changed,
     Items.CursorChange notify only TCastleSceneManager (not custom viewport).
     But thanks to doing RecalculateCursor below, this isn't


### PR DESCRIPTION
accidentaly -> accidentally -  I found that when reading about Ray and just search/fix all docs.

https://whichiscorrect.com/accidentally-vs-accidentaly/
