### PR TITLE
New shadow volumes based on internal scenes

### DIFF
--- a/src/3d/opengl/castleinternalglshadowvolumes.pas
+++ b/src/3d/opengl/castleinternalglshadowvolumes.pas
@@ -237,7 +237,7 @@ type
 
 var
   InternalUseOldShadowVolumes: Boolean = false;
-  InternalRenderOld: Boolean = false;
+  InternalShadowVolumesOldRender: Boolean = false;
   InternalShadowVolumesUseDepth: Boolean = false;
 
 implementation
@@ -867,7 +867,7 @@ var
   OldDepthFunc: TDepthFunction;
 begin
   {$ifndef OpenGLES}
-  if InternalRenderOld then
+  if InternalShadowVolumesOldRender then
   begin
     RenderOld(Params, Render3D, RenderShadowVolumes, DrawShadowVolumes);
     Exit;

--- a/src/3d/opengl/castleinternalglshadowvolumes.pas
+++ b/src/3d/opengl/castleinternalglshadowvolumes.pas
@@ -238,7 +238,8 @@ type
 var
   InternalUseOldShadowVolumes: Boolean = false;
   InternalShadowVolumesOldRender: Boolean = false;
-  InternalShadowVolumesUseDepth: Boolean = false;
+  InternalShadowVolumesUseDepth: Boolean = true;
+  InternalShadowVolumesUseDepthV2: Boolean = true; // To use also needs InternalShadowVolumesUseDepth = true
   InternalUpdateShadowVolumes: Boolean = true;
 
 implementation

--- a/src/3d/opengl/castleinternalglshadowvolumes.pas
+++ b/src/3d/opengl/castleinternalglshadowvolumes.pas
@@ -239,6 +239,7 @@ var
   InternalUseOldShadowVolumes: Boolean = false;
   InternalShadowVolumesOldRender: Boolean = false;
   InternalShadowVolumesUseDepth: Boolean = false;
+  InternalUpdateShadowVolumes: Boolean = true;
 
 implementation
 

--- a/src/3d/opengl/castleinternalglshadowvolumes.pas
+++ b/src/3d/opengl/castleinternalglshadowvolumes.pas
@@ -915,11 +915,11 @@ begin
     glCullFace(GL_FRONT);
     RenderShadowVolumes;
     Count := OldCount;
+    RenderContext.CullFace := OldCullFace;
   end;
 
   glSetDepthAndColorWriteable(true);
   RenderContext.DepthTest := OldDepthTest;
-  RenderContext.CullFace := OldCullFace;
   glDisable(GL_STENCIL_TEST);
 
   { Now render everything once again, with lights turned on.

--- a/src/3d/opengl/castleinternalglshadowvolumes.pas
+++ b/src/3d/opengl/castleinternalglshadowvolumes.pas
@@ -690,11 +690,11 @@ begin
       glSetDepthAndColorWriteable(false);
         glStencilFunc(GL_ALWAYS, 0, 0);
 
-        if StencilTwoSided then
+        {if StencilTwoSided then
         begin
           StencilSetupKind := ssFrontAndBack;
           RenderShadowVolumes;
-        end else
+        end else}
         begin
           glEnable(GL_CULL_FACE);
 

--- a/src/3d/opengl/castleinternalglshadowvolumes.pas
+++ b/src/3d/opengl/castleinternalglshadowvolumes.pas
@@ -1010,6 +1010,7 @@ begin
     ///glPushAttrib(GL_COLOR_BUFFER_BIT or GL_DEPTH_BUFFER_BIT or GL_ENABLE_BIT);
     OldDepthTest := RenderContext.DepthTest;
     RenderContext.DepthTest := true;
+    {$ifndef OpenGLES}
     if InternalUseOldShadowVolumes then
     begin
       glDisable(GL_LIGHTING);
@@ -1019,6 +1020,7 @@ begin
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
       glEnable(GL_BLEND);
     end;
+    {$endif not OpenGLES}
     RenderShadowVolumes;
     ///glPopAttrib;
     RenderContext.DepthTest := OldDepthTest;

--- a/src/3d/opengl/castleinternalglshadowvolumes.pas
+++ b/src/3d/opengl/castleinternalglshadowvolumes.pas
@@ -238,6 +238,7 @@ type
 var
   InternalUseOldShadowVolumes: Boolean = false;
   InternalRenderOld: Boolean = false;
+  InternalShadowVolumesUseDepth: Boolean = false;
 
 implementation
 

--- a/src/images/opengl/castlerendercontext.pas
+++ b/src/images/opengl/castlerendercontext.pas
@@ -52,6 +52,11 @@ type
   { Possible values of @link(TRenderContext.DepthRange). }
   TDepthRange = (drFull, drNear, drFar);
 
+  { Possible values of @link(TRenderContext.DepthFunc). }
+  TDepthFunction = (dfNever = $0200, dfLess = $0201, dfLessEqual = $0203,
+              dfGreater = $0204, dfGreaterEqual = $0206, dfEqual = $0202,
+              dfNotEqual = $0205, dfAlways = $0207);
+
   TColorChannel = 0..3;
   TColorChannels = set of TColorChannel;
 
@@ -91,6 +96,8 @@ type
       FProjectionMatrix: TMatrix4;
       FDepthRange: TDepthRange;
       FCullFace, FFrontFaceCcw: boolean;
+      FDepthTest: Boolean;
+      FDepthFunc: TDepthFunction;
       FColorChannels: TColorChannels;
       FViewport: TRectangle;
       FViewportDelta: TVector2Integer;
@@ -105,6 +112,8 @@ type
       procedure SetDepthRange(const Value: TDepthRange);
       procedure SetCullFace(const Value: boolean);
       procedure SetFrontFaceCcw(const Value: boolean);
+      procedure SetDepthTest(const Value: Boolean);
+      procedure SetDepthFunc(const Value: TDepthFunction);
       function GetColorMask: boolean;
       procedure SetColorMask(const Value: boolean);
       procedure SetColorChannels(const Value: TColorChannels);
@@ -179,6 +188,11 @@ type
       and to interpret the normal vectors (they point outward from front face). }
     property FrontFaceCcw: boolean read FFrontFaceCcw write SetFrontFaceCcw
       default true;
+
+    property DepthTest: Boolean read FDepthTest write SetDepthTest default true;
+
+    property DepthFunc: TDepthFunction read FDepthFunc write SetDepthFunc
+      default dfLess;
 
     { Which color buffer channels are touched by rendering. }
     property ColorMask: boolean
@@ -274,6 +288,8 @@ begin
   FDepthRange := drFull;
   FCullFace := false;
   FFrontFaceCcw := true;
+  FDepthTest := true;
+  FDepthFunc := dfLess;
   FColorChannels := [0..3];
   FViewport := TRectangle.Empty;
 end;
@@ -452,6 +468,30 @@ begin
       glFrontFace(GL_CCW)
     else
       glFrontFace(GL_CW);
+  end;
+end;
+
+procedure TRenderContext.SetDepthTest(const Value: Boolean);
+begin
+  if Self <> RenderContext then
+    WarnContextNotCurrent;
+
+  if FDepthTest <> Value then
+  begin
+    FDepthTest := Value;
+    GLSetEnabled(GL_DEPTH_TEST, FDepthTest);
+  end;
+end;
+
+procedure TRenderContext.SetDepthFunc(const Value: TDepthFunction);
+begin
+  if Self <> RenderContext then
+    WarnContextNotCurrent;
+
+  if FDepthFunc <> Value then
+  begin
+    FDepthFunc := Value;
+    GLDepthFunc(LongWord(FDepthFunc));
   end;
 end;
 

--- a/src/ui/opengl/castleuicontrols.pas
+++ b/src/ui/opengl/castleuicontrols.pas
@@ -3395,7 +3395,7 @@ begin
     GLEnableTexture(CastleGLUtils.etNone);
   end;
 
-  glDisable(GL_DEPTH_TEST);
+  RenderContext.DepthTest := false;
 
   RenderContext.Viewport := ViewportRect;
   OrthoProjection(FloatRectangle(0, 0, ViewportRect.Width, ViewportRect.Height));

--- a/src/x3d/castleshapeinternalshadowvolumes.pas
+++ b/src/x3d/castleshapeinternalshadowvolumes.pas
@@ -111,6 +111,9 @@ type
     SceneDepthNever: TObject;
     TriangleCoordsDepthNever: TCoordinateNode;
 
+    SceneDepthOK: TObject;
+    TriangleCoordsDepthOK: TCoordinateNode;
+
     constructor Create(const AShape: TObject);
     destructor Destroy; override;
 

--- a/src/x3d/castleshapeinternalshadowvolumes.pas
+++ b/src/x3d/castleshapeinternalshadowvolumes.pas
@@ -20,7 +20,8 @@ unit CastleShapeInternalShadowVolumes;
 interface
 
 uses Generics.Collections,
