### PR TITLE
Tiled: Populate tile list of tilesets correctly + Load from more than 1 tileset correctly

### DIFF
--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -978,6 +978,41 @@ procedure TTiledMap.TTileset.Load(const Element: TDOMElement; const BaseUrl: Str
     end;
   end;
 
+  { Generate complete tileset tiles list (Tileset.Tiles).
+    Should only be called if not all tiles are found in the tsx-file! }
+  procedure GenerateCompleteTileList(ATileset: TTileset);
+  var
+    NewTile, Tile: TTile;
+    IncompleteTileList: TTileList;
+    Index: Cardinal;
+  begin
+    { "Copy" old, incomplete tile list and create a new one for the tileset. }
+    IncompleteTileList := ATileset.Tiles;
+    ATileset.Tiles := nil;
+    ATileset.Tiles := TTileList.Create;
+    IncompleteTileList.OwnsObjects := False;
+
+    { Create for every "missing" tile a new tile and add it to tile list. }
+    for Index := 0 to ATileset.TileCount - IncompleteTileList.Count - 1 do
+    begin
+      NewTile := TTile.Create;
+      NewTile.Id := Index;
+      ATileset.Tiles.Add(NewTile);
+    end;
+
+    { Insert all existing tiles (if any) from the iincomplete tile list
+      at the correct position (Tile.Id corresponds to item index). }
+    for Tile in IncompleteTileList do
+      ATileset.Tiles.Insert(Tile.Id, Tile);
+
+    { Give all tiles the correct id. This is esp. important for the new
+      tiles, as they have no id set on creation. }
+    for Index := 0 to ATileset.TileCount - 1 do
+      (ATileset.Tiles.Items[Index] as TTile).Id := Index;
+
+    FreeAndNil(IncompleteTileList);
+  end;
+
 var
   I: TXMLElementIterator;
   NewTile: TTile;
@@ -1044,18 +1079,28 @@ begin
     TileCount := (Image.Width div TileWidth) * (Image.Height div TileHeight);
   end;
 
-  { TODO : Handle tiles which are not explicitly found in the tsx-file.
-    Hint : Tiles which have no special setting (probability equals 1.0,
-           no terrains set, no type set) are not explicitly written down
-           in the tsx file. This means they are not loaded by the iteration
-           above and consequently are not found in the Tiles list. }
   if TileCount <> Tiles.Count then
+  { Hint 1: Tiles which have no special setting (probability equals 1.0,
+            no terrains set, no type set) are not explicitly written down
+            in the tsx-file (like "<tile id="0" ... />").
+            This means they are not loaded by the iteration above
+            and consequently are not found in the tiles list of the tileset.
+            (This means Tiles.Count is smaller than TileCount!)
+
+    Hint 2: This does not affect loading/displaying via TCastleTiledMapControl
+            because this control class determines the tiles from tilesets
+            solely by width/height/column/row-calculations.
+
+    Hint 3: A complete tile list is necessary for X3D loading. (To come)
+            Also, developers can expect to find all tiles in this list. }
   begin
-    WritelnWarning('%s: Could not load all tiles of a tileset. Expected tiles: %d, loaded tiles: %d', [
+    WritelnLog('%s: Could not load all tiles of a tileset. Expected tiles: %d, loaded tiles: %d', [
       URIDisplay(URL),
       TileCount,
       Tiles.Count
     ]);
+
+    GenerateCompleteTileList(Self);
   end;
 end;
 

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -650,6 +650,9 @@ begin
   Properties := TPropertyList.Create;
   Animation := TAnimation.Create;
   Image := TImage.Create;
+
+  { Default values }
+  Probability := 1.0;
 end;
 
 destructor TTiledMap.TTile.Destroy;

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -1041,9 +1041,11 @@ begin
            above and consequently are not found in the Tiles list. }
   if not (TileCount = Tiles.Count) then
   begin
-    WritelnWarning(URIDisplay(URL) + ': Could not load all tiles of tileset!' +
-      ' Expected tiles: ' + IntToStr(TileCount) + ' Loaded tiles: ' +
-      IntToStr(Tiles.Count));
+    WritelnWarning('%s: Could not load all tiles of a tileset. Expected tiles: %d, loaded tiles: %d', [
+      URIDisplay(URL),
+      TileCount,
+      Tiles.Count
+    ]);
   end;
 
   if TileCount = 0 then

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -1034,6 +1034,14 @@ begin
     end;
   finally FreeAndNil(I) end;
 
+  { Fallback: TileCount determination if is not found in (old) tsx-files prior
+    to version 0.13 (Aug 2015). }
+  if TileCount = 0 then
+  begin
+    Image.DetermineSize;
+    TileCount := (Image.Width div TileWidth) * (Image.Height div TileHeight);
+  end;
+
   { TODO : Handle tiles which are not explicitly found in the tsx-file.
     Hint : Tiles which have no special setting (probability equals 1.0,
            no terrains set, no type set) are not explicitly written down
@@ -1046,12 +1054,6 @@ begin
       TileCount,
       Tiles.Count
     ]);
-  end;
-
-  if TileCount = 0 then
-  begin
-    Image.DetermineSize;
-    TileCount := (Image.Width div TileWidth) * (Image.Height div TileHeight);
   end;
 end;
 

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -947,6 +947,7 @@ begin
   Properties := TPropertyList.Create;
   Tiles := TTileList.Create;
   Image := TImage.Create;
+  FirstGID := 1;
 end;
 
 destructor TTiledMap.TTileset.Destroy;
@@ -984,9 +985,7 @@ begin
   Margin := 0;
 
   if Element.AttributeString('firstgid', TmpStr) then
-    FirstGID := StrToDWord(TmpStr)
-  else
-    FirstGID := 1;
+    FirstGID := StrToDWord(TmpStr);
   if Element.AttributeString('source', TmpStr) then
   begin
     URL := CombineURI(BaseUrl, TmpStr);

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -1023,7 +1023,17 @@ begin
   Margin := 0;
 
   if Element.AttributeString('firstgid', TmpStr) then
-    FirstGID := StrToDWord(TmpStr);
+    FirstGID := StrToDWord(TmpStr); 
+  { Otherwise (if firstgid not specified in XML element), leave FirstGID unchanged.
+    This is important to correctly read "firstgid" in case <tileset> in TMX points 
+    to external file like
+    
+      <tileset firstgid="10" source="image3x3-regular.tsx"/>
+      
+     This means that TTiledMap.TTileset.Load calls itself,
+     and outer call set FirstGID to 10 and it should not be overridden by inner call.
+     Testcases in examples/tiled/map_viewer/data/maps/multiple_tilesets/ . }
+      
   if Element.AttributeString('source', TmpStr) then
   begin
     URL := CombineURI(BaseUrl, TmpStr);

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -1041,9 +1041,9 @@ begin
            above and consequently are not found in the Tiles list. }
   if not (TileCount = Tiles.Count) then
   begin
