### PR TITLE
Android app bundle

### DIFF
--- a/tools/build-tool/code/toolandroid.pas
+++ b/tools/build-tool/code/toolandroid.pas
@@ -635,7 +635,7 @@ var
   end;
 
 var
-  ApkName: string;
+  PackageName: string;
   PackageMode: TCompilationMode;
 begin
   { calculate clean AndroidProjectPath }
@@ -660,34 +660,34 @@ begin
   case PackageFormat of
     pfAndroidApk:
       begin
-        ApkName := Project.Name + '-' + PackageModeToName[PackageMode] + '.apk';
+        PackageName := Project.Name + '-' + PackageModeToName[PackageMode] + '.apk';
         CheckRenameFile(AndroidProjectPath + 'app' + PathDelim +
           'build' +  PathDelim +
           'outputs' + PathDelim +
           'apk' + PathDelim +
           PackageModeToName[PackageMode] + PathDelim +
           'app-' + PackageModeToName[PackageMode] + '.apk',
-          Project.OutputPath + ApkName);
+          Project.OutputPath + PackageName);
       end;
     pfAndroidAppBundle:
       begin
-        ApkName := Project.Name + '-' + PackageModeToName[PackageMode] + '.aab';
+        PackageName := Project.Name + '-' + PackageModeToName[PackageMode] + '.aab';
         CheckRenameFile(AndroidProjectPath + 'app' + PathDelim +
           'build' +  PathDelim +
           'outputs' + PathDelim +
           'bundle' + PathDelim +
           PackageModeToName[PackageMode] + PathDelim +
           'app-' + PackageModeToName[PackageMode] + '.aab',
-          Project.OutputPath + ApkName);
+          Project.OutputPath + PackageName);
         {$IFDEF UNIX}
-        Writeln('FpChmod = ' + FpChmod(Project.OutputPath + ApkName, &777).ToString);
+        Writeln('FpChmod = ' + FpChmod(Project.OutputPath + PackageName, &777).ToString);
         {$ENDIF}
       end;
     else
       raise Exception.Create('Unexpected PackageFormat in PackageAndroid: ' + PackageFormatToString(PackageFormat));
   end;
 
-  Writeln('Build ' + ApkName);
+  Writeln('Build ' + PackageName);
 end;
 
 procedure InstallAndroid(const Name, QualifiedName, OutputPath: string);

--- a/tools/build-tool/code/toolandroid.pas
+++ b/tools/build-tool/code/toolandroid.pas
@@ -581,7 +581,7 @@ var
         pfAndroidApk:
           Args.Add('assemble' + Capitalize(PackageModeToName[PackageMode]));
         pfAndroidAppBundle:
-          Args.Add(':app:bundleDebug');
+          Args.Add(':app:bundle' + Capitalize(PackageModeToName[PackageMode]));
         else
           raise Exception.Create('Unexpected PackageFormat in PackageAndroid: ' + PackageFormatToString(PackageFormat));
       end;
@@ -672,7 +672,12 @@ begin
     pfAndroidAppBundle:
       begin
         ApkName := Project.Name + '-' + PackageModeToName[PackageMode] + '.aab';
-        CheckRenameFile(AndroidProjectPath + 'app/build/outputs/bundle/debug/app-debug.aab',
+        CheckRenameFile(AndroidProjectPath + 'app' + PathDelim +
+          'build' +  PathDelim +
+          'outputs' + PathDelim +
+          'bundle' + PathDelim +
+          PackageModeToName[PackageMode] + PathDelim +
+          'app-' + PackageModeToName[PackageMode] + '.aab',
           Project.OutputPath + ApkName);
         Writeln('FpChmod = ' + FpChmod(Project.OutputPath + ApkName, &777).ToString);
       end;

--- a/tools/build-tool/code/toolandroid.pas
+++ b/tools/build-tool/code/toolandroid.pas
@@ -679,7 +679,9 @@ begin
           PackageModeToName[PackageMode] + PathDelim +
           'app-' + PackageModeToName[PackageMode] + '.aab',
           Project.OutputPath + ApkName);
+        {$IFDEF UNIX}
         Writeln('FpChmod = ' + FpChmod(Project.OutputPath + ApkName, &777).ToString);
+        {$ENDIF}
       end;
     else
       raise Exception.Create('Unexpected PackageFormat in PackageAndroid: ' + PackageFormatToString(PackageFormat));

--- a/tools/build-tool/code/toolandroid.pas
+++ b/tools/build-tool/code/toolandroid.pas
@@ -674,7 +674,7 @@ begin
         ApkName := Project.Name + '-' + PackageModeToName[PackageMode] + '.aab';
         CheckRenameFile(AndroidProjectPath + 'app/build/outputs/bundle/debug/app-debug.aab',
           Project.OutputPath + ApkName);
-        Writeln('FpChmod = ' + FpChmod(Project.OutputPath + ApkName, 777).ToString);
+        Writeln('FpChmod = ' + FpChmod(Project.OutputPath + ApkName, &777).ToString);
       end;
     else
       raise Exception.Create('Unexpected PackageFormat in PackageAndroid: ' + PackageFormatToString(PackageFormat));