-  CastleUtils, CastleVectors, CastleTriangles;
+  CastleUtils, CastleVectors, CastleTriangles,
+  X3DNodes;
 
 type
   { Edge that is between exactly two triangles.
@@ -103,6 +104,9 @@ type
     procedure CalculateIfNeededManifoldAndBorderEdges;
   public
     FShape: TObject;
+    SceneForShadowVolumes: TObject;
+    QuadCoords: TCoordinateNode;
+    TriangleCoords: TCoordinateNode;
 
     constructor Create(const AShape: TObject);
     destructor Destroy; override;
@@ -170,7 +174,7 @@ type
 implementation
 
 uses SysUtils,
-  CastleShapes, X3DNodes, CastleLog, CastleTransformExtra, CastleTransform,
+  CastleShapes, CastleLog, CastleTransformExtra, CastleTransform,
   CastleRenderOptions;
 
 constructor TShapeShadowVolumes.Create(const AShape: TObject);
@@ -181,6 +185,7 @@ end;
 
 destructor TShapeShadowVolumes.Destroy;
 begin
+  FreeAndNil(SceneForShadowVolumes);
   { free FTrianglesList* variables }
   InvalidateTrianglesListShadowCasters;
   { frees FManifoldEdges, FBorderEdges if needed }

--- a/src/x3d/castleshapeinternalshadowvolumes.pas
+++ b/src/x3d/castleshapeinternalshadowvolumes.pas
@@ -111,9 +111,6 @@ type
     SceneDepthNever: TObject;
     TriangleCoordsDepthNever: TCoordinateNode;
 
-    SceneDepthOK: TObject;
-    TriangleCoordsDepthOK: TCoordinateNode;
-
     constructor Create(const AShape: TObject);
     destructor Destroy; override;
 

--- a/src/x3d/castleshapeinternalshadowvolumes.pas
+++ b/src/x3d/castleshapeinternalshadowvolumes.pas
@@ -108,6 +108,9 @@ type
     QuadCoords: TCoordinateNode;
     TriangleCoords: TCoordinateNode;
 
+    SceneDepthNever: TObject;
+    TriangleCoordsDepthNever: TCoordinateNode;
+
     constructor Create(const AShape: TObject);
     destructor Destroy; override;
 
@@ -186,6 +189,7 @@ end;
 destructor TShapeShadowVolumes.Destroy;
 begin
   FreeAndNil(SceneForShadowVolumes);
+  FreeAndNil(SceneDepthNever);
   { free FTrianglesList* variables }
   InvalidateTrianglesListShadowCasters;
   { frees FManifoldEdges, FBorderEdges if needed }

--- a/src/x3d/castleshapeinternalshadowvolumes.pas
+++ b/src/x3d/castleshapeinternalshadowvolumes.pas
@@ -108,8 +108,8 @@ type
     QuadCoords: TCoordinateNode;
     TriangleCoords: TCoordinateNode;
 
-    SceneDepthNever: TObject;
-    TriangleCoordsDepthNever: TCoordinateNode;
+    SceneForShadowVolumesCups: TObject;
+    TriangleCoordsCups: TCoordinateNode;
 
     constructor Create(const AShape: TObject);
     destructor Destroy; override;
@@ -189,7 +189,7 @@ end;
 destructor TShapeShadowVolumes.Destroy;
 begin
   FreeAndNil(SceneForShadowVolumes);
-  FreeAndNil(SceneDepthNever);
+  FreeAndNil(SceneForShadowVolumesCups);
   { free FTrianglesList* variables }
   InvalidateTrianglesListShadowCasters;
   { frees FManifoldEdges, FBorderEdges if needed }

--- a/src/x3d/opengl/castleinternalrenderer.pas
+++ b/src/x3d/opengl/castleinternalrenderer.pas
@@ -2052,7 +2052,7 @@ begin
   end else
     LineType := ltSolid;
 
-  GLSetEnabled(GL_DEPTH_TEST, Beginning and RenderOptions.DepthTest);
+  RenderContext.DepthTest := Beginning and RenderOptions.DepthTest;
 
   if GLFeatures.EnableFixedFunction and (RenderOptions.Mode in [rmDepth, rmFull]) then
   begin

--- a/src/x3d/opengl/castlescene.pas
+++ b/src/x3d/opengl/castlescene.pas
@@ -1622,8 +1622,6 @@ var
   Shape: TShape;
   T: TMatrix4;
   ForceOpaque: boolean;
-  Params: TBasicRenderParams;
-  Matrix: TMatrix4f;
 begin
   if GetVisible and CastShadowVolumes then
   begin
@@ -1658,10 +1656,6 @@ begin
             SVRenderer.ZFailAndLightCap,
             SVRenderer.ZFail,
             ForceOpaque);
-          {Params := TBasicRenderParams.Create;
-          Params.RenderingCamera := RenderingCamera;
-          Params.InShadow := true;
-          TCastleScene(Shape.InternalShadowVolumes.SceneForShadowVolumes).Render(Params);}
         end;
       end;
     end;

--- a/src/x3d/opengl/castlescene.pas
+++ b/src/x3d/opengl/castlescene.pas
@@ -1622,6 +1622,8 @@ var
   Shape: TShape;
   T: TMatrix4;
   ForceOpaque: boolean;
+  Params: TBasicRenderParams;
+  Matrix: TMatrix4f;
 begin
   if GetVisible and CastShadowVolumes then
   begin
@@ -1656,6 +1658,10 @@ begin
             SVRenderer.ZFailAndLightCap,
             SVRenderer.ZFail,
             ForceOpaque);
+          {Params := TBasicRenderParams.Create;
+          Params.RenderingCamera := RenderingCamera;
+          Params.InShadow := true;
+          TCastleScene(Shape.InternalShadowVolumes.SceneForShadowVolumes).Render(Params);}
         end;
       end;
     end;

--- a/src/x3d/opengl/castlescreeneffects.pas
+++ b/src/x3d/opengl/castlescreeneffects.pas
@@ -749,7 +749,7 @@ var
       {$ifndef OpenGLES}
       glPushAttrib(GL_ENABLE_BIT);
       glDisable(GL_LIGHTING);
-      glDisable(GL_DEPTH_TEST);
+      RenderContext.DepthTest := false;
 
       glActiveTexture(GL_TEXTURE0);
       glDisable(GL_TEXTURE_2D);

--- a/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
+++ b/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
@@ -20,7 +20,7 @@ unit CastleShapeInternalRenderShadowVolumes;
 interface
 
 uses CastleVectors, CastleShapeInternalShadowVolumes,
-  CastleTriangles;
+  CastleTriangles, CastleLog;
 
 type
   TRenderShapeShadowVolumes = class helper for TShapeShadowVolumes
@@ -69,8 +69,9 @@ implementation
 // to keep it working for backward compatibility.
 uses SysUtils,
   {$ifdef CASTLE_OBJFPC} CastleGL, {$else} GL, GLExt, {$endif}
-  CastleRenderingCamera, CastleGLUtils, CastleUtils, CastleShapes, CastleImages,
-  CastleRenderContext;
+  CastleRenderingCamera, CastleGLUtils, CastleUtils, CastleScene, CastleShapes,
+  CastleImages, CastleRenderContext, CastleColors,
+  X3DNodes;
 {$warnings on}
 
 {$ifndef OpenGLES}
@@ -119,7 +120,7 @@ end;
   TCastleScene.RenderSilhouetteShadowVolume, as FPC 2.6.4 and 2.6.2 on Win32 (but not on Linux
   i386) generates then bad code, the loop to ManifoldEdgesNow.Count doesn't finish OK,
   the index goes beyond ManifoldEdgesNow.Count-1. }
