### PR TITLE
Fix random crashes on Android Adreno devices 

### DIFF
--- a/src/images/opengl/castleglutils_information.inc
+++ b/src/images/opengl/castleglutils_information.inc
@@ -81,7 +81,8 @@ const
         '  Buggy GLSL gl_FrontFacing: %s' + NL +
         '  Buggy GLSL read varying: %s' + NL +
         '  Buggy Pure Shader Pipeline: %s' + NL +
-        '  Buggy Texture Size Above 2048: %s',
+        '  Buggy Texture Size Above 2048: %s' + NL +
+        '  Buggy Shader Bump Mapping num_steps: %s',
         [ Version.VendorMajor, Version.VendorMinor, Version.VendorRelease,
           PChar(glGetString(GL_VENDOR)),
           VendorTypeToStr(Version.VendorType),
@@ -100,7 +101,8 @@ const
           BoolToStr(Version.BuggyGLSLFrontFacing, true),
           BoolToStr(Version.BuggyGLSLReadVarying, true),
           BoolToStr(Version.BuggyPureShaderPipeline, true),
-          BoolToStr(Version.BuggyTextureSizeAbove2048, true)
+          BoolToStr(Version.BuggyTextureSizeAbove2048, true),
+          BoolToStr(Version.BuggyGLSLBumpMappingNumSteps, true)
         ]);
   end;
 

--- a/src/x3d/opengl/castlerendererinternalshader.pas
+++ b/src/x3d/opengl/castlerendererinternalshader.pas
@@ -2944,6 +2944,8 @@ begin
     Define('CASTLE_BUGGY_FRONT_FACING', stFragment);
   if GLVersion.BuggyGLSLReadVarying then
     Define('CASTLE_BUGGY_GLSL_READ_VARYING', stVertex);
+  if GLVersion.BuggyGLSLBumpMappingNumSteps then
+    Define('CASTLE_BUGGY_BUMP_MAPPING_NUM_STEPS', stFragment);
   if GammaCorrection then
     Define('CASTLE_GAMMA_CORRECTION', stFragment);
   case ToneMapping of

--- a/src/x3d/opengl/glsl/generated-pascal/bump_mapping_parallax.fs.inc
+++ b/src/x3d/opengl/glsl/generated-pascal/bump_mapping_parallax.fs.inc
@@ -41,6 +41,9 @@
 '  /* At smaller view angles, much more iterations needed, otherwise ugly' + LineEnding +
 '     aliasing artifacts quickly appear. */' + LineEnding +
 '  float num_steps = mix(30.0, 10.0, v_to_eye.z);' + LineEnding +
+'#ifdef CASTLE_BUGGY_BUMP_MAPPING_NUM_STEPS' + LineEnding +
+'  num_steps = clamp(num_steps, 10.0, 30.0);' + LineEnding +
+'#endif' + LineEnding +
 '  float step = 1.0 / num_steps;' + LineEnding +
 '' + LineEnding +
 '  /* Should we remove "v_to_eye.z" below, i.e. should we apply' + LineEnding +

--- a/src/x3d/opengl/glsl/source/bump_mapping_parallax.fs
+++ b/src/x3d/opengl/glsl/source/bump_mapping_parallax.fs
@@ -39,6 +39,9 @@ void PLUG_texture_coord_shift(inout vec2 tex_coord)
   /* At smaller view angles, much more iterations needed, otherwise ugly
      aliasing artifacts quickly appear. */
   float num_steps = mix(30.0, 10.0, v_to_eye.z);
+#ifdef CASTLE_BUGGY_BUMP_MAPPING_NUM_STEPS
+  num_steps = clamp(num_steps, 10.0, 30.0);
+#endif
   float step = 1.0 / num_steps;
 
   /* Should we remove "v_to_eye.z" below, i.e. should we apply


### PR DESCRIPTION
Running our 3d game template on all Android devices with Snapdragon (Adreno). Crashes randomly. On Medaitek, Exynos everything works ok. After investigation I found that these crashes are caused by BumpMapping (`bmSteepParallax` and `bmSteepParallaxShadowing` modes).  That's why we can't reproduce that in 2D games.

The solution is even weirder - in some cases `num_steps` can have random value. so We need add clamp:

```
  vec3 v_to_eye = normalize(castle_vertex_to_eye_in_tangent_space);
  float num_steps = mix(30.0, 10.0, v_to_eye.z);
#ifdef CASTLE_BUGGY_BUMP_MAPPING_NUM_STEPS
  num_steps = clamp(num_steps, 10.0, 30.0);
#endif
  float step = 1.0 / num_steps;
```
With this everything works OK.

I tested this fix on:
- Xiaomi Mi 10 Lite (M2002J9G), Snapdragon 765G, Adreno 620:
- Motorola Moto G8 (XT2045-2), Snapdragon 665, Adreno 610
- Motorola Moto G7 Plus (XT2081-2), Snapdragon 460, Adreno 610
- Xiaomi Redmi Note 8, Snapdragon 665, Adreno 610
- Xiaomi Redmi Note 7A Snapdragon 439, Adreno 505

I also created a repository with test projects: https://github.com/and3md/castle-adreno-tests