-    WritelnWarning(URL + ': Could not load all tiles of tileset');
-    WritelnWarning('Expected tiles: ' + IntToStr(TileCount) +
-      ' Loaded tiles: ' + IntToStr(Tiles.Count));
+    WritelnWarning(URIDisplay(URL) + ': Could not load all tiles of tileset!' +
+      ' Expected tiles: ' + IntToStr(TileCount) + ' Loaded tiles: ' +
+      IntToStr(Tiles.Count));
   end;
 
   if TileCount = 0 then

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -1034,6 +1034,18 @@ begin
     end;
   finally FreeAndNil(I) end;
 
+  { TODO : Handle tiles which are not explicitly found in the tsx-file.
+    Hint : Tiles which have no special setting (probability equals 1.0,
+           no terrains set, no type set) are not explicitly written down
+           in the tsx file. This means they are not loaded by the iteration
+           above and consequently are not found in the Tiles list. }
+  if not (TileCount = Tiles.Count) then
+  begin
+    WritelnWarning(URL + ': Could not load all tiles of tileset');
+    WritelnWarning('Expected tiles: ' + IntToStr(TileCount) +
+      ' Loaded tiles: ' + IntToStr(Tiles.Count));
+  end;
+
   if TileCount = 0 then
   begin
     Image.DetermineSize;