-function ExtrudeVertex(
+{function ExtrudeVertex(
   const Original: TVector3;
   const LightPos: TVector4): TVector4;
 var
@@ -135,8 +136,624 @@ begin
   Result[1] := Original[1] -  LightPos3[1];
   Result[2] := Original[2] -  LightPos3[2];
   Result[3] := 0;
+end;}
+
+function ExtrudeVertex(
+  const Original: TVector3;
+  const LightPos: TVector4): TVector3;
+var
+  LightPos3: TVector3 absolute LightPos;
+begin
+
+  Result[0] := Original[0] -  LightPos3[0];
+  Result[1] := Original[1] -  LightPos3[1];
+  Result[2] := Original[2] -  LightPos3[2];
+
+  Result.NormalizeMe;
+  Result[0] := Result[0] * 1000000;
+  Result[1] := Result[1] * 1000000;
+  Result[2] := Result[2] * 1000000;
+
+  {Original := Original +
+
+  if not TrySimplePlaneRayIntersection(Result, -1000000, 0, Original, Original -  LightPos3) then
+    raise Exception.Create('hmm');
+  if not TrySimplePlaneRayIntersection(Result,  1000000, 0, Original, Original -  LightPos3) then
+    raise Exception.Create('hmm');
+  if not TrySimplePlaneRayIntersection(Result, -1000000, 1, Original, Original -  LightPos3) then
+    raise Exception.Create('hmm');
+  if not TrySimplePlaneRayIntersection(Result,  1000000, 1, Original, Original -  LightPos3) then
+    raise Exception.Create('hmm');
+  if not TrySimplePlaneRayIntersection(Result, -1000000, 2, Original, Original -  LightPos3) then
+    raise Exception.Create('hmm');
+  if not TrySimplePlaneRayIntersection(Result,  1000000, 2, Original, Original -  LightPos3) then
+    raise Exception.Create('hmm');}
 end;
 
+
+// start nowa
+
+procedure TRenderShapeShadowVolumes.RenderSilhouetteShadowVolume(
+  const LightPos: TVector4;
+  const Transform: TMatrix4;
+  const LightCap, DarkCap: boolean;
+  const ForceOpaque: boolean);
+
+{$ifndef OpenGLES} //TODO-es
+
+{ Is it worth preparing ManifoldEdges list: yes.
+
+  At the beginning we used here the simple algorithm from
+  [http://www.gamedev.net/reference/articles/article1873.asp].
+  For each triangle with dot > 0, add it to the Edges list
+  --- unless it's already there, in which case remove it.
+  This way, at the end Edges contain all edges that have on one
+  side triangle with dot > 0 and on the other side triangle with dot <= 0.
+  In other words, all sihouette edges.
+  (This is all assuming that model is 2-manifold,
+  so each edge has exactly 2 neighbor triangles).
+
+  But this algorithm proved to be unacceptably slow for many cases.
+  While it generated much less shadow quads than naive
+  RenderAllShadowVolume, the time spent in detecting the silhouette edges
+  made the total time even worse than RenderAllShadowVolume.
+  Obviously, that's because we started from the list of triangles,
+  without any explicit information about the edges.
+  The time of this algorithm was n*m, if n is the number of triangles
+  and m the number of edges, and on 2-manifold n*3/2 = m so
+  the time is n^2. Terrible, if you take complicated shadow caster.
+
+  To make this faster, we have to know the connections inside the model:
+  that's what ManifoldEdges list is all about. It allows us to
+  implement this in time proportional to the number of edges.
+}
+
+var
+  Triangles: TTrianglesShadowCastersList;
+  Transform2: TMatrix4;
+
+  procedure RenderShadowQuad(EdgePtr: PManifoldEdge;
+    const P0Index, P1Index: Cardinal); overload;
+  var
+    V0, V1: TVector3;
+    EdgeV0, EdgeV1: PVector3;
+    TrianglePtr: PTriangle3;
+  begin
+    TrianglePtr := Triangles.Ptr(EdgePtr^.Triangles[0]);
+    EdgeV0 := @TrianglePtr^.Data[(EdgePtr^.VertexIndex + P0Index) mod 3];
+    EdgeV1 := @TrianglePtr^.Data[(EdgePtr^.VertexIndex + P1Index) mod 3];
+
+    V0 := Transform2.MultPoint(EdgeV0^);
+    V1 := Transform2.MultPoint(EdgeV1^);
+
+    {glVertexv(V0);
+    glVertexv(V1);}
+
+    {QuadCoords.FdPoint.Items.Add(V0);
+    QuadCoords.FdPoint.Items.Add(V1);
+
+    QuadCoords.FdPoint.Items.Add(ExtrudeVertex(V1, LightPos));
+    QuadCoords.FdPoint.Items.Add(ExtrudeVertex(V0, LightPos));}
+
+    if LightPos[3] <> 0 then
+    begin
+    QuadCoords.FdPoint.Items.Add(V0);
+    QuadCoords.FdPoint.Items.Add(V1);
+
+    QuadCoords.FdPoint.Items.Add(ExtrudeVertex(V1, LightPos));
+    QuadCoords.FdPoint.Items.Add(ExtrudeVertex(V0, LightPos));
+    end else
+    begin
+      TriangleCoords.FdPoint.Items.Add(V0);
+      TriangleCoords.FdPoint.Items.Add(V1);
+      TriangleCoords.FdPoint.Items.Add(Vector3(LightPos[0], LightPos[1], LightPos[2]));
+    end;
+
+    {WritelnLog('V0: ' + V0.ToString);
+    WritelnLog('V1: ' + V1.ToString);
+    WritelnLog('V1E: ' + ExtrudeVertex(V1, LightPos).ToString);
+    WritelnLog('V0E: ' + ExtrudeVertex(V0, LightPos).ToString);}
+
+    {if LightPos[3] <> 0 then
+    begin
+      glVertexv(ExtrudeVertex(V1, LightPos));
+      glVertexv(ExtrudeVertex(V0, LightPos));
+    end else
+      glVertexv(LightPos);}
+  end;
+
+  procedure RenderShadowQuad(EdgePtr: PBorderEdge;
+    const P0Index, P1Index: Cardinal); overload;
+  var
+    V0, V1: TVector3;
+    EdgeV0, EdgeV1: PVector3;
+    TrianglePtr: PTriangle3;
+  begin
+    TrianglePtr := Triangles.Ptr(EdgePtr^.TriangleIndex);
+    EdgeV0 := @TrianglePtr^.Data[(EdgePtr^.VertexIndex + P0Index) mod 3];
+    EdgeV1 := @TrianglePtr^.Data[(EdgePtr^.VertexIndex + P1Index) mod 3];
+
+    V0 := Transform2.MultPoint(EdgeV0^);
+    V1 := Transform2.MultPoint(EdgeV1^);
+
+    //glVertexv(V0);
+    //glVertexv(V1);
+
+    /// border
+    if LightPos[3] <> 0 then
+    begin
+    QuadCoords.FdPoint.Items.Add(V0);
+    QuadCoords.FdPoint.Items.Add(V1);
+
+    QuadCoords.FdPoint.Items.Add(ExtrudeVertex(V1, LightPos));
+    QuadCoords.FdPoint.Items.Add(ExtrudeVertex(V0, LightPos));
+    end else
+    begin
+      TriangleCoords.FdPoint.Items.Add(V0);
+      TriangleCoords.FdPoint.Items.Add(V1);
+      TriangleCoords.FdPoint.Items.Add(Vector3(LightPos[0], LightPos[1], LightPos[2]));
+    end;
+
+    {if LightPos[3] <> 0 then
+    begin
+      glVertexv(ExtrudeVertex(V1, LightPos));
+      glVertexv(ExtrudeVertex(V0, LightPos));
+    end else
+      glVertexv(LightPos);}
+  end;
+
+  { We initialize TrianglesPlaneSide and render caps in one step,
+    this way we have to iterate over Triangles only once, and in case
+    of PlaneSide_NotIdentity and rendering caps --- we have to transform
+    each triangle only once. }
+  procedure InitializeTrianglesPlaneSideAndRenderCaps(
+    TrianglesPlaneSide: TBooleanList;
+    LightCap, DarkCap: boolean);
+
+    procedure RenderCaps(const T: TTriangle3);
+    begin
+      if LightCap then
+      begin
+        {glVertexv(T.Data[0]);
+        glVertexv(T.Data[1]);
+        glVertexv(T.Data[2]);}
+        TriangleCoords.FdPoint.Items.Add(T.Data[0]);
+        TriangleCoords.FdPoint.Items.Add(T.Data[1]);
+        TriangleCoords.FdPoint.Items.Add(T.Data[2]);
+      end;
+
+      if DarkCap then
+      begin
+        {glVertexv(ExtrudeVertex(T.Data[2], LightPos));
+        glVertexv(ExtrudeVertex(T.Data[1], LightPos));
+        glVertexv(ExtrudeVertex(T.Data[0], LightPos));}
+        TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[2], LightPos));
+        TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[1], LightPos));
+        TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[0], LightPos));
+      end;
+    end;
+
+    function PlaneSide(const T: TTriangle3): boolean;
+    var
+      Plane: TVector4;
+      TriangleTransformed: TTriangle3;
+    begin
+      TriangleTransformed.Data[0] := Transform2.MultPoint(T.Data[0]);
+      TriangleTransformed.Data[1] := Transform2.MultPoint(T.Data[1]);
+      TriangleTransformed.Data[2] := Transform2.MultPoint(T.Data[2]);
+      Plane := TriangleTransformed.Plane;
+      Result := (Plane.Data[0] * LightPos.Data[0] +
+                 Plane.Data[1] * LightPos.Data[1] +
+                 Plane.Data[2] * LightPos.Data[2] +
+                 Plane.Data[3] * LightPos.Data[3]) > 0;
+      if Result then RenderCaps(TriangleTransformed);
+    end;
+
+    { Comments for Opaque/TransparentTrianglesBegin/End:
+
+      It's crucial to set glDepthFunc(GL_NEVER) for LightCap.
+      This way we get proper self-shadowing. Otherwise, LightCap would
+      collide in z buffer with the object itself.
+
+      Setting glDepthFunc(GL_NEVER) for DarkCap also is harmless and OK.
+      Proof: if there's anything on this pixel, then indeed the depth test
+      would fail. If the pixel is empty (nothing was rasterized there),
+      then the depth test wouldn't fail... but also, in this case value in
+      stencil buffer will not matter, it doesn't matter if this pixel
+      is in shadow or not because there's simply nothing there.
+
+      And it allows us to render both LightCap and DarkCap in one
+      GL_TRIANGLES pass, in one iteration over Triangles list, which is
+      good for speed.
+
+      Some papers propose other solution:
+        glEnable(GL_POLYGON_OFFSET_FILL);
+        glPolygonOffset(1, 1);
+      but this is no good for use, because it cannot be applied
+      to DarkCap (otherwise DarkCap in infinity (as done by ExtrudeVertex)
+      would go outside of depth range (even for infinite projection,
+      as glPolygonOffset works already after the vertex is transformed
+      by projection), and this would make DarkCap not rendered
+      (outside of depth range)).
+
+      If you consider that some shadow casters and receivers may
+      be partially transparent (that is, rendered without writing
+      to depth buffer) then the above reasoning is not so simple:
+
+      - There's no way to handle transparent
+        objects (that are not recorded in depth buffer) as shadow receivers.
+        Rendering them twice with blending would result in wrong blending
+        modes applied anyway. So TGLShadowVolumeRenderer.Render renders them
+        at the end, as last pass.
+
+        This means that "glDepthFunc(GL_NEVER) for DarkCap" is still
+        Ok: if on some pixel there was only transparent object visible,
+        then stencil value of this pixel is wrong, but transparent object
+        will never be rendered in shadowed state --- so it will not
+        look at stencil value.
+
+        For LightCap, situation is worse. Even if the transparent
+        object is only shadow caster (not receiver), still problems
+        may arise due to glDepthFunc(GL_NEVER): imagine you have
+        a transparent object casting shadow on non-transparent object
+        (see e.g. demo_models/shadow_volumes/ghost_shadow.wrl).
+        This means that you can look through the shadow casting
+        (transp) object and see shadow receiving (opaque) object,
+        that may or may not be in shadow on speciic pixel.
+        Which means that glDepthFunc(GL_NEVER) is wrong for LightCap:
+        the transparent object doesn't hide the shadow on the screen,
+        and the depth test shouldn't fail. Which means that for transparent
+        objects, we cannot do glDepthFunc(GL_NEVER).
+
+      - What to do?
+
+        The trick
+          glEnable(GL_POLYGON_OFFSET_FILL);
+          glPolygonOffset(1, 1);
+        makes light cap rendering working for both transparent and opaque
+        objects, but it's not applicable to dark cap. Moreover,
+        using glPolygonOffset always feels dirty.
+
+        Solution: we decide to handle transparent objects separately.
+        We note that for transparent shadow casters
+        actually no tweaks to caps rendering should be done.
+        No glPolygonOffset, no glDepthFunc(GL_NEVER) needed: light cap
+        should be tested as usual. (Since transparent object is not written
+        to depth buffer, it will not collide in depth buffer with it's
+        light cap).
+
+        This means that is we'll just split triangles list into
+        transparent and opaque ones, then the only complication needed
+        is to switch glDepthFunc(GL_NEVER) trick *off* for transparent
+        triangles. And all works fast.
+
+      - There's actually one more note: for transparent objects,
+        caps are always needed (even with zpass).
+        Note that this means that whole 2-manifold part must have
+        caps.
+
+        This also means that joining one 2-manifold path from some transparent
+        and some opaque triangles will not work. (as then some parts
+        may have caps (like transparent ones) and some note
+        (like opaque ones with zpass)).
+
+        TODO: implement above.
+    }
+
+    procedure OpaqueTrianglesBegin;
+    begin
+      if LightCap or DarkCap then
+      begin
+        glPushAttrib(GL_DEPTH_BUFFER_BIT); { to save glDepthFunc call below }
+        glDepthFunc(GL_NEVER);
+        glBegin(GL_TRIANGLES);
+      end;
+    end;
+
+    procedure OpaqueTrianglesEnd;
+    begin
+      if LightCap or DarkCap then
+      begin
+        glEnd;
+        glPopAttrib;
+      end;
+    end;
+
+    procedure TransparentTrianglesBegin;
+    begin
+      { Caps are always needed, doesn't depend on zpass/zfail.
+        Well, for dark cap we can avoid them if the light is directional. }
+      LightCap := true;
+      DarkCap := LightPos.Data[3] <> 0;
+
+      glBegin(GL_TRIANGLES);
+    end;
+
+    procedure TransparentTrianglesEnd;
+    begin
+      glEnd;
+    end;
+
+  var
+    TrianglePtr: PTriangle3;
+    I: Integer;
+  begin
+    TrianglesPlaneSide.Count := Triangles.Count;
+    TrianglePtr := PTriangle3(Triangles.List);
+
+    { If light is directional, no need to render dark cap }
+    DarkCap := DarkCap and (LightPos.Data[3] <> 0);
+
+    if ForceOpaque or not (TShape(FShape).AlphaChannel = acBlending) then
+      OpaqueTrianglesBegin else
+      TransparentTrianglesBegin;
+
+    for I := 0 to Triangles.Count - 1 do
+    begin
+      TrianglesPlaneSide.L[I] := PlaneSide(TrianglePtr^);
+      Inc(TrianglePtr);
+    end;
+
+    if ForceOpaque or not (TShape(FShape).AlphaChannel = acBlending) then
+      OpaqueTrianglesEnd else
+      TransparentTrianglesEnd;
+  end;
+
+var
+  I: Integer;
+  PlaneSide0, PlaneSide1: boolean;
+  TrianglesPlaneSide: TBooleanList;
+  ManifoldEdgesNow: TManifoldEdgeList;
+  ManifoldEdgePtr: PManifoldEdge;
+  BorderEdgesNow: TBorderEdgeList;
+  BorderEdgePtr: PBorderEdge;
+  Root: TX3DRootNode;
+  CoordRect: TCoordinateNode;
+  QuadSet: TQuadSetNode;
+  TriangleSet: TTriangleSetNode;
+  Shape: TShapeNode;
+  Params: TBasicRenderParams;
+  Material: TUnlitMaterialNode;
+  Material2: TMaterialNode;
+  Apperance: TAppearanceNode;
+  Matrix: TMatrix4;
+  InvMatrix: TMatrix4;
+  CameraMatrix: TMatrix4;
+begin
+  Assert(ManifoldEdges <> nil);
+
+  { if the model is not perfect 2-manifold, do not render it's shadow volumes.
+    We still have here some code to handle BorderEdges, but in practice:
+    this just has no chance to work 100% reliably with BorderEdges.
+    See demo_models/shadow_volumes/not_manifold/README.txt }
+  if BorderEdges.Count <> 0 then Exit;
+
+  Triangles := TrianglesListShadowCasters;
+
+  if SceneForShadowVolumes = nil then
+  begin
+    SceneForShadowVolumes := TCastleScene.Create(nil);
+
+    Root := TX3DRootNode.Create;
+
+    {Material := TUnlitMaterialNode.Create;
+    Material.EmissiveColor := YellowRGB;}
+
+    Material2 := TMaterialNode.Create;
+    //Material2.EmissiveColor := RedRGB;
+
+    Material2.SpecularColor := RedRGB;
+    Material2.DiffuseColor := WhiteRGB;
+
+
+    Apperance := TAppearanceNode.Create;
+    Apperance.Material := Material2;
+
+    QuadCoords := TCoordinateNode.Create;
+    {CoordRect := TCoordinateNode.Create;
+    CoordRect.SetPoint([
+        Vector3(-10.5, -10.5, 0),
+        Vector3( 10.5, -10.5, 0),
+        Vector3( 10.5,  10.5, 0),
+        Vector3(-10.5,  10.5, 0)
+    ]);}
+    QuadSet := TQuadSetNode.Create;
+    QuadSet.Coord := QuadCoords; //CoordRect;
+
+    Shape := TShapeNode.Create;
+    Shape.Geometry := QuadSet;
+    Shape.Appearance := Apperance;
+
+    Root.AddChildren(Shape);
+
+    TriangleCoords := TCoordinateNode.Create;
+
+    TriangleSet := TTriangleSetNode.Create;
+    TriangleSet.Coord := TriangleCoords;
+
+    Shape := TShapeNode.Create;
+    Shape.Geometry := TriangleSet;
+    Shape.Appearance := Apperance;
+
+    Root.AddChildren(Shape);
+
+    TCastleScene(SceneForShadowVolumes).Load(Root, true);
+  end;
+
+  TriangleCoords.FdPoint.Items.Clear;
+  QuadCoords.FdPoint.Items.Clear;
+
+  if RenderingCamera.RotationOnly then
+    CameraMatrix := RenderingCamera.RotationMatrix
+  else
+    CameraMatrix := RenderingCamera.Matrix;
+
+  //Transform2 := RenderContext.ProjectionMatrix * CameraMatrix * Transform;
+  //Transform2 := Transform * CameraMatrix * RenderContext.ProjectionMatrix;
+  Transform2 := Transform;
+
+
+  TrianglesPlaneSide := TBooleanList.Create;
+  try
+    InitializeTrianglesPlaneSideAndRenderCaps(TrianglesPlaneSide,
+      LightCap, DarkCap);
+
+    ManifoldEdgesNow := ManifoldEdges;
+    ManifoldEdgePtr := PManifoldEdge(ManifoldEdgesNow.List);
+    for I := 0 to ManifoldEdgesNow.Count - 1 do
+    begin
+      PlaneSide0 := TrianglesPlaneSide.L[ManifoldEdgePtr^.Triangles[0]];
+      PlaneSide1 := TrianglesPlaneSide.L[ManifoldEdgePtr^.Triangles[1]];
+
+      { Only if PlaneSide0 <> PlaneSide1 it's a silhouette edge,
+        so only then render it's shadow quad.
+
+        We want to have consistent CCW orientation of shadow quads faces,
+        so that face is oriented CCW <=> you're looking at it from outside
+        (i.e. it's considered front face of this shadow quad).
+        This is needed, since user of this method may want to do culling
+        to eliminate back or front faces.
+
+        TriangleDirection(T) indicates direction that goes from CCW triangle side
+        (that's guaranteed by the way TriangleDir calculates plane dir).
+        So PlaneSideX is @true if LightPos is on CCW side of appropriate
+        triangle. So if PlaneSide0 the shadow quad is extended
+        in reversed Triangles[0] order, i.e. like 1, 0, Extruded0, Extruded1.
+        Otherwise, in normal Triangles[0], i.e. 0, 1, Extruded1, Extruded0.
+
+        Just draw it, the triangle corners numbered with 0,1,2 in CCW and
+        imagine that you want the shadow quad to be also CCW on the outside,
+        it will make sense then :) }
+      if PlaneSide0 and not PlaneSide1 then
+        RenderShadowQuad(ManifoldEdgePtr, 1, 0) else
+      if PlaneSide1 and not PlaneSide0 then
+        RenderShadowQuad(ManifoldEdgePtr, 0, 1);
+
+      Inc(ManifoldEdgePtr);
+    end;
+
+  finally FreeAndNil(TrianglesPlaneSide) end;
+
+  {PushMatrix;
+
+  TrianglesPlaneSide := TBooleanList.Create;
+  try
+    InitializeTrianglesPlaneSideAndRenderCaps(TrianglesPlaneSide,
+      LightCap, DarkCap);
+
+    if LightPos[3] <> 0 then
+      glBegin(GL_QUADS) else
+      glBegin(GL_TRIANGLES);
+
+      { for each 2-manifold edge, possibly render it's shadow quad }
+      ManifoldEdgesNow := ManifoldEdges;
+      ManifoldEdgePtr := PManifoldEdge(ManifoldEdgesNow.List);
+      for I := 0 to ManifoldEdgesNow.Count - 1 do
+      begin
+        PlaneSide0 := TrianglesPlaneSide.L[ManifoldEdgePtr^.Triangles[0]];
+        PlaneSide1 := TrianglesPlaneSide.L[ManifoldEdgePtr^.Triangles[1]];
+
+        { Only if PlaneSide0 <> PlaneSide1 it's a silhouette edge,
+          so only then render it's shadow quad.
+
+          We want to have consistent CCW orientation of shadow quads faces,
+          so that face is oriented CCW <=> you're looking at it from outside
+          (i.e. it's considered front face of this shadow quad).
+          This is needed, since user of this method may want to do culling
+          to eliminate back or front faces.
+
+          TriangleDirection(T) indicates direction that goes from CCW triangle side
+          (that's guaranteed by the way TriangleDir calculates plane dir).
+          So PlaneSideX is @true if LightPos is on CCW side of appropriate
+          triangle. So if PlaneSide0 the shadow quad is extended
+          in reversed Triangles[0] order, i.e. like 1, 0, Extruded0, Extruded1.
+          Otherwise, in normal Triangles[0], i.e. 0, 1, Extruded1, Extruded0.
+
+          Just draw it, the triangle corners numbered with 0,1,2 in CCW and
+          imagine that you want the shadow quad to be also CCW on the outside,
+          it will make sense then :) }
+        if PlaneSide0 and not PlaneSide1 then
+          RenderShadowQuad(ManifoldEdgePtr, 1, 0) else
+        if PlaneSide1 and not PlaneSide0 then
+          RenderShadowQuad(ManifoldEdgePtr, 0, 1);
+
+        Inc(ManifoldEdgePtr);
+      end;
+
+      { For each border edge, always render it's shadow quad.
+        THIS CODE IS NEVER USED NOW (at the beginning of this method,
+        we exit if BorderEdges.Count <> 0). That's because rendering
+        the shadow quads from border edges doesn't solve the problem fully:
+        artifacts are still possible.
+
+        See http://http.developer.nvidia.com/GPUGems3/gpugems3_ch11.html
+        for more involved approach. Rendering shadow quads from border edges,
+        like below, is only part of the solution. }
+      BorderEdgesNow := BorderEdges;
+      BorderEdgePtr := PBorderEdge(BorderEdgesNow.List);
+      for I := 0 to BorderEdgesNow.Count - 1 do
+      begin
+        PlaneSide0 := TrianglesPlaneSide.L[BorderEdgePtr^.TriangleIndex];
+
+        { We want to have consistent CCW orientation of shadow quads faces,
+          so that face is oriented CCW <=> you're looking at it from outside
+          (i.e. it's considered front face of this shadow quad).
+          This is needed, since user of this method may want to do culling
+          to eliminate back or front faces.
+
+          TriangleDirection(T) indicates direction that goes from CCW triangle side
+          (that's guaranteed by the way TriangleDir calculates plane dir).
+          So PlaneSide0 is true if LightPos is on CCW side of appropriate
+          triangle. So if PlaneSide0, the shadow quad is extended
+          in the direction of TriangleIndex, like 1, 0, Extruded0, Extruded1. }
+        if PlaneSide0 then
+          RenderShadowQuad(BorderEdgePtr, 1, 0) else
+          RenderShadowQuad(BorderEdgePtr, 0, 1);
+
+        Inc(BorderEdgePtr);
+      end;
+
+    glEnd;
+
+  finally FreeAndNil(TrianglesPlaneSide) end;
+
+  PopMatrix;}
+
+  Params := TBasicRenderParams.Create;
+  try
+  Params.RenderingCamera := RenderingCamera;
+  Params.TransformIdentity := true;
+  Params.Frustum := @RenderingCamera.Frustum;
+  Params.Transparent := false;
+  Matrix := TMatrix4.Identity;
+  //Matrix := Transform;
+
+  //Matrix := TMatrix4.Identity * RenderContext.ProjectionMatrix * RenderingCamera.Matrix * Transform;
+  // Matrix := CameraMatrix;
+  //Matrix := Transform * RenderingCamera.Matrix * TMatrix4.Identity;
+  // Matrix := Transform;
+  //Matrix := TMatrix4.Identity;
+  Params.Transform := @Matrix;
+  //InvMatrix := Matrix.Inverse(1);
+  //Params.InverseTransform := @InvMatrix;
+  Params.ShadowVolumesReceivers := [true];
+  //TCastleScene(SceneForShadowVolumes).Transform := Transform;
+  TCastleScene(SceneForShadowVolumes).InternalIgnoreFrustum := true;
+  // TCastleScene(SceneForShadowVolumes).Save('/home/and3md/Pulpit/aha.x3dv');
+  TCastleScene(SceneForShadowVolumes).Translation := Vector3(0,0,0);
+  TCastleScene(SceneForShadowVolumes).Render(Params);
+  finally
+    FreeAndNil(Params);
+  end;
+
+{$else}
+begin
+{$endif}
+end;
+
+
+{
+// start stara
 procedure TRenderShapeShadowVolumes.RenderSilhouetteShadowVolume(
   const LightPos: TVector4;
   const Transform: TMatrix4;
@@ -191,6 +808,10 @@ var
 
     glVertexv(V0);
     glVertexv(V1);
+    WritelnLog('V0: ' + V0.ToString);
+    WritelnLog('V1: ' + V1.ToString);
+    WritelnLog('V1E: ' + ExtrudeVertex(V1, LightPos).ToString);
+    WritelnLog('V0E: ' + ExtrudeVertex(V0, LightPos).ToString);
 
     if LightPos[3] <> 0 then
     begin
@@ -522,5 +1143,5 @@ begin
 begin
 {$endif}
 end;
-
+}
 end.

--- a/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
+++ b/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
@@ -150,24 +150,7 @@ begin
   Result[2] := Original[2] -  LightPos3[2];
 
   Result.NormalizeMe;
-  Result[0] := Result[0] * 1000000;
-  Result[1] := Result[1] * 1000000;
-  Result[2] := Result[2] * 1000000;
-
-  {Original := Original +
-
-  if not TrySimplePlaneRayIntersection(Result, -1000000, 0, Original, Original -  LightPos3) then
-    raise Exception.Create('hmm');
-  if not TrySimplePlaneRayIntersection(Result,  1000000, 0, Original, Original -  LightPos3) then
-    raise Exception.Create('hmm');
-  if not TrySimplePlaneRayIntersection(Result, -1000000, 1, Original, Original -  LightPos3) then
-    raise Exception.Create('hmm');
-  if not TrySimplePlaneRayIntersection(Result,  1000000, 1, Original, Original -  LightPos3) then
-    raise Exception.Create('hmm');
-  if not TrySimplePlaneRayIntersection(Result, -1000000, 2, Original, Original -  LightPos3) then
-    raise Exception.Create('hmm');
-  if not TrySimplePlaneRayIntersection(Result,  1000000, 2, Original, Original -  LightPos3) then
-    raise Exception.Create('hmm');}
+  Result := Result * 1000000;
 end;
 
 
@@ -179,7 +162,7 @@ procedure TRenderShapeShadowVolumes.RenderSilhouetteShadowVolume(
   const LightCap, DarkCap: boolean;
   const ForceOpaque: boolean);
 
-{$ifndef OpenGLES} //TODO-es
+//{$ifndef OpenGLES} //TODO-es
 
 { Is it worth preparing ManifoldEdges list: yes.
 
@@ -210,7 +193,6 @@ procedure TRenderShapeShadowVolumes.RenderSilhouetteShadowVolume(
 
 var
   Triangles: TTrianglesShadowCastersList;
-  Transform2: TMatrix4;
 
   procedure RenderShadowQuad(EdgePtr: PManifoldEdge;
     const P0Index, P1Index: Cardinal); overload;
@@ -223,17 +205,11 @@ var
     EdgeV0 := @TrianglePtr^.Data[(EdgePtr^.VertexIndex + P0Index) mod 3];
     EdgeV1 := @TrianglePtr^.Data[(EdgePtr^.VertexIndex + P1Index) mod 3];
 
-    V0 := Transform2.MultPoint(EdgeV0^);
-    V1 := Transform2.MultPoint(EdgeV1^);
+    V0 := Transform.MultPoint(EdgeV0^);
+    V1 := Transform.MultPoint(EdgeV1^);
 
     {glVertexv(V0);
     glVertexv(V1);}
-
-    {QuadCoords.FdPoint.Items.Add(V0);
-    QuadCoords.FdPoint.Items.Add(V1);
-
-    QuadCoords.FdPoint.Items.Add(ExtrudeVertex(V1, LightPos));
-    QuadCoords.FdPoint.Items.Add(ExtrudeVertex(V0, LightPos));}
 
     if LightPos[3] <> 0 then
     begin
@@ -273,8 +249,8 @@ var
     EdgeV0 := @TrianglePtr^.Data[(EdgePtr^.VertexIndex + P0Index) mod 3];
     EdgeV1 := @TrianglePtr^.Data[(EdgePtr^.VertexIndex + P1Index) mod 3];
 
-    V0 := Transform2.MultPoint(EdgeV0^);
-    V1 := Transform2.MultPoint(EdgeV1^);
+    V0 := Transform.MultPoint(EdgeV0^);
+    V1 := Transform.MultPoint(EdgeV1^);
 
     //glVertexv(V0);
     //glVertexv(V1);
@@ -320,6 +296,11 @@ var
         TriangleCoords.FdPoint.Items.Add(T.Data[0]);
         TriangleCoords.FdPoint.Items.Add(T.Data[1]);
         TriangleCoords.FdPoint.Items.Add(T.Data[2]);
+
+        {TriangleCoords.FdPoint.Items.Add(T.Data[2]);
+        TriangleCoords.FdPoint.Items.Add(T.Data[1]);
+        TriangleCoords.FdPoint.Items.Add(T.Data[0]);}
+
       end;
 
       if DarkCap then
@@ -330,6 +311,11 @@ var
         TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[2], LightPos));
         TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[1], LightPos));
         TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[0], LightPos));
+
+        {TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[0], LightPos));
+        TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[1], LightPos));
+        TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[2], LightPos));}
+
       end;
     end;
 
