### PR TITLE
Quick patches: Load color property + fix typo in type name (rel. to Tiled maps)

### DIFF
--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -85,7 +85,7 @@ type
 
       TObjectsDrawOrder = (odoIndex, odoTopDown);
 
-      TTileObjectPrimitive = (topRectangle, topPoint, topEllipse, topPolygon,
+      TTiledObjectPrimitive = (topRectangle, topPoint, topEllipse, topPolygon,
         topPolyLine);
 
       { Object definition. }

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -833,6 +833,10 @@ begin
   Visible := True;
   OffsetX := 0;
   OffsetY := 0;
+  if Element.AttributeString('color', TmpStr) then
+    Color := TiledToColorRGB(TmpStr)
+  else
+    Color := BlackRGB; // Default layer color in Tiled editor if no color is set.
   Name := Element.AttributeStringDef('name', '');
   if Element.AttributeString('opacity', TmpStr) then
     Opacity := StrToFloatDot(TmpStr);


### PR DESCRIPTION
Patch 1) Set color property on loading of Tiled maps.
Patch 2) Fix typo in type name of Tiled object primitives.