--- a/tools/build-tool/code/toolandroid.pas
+++ b/tools/build-tool/code/toolandroid.pas
@@ -47,7 +47,7 @@ procedure RunAndroid(const Project: TCastleProject);
 
 implementation
 
-uses SysUtils, DOM, XMLWrite,
+uses SysUtils, DOM, XMLWrite, BaseUnix,
   CastleURIUtils, CastleXMLUtils, CastleLog, CastleFilesUtils, CastleImages,
   ToolEmbeddedImages, ToolFPCVersion, ToolPackage, ToolCommonUtils, ToolUtils,
   ToolManifest;
@@ -575,7 +575,8 @@ var
   begin
     Args := TCastleStringList.Create;
     try
-      Args.Add('assemble' + Capitalize(PackageModeToName[PackageMode]));
+      Args.Add(':app:bundleDebug');
+      //Args.Add('assemble' + Capitalize(PackageModeToName[PackageMode]));
       if not Verbose then
         Args.Add('--quiet');
       if PackageMode <> cmDebug then
@@ -648,7 +649,7 @@ begin
   RunNdkBuild;
   RunGradle(PackageMode);
 
-  ApkName := Project.Name + '-' + PackageModeToName[PackageMode] + '.apk';
+  {ApkName := Project.Name + '-' + PackageModeToName[PackageMode] + '.apk';
   CheckRenameFile(AndroidProjectPath + 'app' + PathDelim +
     'build' +  PathDelim +
     'outputs' + PathDelim +
@@ -656,6 +657,13 @@ begin
     PackageModeToName[PackageMode] + PathDelim +
     'app-' + PackageModeToName[PackageMode] + '.apk',
     Project.OutputPath + ApkName);
+
+  Writeln('Build ' + ApkName);}
+
+  ApkName := Project.Name + '-' + PackageModeToName[PackageMode] + '.aab';
+  CheckRenameFile(AndroidProjectPath + 'app/build/outputs/bundle/debug/app-debug.aab',
+    Project.OutputPath + ApkName);
+  Writeln(FpChmod(Project.OutputPath + ApkName, 777));
 
   Writeln('Build ' + ApkName);
 end;

--- a/tools/build-tool/code/toolpackage.pas
+++ b/tools/build-tool/code/toolpackage.pas
@@ -28,6 +28,8 @@ type
     pfDirectory,
     pfZip,
     pfTarGz,
+    pfAndroidApk,
+    pfAndroidAppBundle,
     pfIosArchiveDevelopment,
     pfIosArchiveAdHoc,
     pfIosArchiveAppStore
@@ -232,6 +234,8 @@ const
     'directory',
     'zip',
     'targz',
+    'android-apk',
+    'android-app-bundle',
     'ios-archive-development',
     'ios-archive-ad-hoc',
     'ios-archive-app-store'

--- a/tools/build-tool/code/toolproject.pas
+++ b/tools/build-tool/code/toolproject.pas
@@ -718,19 +718,28 @@ begin
     Exit;
   end;
 
+  { for Android, the packaging process is special }
+  if (Target = targetAndroid) or (OS = Android) then
+  begin
+    if (PackageFormat = pfDefault) then
+      PackageFormatFinal := pfAndroidApk
+    else
+      PackageFormatFinal := PackageFormat;
+    if not (PackageFormatFinal in [pfAndroidApk, pfAndroidAppBundle]) then
+      raise Exception.Create('Trying to package for Android, but package format is ' +
+        PackageFormatToString(PackageFormatFinal) + '. Expected: ' +
+        PackageFormatToString(pfAndroidApk) + ' or ' +
+        PackageFormatToString(pfAndroidAppBundle) + '.');
+    if Target = targetAndroid then
+      AndroidCPUS := DetectAndroidCPUS
+    else
+      AndroidCPUS := [CPU];
+    PackageAndroid(Self, OS, AndroidCPUS, Mode, PackageFormatFinal);
+    Exit;
+  end;
+
   if PackageFormat = pfDefault then
   begin
-    { for Android, the packaging process is special }
-    if (Target = targetAndroid) or (OS = Android) then
-    begin
-      if Target = targetAndroid then
-        AndroidCPUS := DetectAndroidCPUS
-      else
-        AndroidCPUS := [CPU];
-      PackageAndroid(Self, OS, AndroidCPUS, Mode);
-      Exit;
-    end;
-
     { for Nintendo Switch, the packaging process is special }
     if Target = targetNintendoSwitch then
     begin


### PR DESCRIPTION
Generating Android App Bundle for Google Play Store.

As in

* `--package-format=default` (will generate `android-apk`)
* `--package-format=android-apk`
* `--package-format=android-app-bundle`

Tested and generates a proper signature key.

Note: It **does not use resources**, the internal structure of the project remains the same as it was before, when only APK was generated. Google guidelines suggest that different resources should be packaged for different devices (e.g. different images sizes for different screen resolutions, or different strings for different device localizations)