@@ -338,9 +324,9 @@ var
       Plane: TVector4;
       TriangleTransformed: TTriangle3;
     begin
-      TriangleTransformed.Data[0] := Transform2.MultPoint(T.Data[0]);
-      TriangleTransformed.Data[1] := Transform2.MultPoint(T.Data[1]);
-      TriangleTransformed.Data[2] := Transform2.MultPoint(T.Data[2]);
+      TriangleTransformed.Data[0] := Transform.MultPoint(T.Data[0]);
+      TriangleTransformed.Data[1] := Transform.MultPoint(T.Data[1]);
+      TriangleTransformed.Data[2] := Transform.MultPoint(T.Data[2]);
       Plane := TriangleTransformed.Plane;
       Result := (Plane.Data[0] * LightPos.Data[0] +
                  Plane.Data[1] * LightPos.Data[1] +
@@ -444,9 +430,9 @@ var
     begin
       if LightCap or DarkCap then
       begin
-        glPushAttrib(GL_DEPTH_BUFFER_BIT); { to save glDepthFunc call below }
-        glDepthFunc(GL_NEVER);
-        glBegin(GL_TRIANGLES);
+        ///glPushAttrib(GL_DEPTH_BUFFER_BIT); { to save glDepthFunc call below }
+        ///glDepthFunc(GL_NEVER);
+        ///glBegin(GL_TRIANGLES);
       end;
     end;
 
@@ -454,8 +440,8 @@ var
     begin
       if LightCap or DarkCap then
       begin
-        glEnd;
-        glPopAttrib;
+        ///glEnd;
+        ///glPopAttrib;
       end;
     end;
 
@@ -466,12 +452,12 @@ var
       LightCap := true;
       DarkCap := LightPos.Data[3] <> 0;
 
-      glBegin(GL_TRIANGLES);
+      ///glBegin(GL_TRIANGLES);
     end;
 
     procedure TransparentTrianglesEnd;
     begin
-      glEnd;
+      ///glEnd;
     end;
 
   var
@@ -508,17 +494,13 @@ var
   BorderEdgesNow: TBorderEdgeList;
   BorderEdgePtr: PBorderEdge;
   Root: TX3DRootNode;
-  CoordRect: TCoordinateNode;
   QuadSet: TQuadSetNode;
   TriangleSet: TTriangleSetNode;
-  Shape: TShapeNode;
+  Sh: TShapeNode;
   Params: TBasicRenderParams;
-  Material: TUnlitMaterialNode;
-  Material2: TMaterialNode;
+  Material: TMaterialNode;
   Apperance: TAppearanceNode;
   Matrix: TMatrix4;
-  InvMatrix: TMatrix4;
-  CameraMatrix: TMatrix4;
 begin
   Assert(ManifoldEdges <> nil);
 
@@ -536,62 +518,40 @@ begin
 
     Root := TX3DRootNode.Create;
 
-    {Material := TUnlitMaterialNode.Create;
-    Material.EmissiveColor := YellowRGB;}
-
-    Material2 := TMaterialNode.Create;
-    //Material2.EmissiveColor := RedRGB;
-
-    Material2.SpecularColor := RedRGB;
-    Material2.DiffuseColor := WhiteRGB;
-
+    Material := TMaterialNode.Create;
+    Material.EmissiveColor := RedRGB;
 
     Apperance := TAppearanceNode.Create;
-    Apperance.Material := Material2;
+    Apperance.Material := Material;
 
     QuadCoords := TCoordinateNode.Create;
-    {CoordRect := TCoordinateNode.Create;
-    CoordRect.SetPoint([
-        Vector3(-10.5, -10.5, 0),
-        Vector3( 10.5, -10.5, 0),
-        Vector3( 10.5,  10.5, 0),
-        Vector3(-10.5,  10.5, 0)
-    ]);}
     QuadSet := TQuadSetNode.Create;
-    QuadSet.Coord := QuadCoords; //CoordRect;
+    QuadSet.Solid := false;
+    QuadSet.Coord := QuadCoords;
 
-    Shape := TShapeNode.Create;
-    Shape.Geometry := QuadSet;
-    Shape.Appearance := Apperance;
+    Sh := TShapeNode.Create;
+    Sh.Geometry := QuadSet;
+    Sh.Appearance := Apperance;
 
-    Root.AddChildren(Shape);
+    Root.AddChildren(Sh);
 
     TriangleCoords := TCoordinateNode.Create;
 
     TriangleSet := TTriangleSetNode.Create;
+    TriangleSet.Solid := false;
     TriangleSet.Coord := TriangleCoords;
 
-    Shape := TShapeNode.Create;
-    Shape.Geometry := TriangleSet;
-    Shape.Appearance := Apperance;
+    Sh := TShapeNode.Create;
+    Sh.Geometry := TriangleSet;
+    Sh.Appearance := Apperance;
 
-    Root.AddChildren(Shape);
+    Root.AddChildren(Sh);
 
     TCastleScene(SceneForShadowVolumes).Load(Root, true);
   end;
 
   TriangleCoords.FdPoint.Items.Clear;
   QuadCoords.FdPoint.Items.Clear;
-
-  if RenderingCamera.RotationOnly then
-    CameraMatrix := RenderingCamera.RotationMatrix
-  else
-    CameraMatrix := RenderingCamera.Matrix;
-
-  //Transform2 := RenderContext.ProjectionMatrix * CameraMatrix * Transform;
-  //Transform2 := Transform * CameraMatrix * RenderContext.ProjectionMatrix;
-  Transform2 := Transform;
-
 
   TrianglesPlaneSide := TBooleanList.Create;
   try
@@ -634,121 +594,22 @@ begin
 
   finally FreeAndNil(TrianglesPlaneSide) end;
 
-  {PushMatrix;
-
-  TrianglesPlaneSide := TBooleanList.Create;
-  try
-    InitializeTrianglesPlaneSideAndRenderCaps(TrianglesPlaneSide,
-      LightCap, DarkCap);
-
-    if LightPos[3] <> 0 then
-      glBegin(GL_QUADS) else
-      glBegin(GL_TRIANGLES);
-
-      { for each 2-manifold edge, possibly render it's shadow quad }
-      ManifoldEdgesNow := ManifoldEdges;
-      ManifoldEdgePtr := PManifoldEdge(ManifoldEdgesNow.List);
-      for I := 0 to ManifoldEdgesNow.Count - 1 do
-      begin
-        PlaneSide0 := TrianglesPlaneSide.L[ManifoldEdgePtr^.Triangles[0]];
-        PlaneSide1 := TrianglesPlaneSide.L[ManifoldEdgePtr^.Triangles[1]];
-
-        { Only if PlaneSide0 <> PlaneSide1 it's a silhouette edge,
-          so only then render it's shadow quad.
-
-          We want to have consistent CCW orientation of shadow quads faces,
-          so that face is oriented CCW <=> you're looking at it from outside
-          (i.e. it's considered front face of this shadow quad).
-          This is needed, since user of this method may want to do culling
-          to eliminate back or front faces.
-
-          TriangleDirection(T) indicates direction that goes from CCW triangle side
-          (that's guaranteed by the way TriangleDir calculates plane dir).
-          So PlaneSideX is @true if LightPos is on CCW side of appropriate
-          triangle. So if PlaneSide0 the shadow quad is extended
-          in reversed Triangles[0] order, i.e. like 1, 0, Extruded0, Extruded1.
-          Otherwise, in normal Triangles[0], i.e. 0, 1, Extruded1, Extruded0.
-
-          Just draw it, the triangle corners numbered with 0,1,2 in CCW and
-          imagine that you want the shadow quad to be also CCW on the outside,
-          it will make sense then :) }
-        if PlaneSide0 and not PlaneSide1 then
-          RenderShadowQuad(ManifoldEdgePtr, 1, 0) else
-        if PlaneSide1 and not PlaneSide0 then
-          RenderShadowQuad(ManifoldEdgePtr, 0, 1);
-
-        Inc(ManifoldEdgePtr);
-      end;
-
-      { For each border edge, always render it's shadow quad.
-        THIS CODE IS NEVER USED NOW (at the beginning of this method,
-        we exit if BorderEdges.Count <> 0). That's because rendering
-        the shadow quads from border edges doesn't solve the problem fully:
-        artifacts are still possible.
-
-        See http://http.developer.nvidia.com/GPUGems3/gpugems3_ch11.html
-        for more involved approach. Rendering shadow quads from border edges,
-        like below, is only part of the solution. }
-      BorderEdgesNow := BorderEdges;
-      BorderEdgePtr := PBorderEdge(BorderEdgesNow.List);
-      for I := 0 to BorderEdgesNow.Count - 1 do
-      begin
-        PlaneSide0 := TrianglesPlaneSide.L[BorderEdgePtr^.TriangleIndex];
-
-        { We want to have consistent CCW orientation of shadow quads faces,
-          so that face is oriented CCW <=> you're looking at it from outside
-          (i.e. it's considered front face of this shadow quad).
-          This is needed, since user of this method may want to do culling
-          to eliminate back or front faces.
-
-          TriangleDirection(T) indicates direction that goes from CCW triangle side
-          (that's guaranteed by the way TriangleDir calculates plane dir).
-          So PlaneSide0 is true if LightPos is on CCW side of appropriate
-          triangle. So if PlaneSide0, the shadow quad is extended
-          in the direction of TriangleIndex, like 1, 0, Extruded0, Extruded1. }
-        if PlaneSide0 then
-          RenderShadowQuad(BorderEdgePtr, 1, 0) else
-          RenderShadowQuad(BorderEdgePtr, 0, 1);
-
-        Inc(BorderEdgePtr);
-      end;
-
-    glEnd;
-
-  finally FreeAndNil(TrianglesPlaneSide) end;
-
-  PopMatrix;}
+  TriangleCoords.FdPoint.Changed;
+  QuadCoords.FdPoint.Changed;
 
   Params := TBasicRenderParams.Create;
   try
   Params.RenderingCamera := RenderingCamera;
   Params.TransformIdentity := true;
-  Params.Frustum := @RenderingCamera.Frustum;
   Params.Transparent := false;
   Matrix := TMatrix4.Identity;
-  //Matrix := Transform;
-
-  //Matrix := TMatrix4.Identity * RenderContext.ProjectionMatrix * RenderingCamera.Matrix * Transform;
-  // Matrix := CameraMatrix;
-  //Matrix := Transform * RenderingCamera.Matrix * TMatrix4.Identity;
-  // Matrix := Transform;
-  //Matrix := TMatrix4.Identity;
   Params.Transform := @Matrix;
-  //InvMatrix := Matrix.Inverse(1);
-  //Params.InverseTransform := @InvMatrix;
   Params.ShadowVolumesReceivers := [true];
-  //TCastleScene(SceneForShadowVolumes).Transform := Transform;
   TCastleScene(SceneForShadowVolumes).InternalIgnoreFrustum := true;
-  // TCastleScene(SceneForShadowVolumes).Save('/home/and3md/Pulpit/aha.x3dv');
-  TCastleScene(SceneForShadowVolumes).Translation := Vector3(0,0,0);
   TCastleScene(SceneForShadowVolumes).Render(Params);
   finally
     FreeAndNil(Params);
   end;
-
-{$else}
-begin
-{$endif}
 end;
 
 
@@ -808,10 +669,10 @@ var
 
     glVertexv(V0);
     glVertexv(V1);
-    WritelnLog('V0: ' + V0.ToString);
+    {WritelnLog('V0: ' + V0.ToString);
     WritelnLog('V1: ' + V1.ToString);
     WritelnLog('V1E: ' + ExtrudeVertex(V1, LightPos).ToString);
-    WritelnLog('V0E: ' + ExtrudeVertex(V0, LightPos).ToString);
+    WritelnLog('V0E: ' + ExtrudeVertex(V0, LightPos).ToString);}
 
     if LightPos[3] <> 0 then
     begin
@@ -1144,4 +1005,5 @@ begin
 {$endif}
 end;
 }
+
 end.

--- a/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
+++ b/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
@@ -632,15 +632,13 @@ begin
     Matrix := TMatrix4.Identity;
     Params.Transform := @Matrix;
     Params.ShadowVolumesReceivers := [true];
-    //Params.;
-
 
     //RenderContext.DepthFunc := dfNever;
     glEnable(GL_POLYGON_OFFSET_FILL);
     glPolygonOffset(1, 1);
     TCastleScene(SceneDepthNever).Render(Params);
     glDisable(GL_POLYGON_OFFSET_FILL);
-    RenderContext.DepthFunc := dfLessEqual;
+    //RenderContext.DepthFunc := dfLessEqual;
     TCastleScene(SceneForShadowVolumes).Render(Params);
   finally
     FreeAndNil(Params);

--- a/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
+++ b/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
@@ -279,33 +279,25 @@ var
           TriangleCoordsDepthNever.FdPoint.Items.Add(T.Data[2]);
         end else
         begin
-          TriangleCoordsDepthOK.FdPoint.Items.Add(T.Data[0]);
-          TriangleCoordsDepthOK.FdPoint.Items.Add(T.Data[1]);
-          TriangleCoordsDepthOK.FdPoint.Items.Add(T.Data[2]);
-
-          {TriangleCoords.FdPoint.Items.Add(T.Data[0]);
+          TriangleCoords.FdPoint.Items.Add(T.Data[0]);
           TriangleCoords.FdPoint.Items.Add(T.Data[1]);
-          TriangleCoords.FdPoint.Items.Add(T.Data[2]);}
+          TriangleCoords.FdPoint.Items.Add(T.Data[2]);
         end;
       end;
 
       if DarkCap then
       begin
-        if DepthNever then
+        {if DepthNever then
         begin
           TriangleCoordsDepthNever.FdPoint.Items.Add(ExtrudeVertex(T.Data[2], LightPos));
           TriangleCoordsDepthNever.FdPoint.Items.Add(ExtrudeVertex(T.Data[1], LightPos));
           TriangleCoordsDepthNever.FdPoint.Items.Add(ExtrudeVertex(T.Data[0], LightPos));
         end
-        else
+        else}
           begin
-            TriangleCoordsDepthOK.FdPoint.Items.Add(ExtrudeVertex(T.Data[2], LightPos));
-            TriangleCoordsDepthOK.FdPoint.Items.Add(ExtrudeVertex(T.Data[1], LightPos));
-            TriangleCoordsDepthOK.FdPoint.Items.Add(ExtrudeVertex(T.Data[0], LightPos));
-
-            {TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[2], LightPos));
+            TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[2], LightPos));
             TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[1], LightPos));
