### PR TITLE
Not existing TRigidBody should not be ksfRayCastable (found by ray cast)

### DIFF
--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -1109,9 +1109,11 @@ begin
   if Assigned(Collider) and Assigned(Collider.FKraftShape) then
   begin
     if FExists then
-      Collider.FKraftShape.Flags := Collider.FKraftShape.Flags + [ksfCollision]
+      Collider.FKraftShape.Flags := Collider.FKraftShape.Flags + [ksfCollision,
+        ksfRayCastable]
     else
-      Collider.FKraftShape.Flags := Collider.FKraftShape.Flags - [ksfCollision];
+      Collider.FKraftShape.Flags := Collider.FKraftShape.Flags - [ksfCollision,
+        ksfRayCastable];
   end;
 end;
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -1108,6 +1108,7 @@ begin
 
   if Assigned(Collider) and Assigned(Collider.FKraftShape) then
   begin
+    { Note: ksfRayCastable flag determines whether body is detected by PhysicsRayCast. }
     if FExists then
       Collider.FKraftShape.Flags := Collider.FKraftShape.Flags + [ksfCollision,
         ksfRayCastable]


### PR DESCRIPTION
In Kraft rigid body without `ksfCollision` still can be found by ray cast. But we don't want that when `TRigidBody.Exist = false`. This PR fixes that.