--- a/src/ui/opengl/castletiledmap_map.inc
+++ b/src/ui/opengl/castletiledmap_map.inc
@@ -1039,7 +1039,7 @@ begin
            no terrains set, no type set) are not explicitly written down
            in the tsx file. This means they are not loaded by the iteration
            above and consequently are not found in the Tiles list. }
-  if not (TileCount = Tiles.Count) then
+  if TileCount <> Tiles.Count then
   begin
     WritelnWarning('%s: Could not load all tiles of a tileset. Expected tiles: %d, loaded tiles: %d', [
       URIDisplay(URL),


### PR DESCRIPTION
This PR re-opens and updates (closed) PR #317.

It adds 1 (important) fix and 1 feature related to loading of tilesets (from Tiled editor).

1) Fix (commit 4bef64b): If tiles were chosen from more than 1 tileset to populate a tile layer, the tiles were not correctly displayed due to a bug (all tilesets got FirstGID = 1). This got fixed. Every tileset has its actual FirstGID now.

See example (map64-two-tilesets.tmx) before and after applied fix. (Project code, see below)

2) Fix (other commits): If no special settings like probability are set in the Tiled editor for a tileset, the tiles are not explicitly written down in the tsx-file. In this case, the Tileset.Tiles (which is of type TTileList) is not populated. Only tiles which are explicitly found in the tsx-file are added. This doesn't seem to be a problem as TCastleTiledMapControl does not rely on this list, anyway. But for the X3D converter (WIP at https://github.com/Free-Pascal-meets-SDL-Website/CastleConvertTiledMap) the list is necessary (atm.) and as a developer one would expect it to be consistent with the tileset.

See examples (map64.tmx and map64-missing-tiles.tmx), but attention, these two examples won't show a difference for the TCastleTileMapControl in the project code below (for the reason described at 2)) - but for the converter, see link, the second map will not work correctly because of the wrongly filled tilelist of the tileset.

Best regards,
Matthias

For all three examples, you can use this project code, just change the map name:

`program two_tilesets;

{$mode objfpc}{$H+} // you can also set ObjFpc and long strings in project compiler options

uses CastleWindow, CastleTiledMap, CastleLog, CastleRectangles;
var
  Window: TCastleWindowBase;
  TiledMap: TCastleTiledMapControl;

begin
  SetHeapTraceOutput('heaptrc.log');
  InitializeLog;

  Window := TCastleWindowBase.Create(Application);
  Window.Open;

  TiledMap := TCastleTiledMapControl.Create(Application);

  TiledMap.URL := 'castle-data:/map64-two-tilesets.tmx';

  TiledMap.Anchor(hpMiddle);
  TiledMap.Anchor(vpMiddle);
  Window.Controls.InsertFront(TiledMap);

  Application.Run;
end. `

![image3x3](https://user-images.githubusercontent.com/16453692/126416053-3e0d48d7-f1a2-4b11-8354-7e6c71a5f26e.png)
![image3x3-missing-tiles](https://user-images.githubusercontent.com/16453692/126416054-96eb81bd-2c16-41da-af2e-d1c06954f83c.png)

(had to rename these files to txt-files because of upload-filter)
[map64-two-tilesets.tmx.txt](https://github.com/castle-engine/castle-engine/files/6852150/map64-two-tilesets.tmx.txt)
[map64-missing-tiles.tmx.txt](https://github.com/castle-engine/castle-engine/files/6852154/map64-missing-tiles.tmx.txt)
[map64.tmx.txt](https://github.com/castle-engine/castle-engine/files/6852155/map64.tmx.txt)
[image3x3-regular.tsx.txt](https://github.com/castle-engine/castle-engine/files/6852162/image3x3-regular.tsx.txt)
[image3x3-missing-tiles.tsx.txt](https://github.com/castle-engine/castle-engine/files/6852163/image3x3-missing-tiles.tsx.txt)