-            TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[0], LightPos));}
+            TriangleCoords.FdPoint.Items.Add(ExtrudeVertex(T.Data[0], LightPos));
           end;
       end;
     end;
@@ -540,34 +532,6 @@ var
       TCastleScene(SceneDepthNever).Load(RootNode, true);
     end;
 
-    if SceneDepthOK = nil then
-    begin
-      SceneDepthOK := TCastleScene.Create(nil);
-
-      RootNode := TX3DRootNode.Create;
-
-      MaterialNode := TMaterialNode.Create;
-      MaterialNode.EmissiveColor := RedRGB;
-
-      ApperanceNode := TAppearanceNode.Create;
-      ApperanceNode.Material := MaterialNode;
-
-      TriangleCoordsDepthOK := TCoordinateNode.Create;
-
-      TriangleSetNode := TTriangleSetNode.Create;
-      TriangleSetNode.Solid := false;
-      TriangleSetNode.Coord := TriangleCoordsDepthOK;
-
-      ShapeNode := TShapeNode.Create;
-      ShapeNode.Geometry := TriangleSetNode;
-      ShapeNode.Appearance := ApperanceNode;
-
-      RootNode.AddChildren(ShapeNode);
-
-      TCastleScene(SceneDepthOK).Load(RootNode, true);
-    end;
-
-
   end;
 
   procedure ClearInternalScenes;
