### PR TITLE
Platformer demo: Pause game only when it's not paused (fixes crash).

### DIFF
--- a/examples/platformer/code/gamestateplay.pas
+++ b/examples/platformer/code/gamestateplay.pas
@@ -1642,7 +1642,7 @@ begin
   {if Event.IsKey(keyF6) then
     CoinsRoot.Exists := not CoinsRoot.Exists;}
 
-  if Event.IsKey(keyEscape) then
+  if Event.IsKey(keyEscape) and (TUIState.CurrentTop = StatePlay) then
   begin
     PauseGame;
     TUIState.Push(StatePause);


### PR DESCRIPTION
Fixes https://trello.com/c/kK8wTdhj/158-platformer-errors-when-using-escape-to-go-to-options-from-game-when-dead-or-not-dead