### PR TITLE
Change rigid bodies existence when TCastleTransform.Exists changes.

### DIFF
--- a/packages/castle_base.lpk
+++ b/packages/castle_base.lpk
@@ -74,7 +74,7 @@ This is the same license as used by Lazarus LCL and FPC RTL.
 See https://castle-engine.io/license.php for details.
 "/>
     <Version Major="6" Minor="5"/>
-    <Files Count="720">
+    <Files Count="721">
       <Item1>
         <Filename Value="../src/3d/castleboxes.pas"/>
         <UnitName Value="CastleBoxes"/>
@@ -2971,6 +2971,10 @@ See https://castle-engine.io/license.php for details.
         <Filename Value="../src/game/castlebehaviors.pas"/>
         <UnitName Value="CastleBehaviors"/>
       </Item720>
+      <Item721>
+        <Filename Value="../src/3d/castletransform_physics.inc"/>
+        <Type Value="Include"/>
+      </Item721>
     </Files>
     <RequiredPkgs Count="1">
       <Item1>

--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -341,10 +341,10 @@ type
     FLastUpdatedGetExists: Boolean;
     FLastUpdatedGetExistsValid: Boolean;
 
-    { When castle transform existance changes to false, we need update existance
+    { When castle transform existence changes to false, we need update existence
       in all castle transform children rigid bodies }
     procedure UpdateExistRecursively(const AExists: Boolean);
-    { Update rigid body existance when castle transform (or it parent) GetExists
+    { Update rigid body existence when castle transform (or it parent) GetExists
       changes. }
     procedure UpdateExist(const AExists: Boolean);
   private

--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -350,7 +350,7 @@ type
 
     { Check current item exist taking into account the existence of the
       unique parents of this item, needed only before first Update() call.
-      See GetRealExistance(). }
+      See GetRealExistence(). }
     function GetExistsRecursively: Boolean;
   private
     type
@@ -454,8 +454,18 @@ type
     procedure SetListenPressRelease(const Value: Boolean);
 
     { Check current item exist taking into account the existence of the
-      unique parents of this item }
-    function GetRealExistance: Boolean;
+      unique parents of this item.
+
+      This return true when this transform, and all its parents, have Exists = true.
+      Return value is *undefined* when some transformation along the way has multiple
+      parents, so you should only use this when you require "single parent" anyway
+      (e.g. physics requires it).
+
+      For performance, this is valid now only if "FWorld.FKraftEngine <> nil",
+      as calculating it requires sometimes iterating inside an inactive
+      transform tree (which is not otherwise needed).
+      But if needed, it could be updated in the future in other situations too.}
+    function GetRealExistence: Boolean;
   protected
     { Called when the current @link(World) that contains this object changes.
       In the usual case, @link(World) corresponds to a @link(TCastleViewport.Items)
@@ -2611,12 +2621,12 @@ begin
     Result := UniqueParent.GetExistsRecursively;
 end;
 
-function TCastleTransform.GetRealExistance: Boolean;
+function TCastleTransform.GetRealExistence: Boolean;
 begin
   if FLastUpdatedGetExistsValid then
     Exit(FLastUpdatedGetExists);
 
-  { Only needed when you call GetRealExistance() before first update. }
+  { Only needed when you call GetRealExistence() before first update. }
   Exit(GetExistsRecursively);
 end;
 

--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -2565,8 +2565,6 @@ end;
 procedure TCastleTransform.UpdateExistRecursively(const AExists: Boolean);
 var
   I: Integer;
-  ChildTransform: TCastleTransform;
-  CurrentChildExists: Boolean;
 begin
   Assert(AExists = false, 'This funcion is only used when AExist is false');
   UpdateExist(AExists);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -721,7 +721,7 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
     FKraftBody.Finish;
 
     UpdateCollides(Transform);
-    UpdateExist(Transform.GetRealExistance);
+    UpdateExist(Transform.GetRealExistence);
 
     if (not FAngularVelocity.IsPerfectlyZero) or
        (not FLinearVelocity.IsPerfectlyZero) then
@@ -1175,7 +1175,7 @@ begin
     Exit;
 
   FExists := Value;
-  UpdateExist(FTransform.GetRealExistance);
+  UpdateExist(FTransform.GetRealExistence);
 end;
 
 procedure TRigidBody.SetTrigger(const Value: Boolean);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -721,7 +721,7 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
     FKraftBody.Finish;
 
     UpdateCollides(Transform);
-    UpdateExist(Transform.GetExistsRecursively);
+    UpdateExist(Transform.GetRealExistance);
 
     if (not FAngularVelocity.IsPerfectlyZero) or
        (not FLinearVelocity.IsPerfectlyZero) then
@@ -1175,7 +1175,7 @@ begin
     Exit;
 
   FExists := Value;
-  UpdateExist(FTransform.GetExistsRecursively);
+  UpdateExist(FTransform.GetRealExistance);
 end;
 
 procedure TRigidBody.SetTrigger(const Value: Boolean);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -1314,8 +1314,15 @@ var
   KraftGravity: TVector3;
   PhysicsTicksCount:Integer;
   OldTimeAccumulator: TFloatTime;
+  CurrentGetExists: Boolean;
 begin
-  if not GetExists then Exit;
+  CurrentGetExists := GetExists;
+
+  if ((FWorld.FKraftEngine <> nil) and
+     (UpdateFrameId = TFramesPerSecond.FrameId)) then
+    UpdateRealExistence(CurrentGetExists);
+
+  if not CurrentGetExists then Exit;
 
   { Avoid doing this two times within the same FrameId.
     Important if the same TCastleAbstractRootTransform is present in multiple viewports. }

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -727,7 +727,7 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
     FKraftBody.Finish;
 
     UpdateCollides(Transform);
-    UpdateExist(Transform.GetRealExistence);
+    UpdateExist(Transform.GetExistsInRoot);
 
     if (not FAngularVelocity.IsPerfectlyZero) or
        (not FLinearVelocity.IsPerfectlyZero) then
@@ -1181,7 +1181,7 @@ begin
     Exit;
 
   FExists := Value;
-  UpdateExist(FTransform.GetRealExistence);
+  UpdateExist(FTransform.GetExistsInRoot);
 end;
 
 procedure TRigidBody.SetTrigger(const Value: Boolean);
@@ -1325,8 +1325,8 @@ begin
   CurrentGetExists := GetExists;
 
   if ((FWorld.FKraftEngine <> nil) and
-     (UpdateFrameId = TFramesPerSecond.FrameId)) then
-    UpdateRealExistence(CurrentGetExists);
+     (UpdateFrameId <> TFramesPerSecond.FrameId)) then
+    UpdateExistsInRoot(CurrentGetExists);
 
   if not CurrentGetExists then Exit;
 

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -218,6 +218,7 @@
     FCollisionList: TCastleTransformList;
 
     procedure UpdateCollides(const Transform: TCastleTransform);