@@ -575,7 +539,6 @@ var
     TriangleCoordsDepthNever.FdPoint.Items.Clear;
     TriangleCoords.FdPoint.Items.Clear;
     QuadCoords.FdPoint.Items.Clear;
-    TriangleCoordsDepthOK.FdPoint.Items.Clear;
   end;
 
   procedure UpdateInternalScenes;
@@ -583,7 +546,6 @@ var
     TriangleCoordsDepthNever.FdPoint.Changed;
     TriangleCoords.FdPoint.Changed;
     QuadCoords.FdPoint.Changed;
-    TriangleCoordsDepthOK.FdPoint.Changed;
   end;
 
 var
@@ -678,9 +640,7 @@ begin
     glPolygonOffset(1, 1);
     TCastleScene(SceneDepthNever).Render(Params);
     glDisable(GL_POLYGON_OFFSET_FILL);
-    TCastleScene(SceneDepthOK).Render(Params);
     RenderContext.DepthFunc := dfLessEqual;
-    //
     TCastleScene(SceneForShadowVolumes).Render(Params);
   finally
     FreeAndNil(Params);

--- a/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
+++ b/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
@@ -599,14 +599,13 @@ begin
 
   Params := TBasicRenderParams.Create;
   try
-  Params.RenderingCamera := RenderingCamera;
-  Params.TransformIdentity := true;
-  Params.Transparent := false;
-  Matrix := TMatrix4.Identity;
-  Params.Transform := @Matrix;
-  Params.ShadowVolumesReceivers := [true];
-  TCastleScene(SceneForShadowVolumes).InternalIgnoreFrustum := true;
-  TCastleScene(SceneForShadowVolumes).Render(Params);
+    Params.RenderingCamera := RenderingCamera;
+    Params.TransformIdentity := true;
+    Params.Transparent := false;
+    Matrix := TMatrix4.Identity;
+    Params.Transform := @Matrix;
+    Params.ShadowVolumesReceivers := [true];
+    TCastleScene(SceneForShadowVolumes).Render(Params);
   finally
     FreeAndNil(Params);
   end;

