### PR TITLE
Fix PhysicsRayCast() return value

### DIFF
--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -1061,7 +1061,7 @@ begin
     if Hit then
     begin
       Distance := FTransform.UniqueParent.WorldToLocalDistance(ResultingDistance);
-      Result := TCastleTransform(Shape.RigidBody.UserData);
+      Result := TRigidBody(Shape.RigidBody.UserData).FTransform;
     end else
       Result := nil;
   finally


### PR DESCRIPTION
Fix PhysicsRayCast() return value: `TKraftRigidBody.UserData` is `TRigidBody` not `TCastleTransform`.