+    procedure UpdateExist(const TransformExists: Boolean);
 
     { Sets all values from Kraft to CGE private fields. }
     procedure SynchronizeFromKraft;
@@ -720,6 +721,7 @@ procedure TRigidBody.InitializeTransform(const Transform: TCastleTransform);
     FKraftBody.Finish;
 
     UpdateCollides(Transform);
+    UpdateExist(Transform.GetExistsRecursively);
 
     if (not FAngularVelocity.IsPerfectlyZero) or
        (not FLinearVelocity.IsPerfectlyZero) then
@@ -931,6 +933,28 @@ begin
   begin
     FKraftBody.CollideWithCollisionGroups := [];
     FKraftBody.CollisionGroups := [];
+  end;
+end;
+
+procedure TRigidBody.UpdateExist(const TransformExists: Boolean);
+begin
+  if Assigned(FKraftBody) then
+  begin
+    if FExists and TransformExists then
+      FKraftBody.Flags := FKraftBody.Flags + [krbfActive]
+    else
+      FKraftBody.Flags := FKraftBody.Flags - [krbfActive];
+  end;
+
+  if Assigned(Collider) and Assigned(Collider.FKraftShape) then
+  begin
+    { Note: ksfRayCastable flag determines whether body is detected by PhysicsRayCast. }
+    if FExists and TransformExists then
+      Collider.FKraftShape.Flags := Collider.FKraftShape.Flags + [ksfCollision,
+        ksfRayCastable]
+    else
+      Collider.FKraftShape.Flags := Collider.FKraftShape.Flags - [ksfCollision,
+        ksfRayCastable];
   end;
 end;
 
@@ -1151,25 +1175,7 @@ begin
     Exit;
 
   FExists := Value;
-
-  if Assigned(FKraftBody) then
-  begin
-    if FExists then
-      FKraftBody.Flags := FKraftBody.Flags + [krbfActive]
-    else
-      FKraftBody.Flags := FKraftBody.Flags - [krbfActive];
-  end;
-
-  if Assigned(Collider) and Assigned(Collider.FKraftShape) then
-  begin
-    { Note: ksfRayCastable flag determines whether body is detected by PhysicsRayCast. }
-    if FExists then
-      Collider.FKraftShape.Flags := Collider.FKraftShape.Flags + [ksfCollision,
-        ksfRayCastable]
-    else
-      Collider.FKraftShape.Flags := Collider.FKraftShape.Flags - [ksfCollision,
-        ksfRayCastable];
-  end;
+  UpdateExist(FTransform.GetExistsRecursively);
 end;
 
 procedure TRigidBody.SetTrigger(const Value: Boolean);

--- a/src/3d/castletransform_physics.inc
+++ b/src/3d/castletransform_physics.inc
@@ -126,6 +126,9 @@
 
     property Restitution: Single read FRestitution write FRestitution default DefaultRestitution;
     property Friction: Single read FFriction write FFriction default DefaultFriction;
+
+    { @exclude Only for testing. }
+    property InternalKraftShape: TKraftShape read FKraftShape;
   end;
 
   { Collide as an infinite plane.
@@ -436,6 +439,9 @@
       When this is @false, the rigid body is not updated by the physics engine,
       and it does not cause collisions with other rigid bodies. }
     property Exists: Boolean read FExists write SetExists default true;
+
+    { @exclude Only for testing. }
+    property InternalKraftBody: TKraftRigidBody read FKraftBody;
   end;
 
 {$endif read_interface}


### PR DESCRIPTION
Before this PR, when you set `TCastleTransform.Exists` to `False` assigned `TRigidBody` still exists. So this makes very funny bugs;)

Before this PR you need set two `Exists` to `False`:
```
CastleTransform.Exists := False;
CastleTransform.RigidBody.Exists := False;
```
to make something really not existing. And you need make loop on all children to make them not existing too.

This PR add existence tracking mechanism to `TCastleTransform` and use it only to update Kraft flags.  So it's also disabled when `FWorld.FKraftEngine = nil`. Thanks to change Kraft flags you can remember `RigidBody.Exists` value.

Currently `TCastleAbstractRootTransform` existence is not tracked. So when you set `TCastleAbstractRootTransform.Exists` to `False` children will not be updated. This can be done (with small code complications) but I don't know is it worth to do it (or we want to support that case?