--- a/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
+++ b/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
@@ -201,7 +201,7 @@ var
   procedure RenderShadowQuad(EdgePtr: PManifoldEdge;
     const P0Index, P1Index: Cardinal); overload;
   var
-    V0, V1: TVector3;
+    V0, V1, DirectionalLight: TVector3;
     EdgeV0, EdgeV1: PVector3;
     TrianglePtr: PTriangle3;
   begin
@@ -223,7 +223,11 @@ var
     begin
       TriangleCoords.FdPoint.Items.Add(V0);
       TriangleCoords.FdPoint.Items.Add(V1);
-      TriangleCoords.FdPoint.Items.Add(Vector3(LightPos[0], LightPos[1], LightPos[2]));
+      // When we will have 4 coordinates support we can do simply:
+      // TriangleCoords.FdPoint.Items.Add(LightPos);
+      DirectionalLight := Vector3(LightPos[0], LightPos[1], LightPos[2]);
+      DirectionalLight.NormalizeMe;
+      TriangleCoords.FdPoint.Items.Add(DirectionalLight * 1000000);
     end;
   end;
 

--- a/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
+++ b/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
@@ -666,6 +666,12 @@ begin
     See demo_models/shadow_volumes/not_manifold/README.txt }
   if BorderEdges.Count <> 0 then Exit;
 
+  // InternalUpdateShadowVolumes := false;
+  if (InternalShadowVolumesUseDepth = true) or
+     (InternalUpdateShadowVolumes = true) or
+     (SceneForShadowVolumes = nil) then
+  begin
+
   Triangles := TrianglesListShadowCasters;
 
   InitializeInternalScenes;
@@ -714,6 +720,8 @@ begin
   finally FreeAndNil(TrianglesPlaneSide) end;
 
   UpdateInternalScenes;
+
+  end;
 
   Params := TBasicRenderParams.Create;
   try

--- a/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
+++ b/src/x3d/opengl/castleshapeinternalrendershadowvolumes.pas
@@ -79,6 +79,7 @@ uses SysUtils,
   {$ifdef CASTLE_OBJFPC} CastleGL, {$else} GL, GLExt, {$endif}
   CastleRenderingCamera, CastleGLUtils, CastleUtils, CastleScene, CastleShapes,
   CastleImages, CastleRenderContext, CastleColors, CastleInternalGLShadowVolumes,
+  CastleRenderOptions,
   X3DNodes;
 {$warnings on}
 
@@ -594,6 +595,12 @@ var
       RootNode.AddChildren(ShapeNode);
 
       TCastleScene(SceneForShadowVolumes).Load(RootNode, true);
+      TCastleScene(SceneForShadowVolumes).RenderOptions.Mode := rmDepth;
+      TCastleScene(SceneForShadowVolumes).ShapeFrustumCulling := false;
+      TCastleScene(SceneForShadowVolumes).Spatial := [];
+      TCastleScene(SceneForShadowVolumes).SceneFrustumCulling := false;
+      TCastleScene(SceneForShadowVolumes).ShadowMaps := false;
+      TCastleScene(SceneForShadowVolumes).InternalIgnoreFrustum := true;
     end;
 
     if SceneForShadowVolumesCups = nil then
@@ -621,6 +628,12 @@ var
       RootNode.AddChildren(ShapeNode);
 
       TCastleScene(SceneForShadowVolumesCups).Load(RootNode, true);
+      TCastleScene(SceneForShadowVolumesCups).RenderOptions.Mode := rmDepth;
+      TCastleScene(SceneForShadowVolumesCups).ShapeFrustumCulling := false;
+      TCastleScene(SceneForShadowVolumesCups).Spatial := [];
+      TCastleScene(SceneForShadowVolumesCups).SceneFrustumCulling := false;
+      TCastleScene(SceneForShadowVolumesCups).ShadowMaps := false;
+      TCastleScene(SceneForShadowVolumesCups).InternalIgnoreFrustum := true;
     end;
 
   end;


### PR DESCRIPTION
This PR adds new shadow volumes algorithms compatible wit OpenGL ES (works on mobile phones). Don't merge it now to master (a lot of code duplication for testing). 

### Current state
We have now four algorithms for testing:
* old fixed OpenGL algorithm - set `InternalUseOldShadowVolumes := true` to use it 
* new internal scene based with GL_POLYGON_OFFSET_FILL - set `InternalUseOldShadowVolumes` and `InternalShadowVolumesUseDepth` to `false`
* new internal scene based with DEPTH approach in cups (V1) - renders cups in `OpaqueTrianglesEnd` or `TransparentTrianglesEnd` (set `InternalUseOldShadowVolumes` and `InternalShadowVolumesUseDepthV2` to `false` and `InternalShadowVolumesUseDepth` to `true`)
* new internal scene based with DEPTH approach in cups (V2) - renders cups in one place - end of `RenderSilhouetteShadowVolume` (set `InternalUseOldShadowVolumes` to `false` and `InternalShadowVolumesUseDepth` and `InternalShadowVolumesUseDepthV2` to `true`)

I think internal scene based with DEPTH approach in cups (V2) is the most promising.

### Algorithms correctness
All algorithms works the same (shadows are the same), with our example models but test that please.

### Speed
In base scenario internal scene based algorithm is slower than the old one. It can be faster when we set `TCastleViewport.InternalShadowVolumeUpdateFactor` to value bigger than 0 (0 = update every frame). What makes shadows are updated less frequently than every frame. New algorithm works faster **on desktop** when there are more objects and update factor > 0. On mobile rendering slows down the most. 

I think old algorithm is faster because graphic card driver can buffer `glVertex` calls more efficiently (maybe in one VBO) than we switching our VBO it on every internal castle scene. Or maybe that's because we have two scenes per shape.

So we need find a way to speed up internal scenes or maybe we should make only two "global" internal scenes (or internal scenes per `TCastleScene`) not scenes for each shape. 

So there are two things to optimize:
1. Creating and updating internal scenes for shadow volumes - once we have internal scenes we can update shadows less frequently
2. Internal scenes rendering - we need choose direction how to optimize that ;)

### How to test?
* View3DScene with more shadow volumes settings: https://github.com/castle-engine/view3dscene/tree/shadow_volumes_testing 
* Test project for shadow volumes: https://github.com/and3md/testsh

![obraz](https://user-images.githubusercontent.com/18555708/123758029-d42c7000-d8be-11eb-916b-ac5ce30480ad.png)

### TGLShadowVolumeRenderer.Render testing
It also can be tested, when `InternalShadowVolumesOldRender` is `true` there is the old render with `glPushAttrib()`/`glPushAttrib()`

### Code style
Code has a lot duplications but will be cleaned after testing/choose new solution.