### PR TITLE
Delphi: Fix Escape() Unescape() FilenameToURISafe() URIToFilenameSafe() 

### DIFF
--- a/src/compatibility/delphi-only/uriparser.pas
+++ b/src/compatibility/delphi-only/uriparser.pas
@@ -56,7 +56,7 @@ function IsAbsoluteURI(const UriReference: string): Boolean;
 
 implementation
 
-uses SysUtils;
+uses SysUtils, CastleURIUtils;
 
 const
   GenDelims = [':', '/', '?', '#', '[', ']', '@'];
@@ -65,35 +65,6 @@ const
   DIGIT = ['0'..'9'];
   Unreserved = ALPHA + DIGIT + ['-', '.', '_', '~'];
   ValidPathChars = Unreserved + SubDelims + ['@', ':', '/'];
-
-function Escape(const s: String; const Allowed: TSysCharSet): String;
-var
-  i, L: Integer;
-  P: PChar;
-begin
-  L := Length(s);
-  for i := 1 to Length(s) do
-    if not (s[i] in Allowed) then Inc(L,2);
-  if L = Length(s) then
-  begin
-    Result := s;
-    Exit;
-  end;
-
-  SetLength(Result, L);
-  P := @Result[1];
-  for i := 1 to Length(s) do
-  begin
-    if not (s[i] in Allowed) then
-    begin
-      P^ := '%'; Inc(P);
-      StrFmt(P, '%.2x', [ord(s[i])]); Inc(P);
-    end
-    else
-      P^ := s[i];
-    Inc(P);
-  end;
-end;
 
 function EncodeURI(const URI: TURI): String;
 // ! if no scheme then first colon in path should be escaped
@@ -115,17 +86,17 @@ begin
   end;
   if URI.Port <> 0 then
     Result := Result + ':' + IntToStr(URI.Port);
-  Result := Result + Escape(URI.Path, ValidPathChars);
+  Result := Result + InternalURIEscape(URI.Path, ValidPathChars);
   if Length(URI.Document) > 0 then
   begin
     if (Length(URI.Path) > 0) and ((Length(Result) = 0) or (Result[Length(Result)] <> '/')) then
       Result := Result + '/';
-    Result := Result + Escape(URI.Document, ValidPathChars);
+    Result := Result + InternalURIEscape(URI.Document, ValidPathChars);
   end;
   if Length(URI.Params) > 0 then
-    Result := Result + '?' + Escape(URI.Params, ValidPathChars);
+    Result := Result + '?' + InternalURIEscape(URI.Params, ValidPathChars);
   if Length(URI.Bookmark) > 0 then
-    Result := Result + '#' + Escape(URI.Bookmark, ValidPathChars);
+    Result := Result + '#' + InternalURIEscape(URI.Bookmark, ValidPathChars);
 end;
 
 function ParseURI(const URI: String; Decode : Boolean = True):  TURI;
@@ -144,38 +115,13 @@ begin
   end;
 end;
 
-function Unescape(const s: String): String;
-var
-  i, RealLength: Integer;
-  P: PChar;
-begin
-  SetLength(Result, Length(s));
-  i := 1;
-  P := PChar(Result);  { use PChar to prevent numerous calls to UniqueString }
-  RealLength := 0;
-  while i <= Length(s) do
-  begin
-    if s[i] = '%' then
-    begin
-      P[RealLength] := Chr(HexValue(s[i + 1]) shl 4 or HexValue(s[i + 2]));
-      Inc(i, 3);
-    end else
-    begin
-      P[RealLength] := s[i];
-      Inc(i);
-    end;
-    Inc(RealLength);
-  end;
-  SetLength(Result, RealLength);
-end;
-
 function ParseURI(const URI, DefaultProtocol: String; DefaultPort: Word;Decode : Boolean = True):  TURI;
 
 var
   s, Authority: String;
   i,j: Integer;
   PortValid: Boolean;
-  
+
 begin
   Result:=Default(TURI);
   Result.Protocol := LowerCase(DefaultProtocol);
@@ -203,7 +149,7 @@ begin
   begin
     Result.Bookmark := Copy(s, i + 1, MaxInt);
     if Decode then
-      Result.Bookmark:=Unescape(Result.Bookmark);
+      Result.Bookmark:=InternalURIUnescape(Result.Bookmark);
     s := Copy(s, 1, i - 1);
   end;
 
@@ -214,7 +160,7 @@ begin
   begin
     Result.Params := Copy(s, i + 1, MaxInt);
     if Decode then
-      Result.Params:=Unescape(Result.Params);
+      Result.Params:=InternalURIUnescape(Result.Params);
     s := Copy(s, 1, i - 1);
   end;
 
@@ -243,7 +189,7 @@ begin
     begin
       Result.Document :=Copy(s, i + 1, Length(s));
       if Decode then
-        Result.Document:=Unescape(Result.Document);
+        Result.Document:=InternalURIUnescape(Result.Document);
       if (Result.Document <> '.') and (Result.Document <> '..') then
         s := Copy(s, 1, i)
       else
@@ -255,7 +201,7 @@ begin
     begin
       Result.Document :=s;
       if Decode then
-        Result.Document:=Unescape(Result.Document);
+        Result.Document:=InternalURIUnescape(Result.Document);
       if (Result.Document <> '.') and (Result.Document <> '..') then
         s := ''
       else
@@ -267,7 +213,7 @@ begin
 
   Result.Path := s;
   if Decode then
-    Result.Path:=Unescape(Result.Path);
+    Result.Path:=InternalURIUnescape(Result.Path);
 
   // Extract the port number
 
@@ -472,7 +418,7 @@ begin
     end;
   end;
   if Encode then
-    FilenamePart := Escape(FilenamePart, ValidPathChars);
+    FilenamePart := InternalURIEscape(FilenamePart, ValidPathChars);
 
   Result := Result + FilenamePart;
 end;

--- a/src/files/castleuriutils.pas
+++ b/src/files/castleuriutils.pas
@@ -398,55 +398,109 @@ implementation
 uses SysUtils, URIParser,
   CastleUtils, CastleDataURI, CastleLog, CastleFilesUtils,
   CastleInternalDirectoryInformation, CastleFindFiles, CastleDownload
-  {$ifdef CASTLE_NINTENDO_SWITCH} , CastleInternalNxBase {$endif};
+  {$ifdef CASTLE_NINTENDO_SWITCH}, CastleInternalNxBase {$endif}
+  {$ifndef FPC}, Character{$endif};
 
 { Escape and Unescape --------------------------------------------------------
   Copied from URIParser, as they are internal there.
 }
 
-function Unescape(const s: String): String;
+function Unescape(const S: String): String;
 
-  function HexValue(c: Char): Integer;
+  function HexValue(C: Char): Integer;
   begin
-    case c of
-      '0'..'9': Result := ord(c) - ord('0');
-      'A'..'F': Result := ord(c) - (ord('A') - 10);
-      'a'..'f': Result := ord(c) - (ord('a') - 10);
+    case C of
+      '0'..'9': Result := Ord(C) - ord('0');
+      'A'..'F': Result := Ord(C) - (ord('A') - 10);
+      'a'..'f': Result := Ord(C) - (ord('a') - 10);
     else
       Result := 0;
     end;
   end;
 
 var
-  i, RealLength: Integer;
+  I, J: Integer;
+  {$ifdef FPC}
+  RealLength: Integer;
   P: PChar;
+  {$else}
+  Utf8Char: RawByteString;
+  Utf16Char: String;
+  {$endif}
 begin
+  I := 1;
+  {$ifdef FPC}
   SetLength(Result, Length(s));
-  i := 1;
   P := PChar(Result);  { use PChar to prevent numerous calls to UniqueString }
   RealLength := 0;
-  while i <= Length(s) do
+  while i <= Length(S) do
   begin
-    if s[i] = '%' then
+    if S[I] = '%' then
     begin
-      P[RealLength] := Chr(HexValue(s[i + 1]) shl 4 or HexValue(s[i + 2]));
-      Inc(i, 3);
+      P[RealLength] := Chr(HexValue(S[I + 1]) shl 4 or HexValue(S[I + 2]));
+      Inc(I, 3);
     end else
     begin
-      P[RealLength] := s[i];
-      Inc(i);
+      P[RealLength] := S[I];
+      Inc(I);
     end;
     Inc(RealLength);
   end;
   SetLength(Result, RealLength);
+  {$else}
+  if S = '' then
+    Exit('');
+
+  while I <= Length(S) do
+  begin
+    if IsSurrogate(S, I) then
+    begin
+      { I don't think that should ever happen. If so, we simply add
+        such a character. }
+      Result := Result + S[I];
+      if I <> Length(S) then
+      begin
+        Result := Result + S[I + 1];
+      end;
+      Inc(I);
+    end else
+    if S[I] = '%' then
+    begin
+      { We need support here a case when more than one "%" block make one UTF16
+        character }
+      Utf8Char := '';
+      J := I;
+      while J <= Length(S) do
+      begin
+        Utf8Char := Utf8Char + AnsiChar(HexValue(S[J + 1]) shl 4 or HexValue(S[J + 2]));
+        Inc(J, 3);
+        if S[J] <> '%' then
+          Break;
+      end;
+      I := J - 1; { -1 becouse incrementation on the loop end }
+      Utf16Char :=  UTF8ToString(Utf8Char);
+      Result := Result + Utf16Char;
+    end else
+      Result := Result + S[I];
+
+    Inc(I);
+  end;
+  {$endif}
 end;
 
 function Escape(const s: String; const Allowed: TSysCharSet): String;
 var
   i, L: Integer;
+  {$ifdef FPC}
   P: PChar;
+  {$else}
+  J: Integer;
+  Utf16Char: String; // String here becouse somtimes UTF-16 char can be two wide chars
+  UTF8Char: UTF8String;
+  {$endif}
 begin
   L := Length(s);
+  {$ifdef FPC}
   for i := 1 to Length(s) do
     if not CharInSet(s[i], Allowed) then Inc(L,2);
   if L = Length(s) then
@@ -463,11 +517,49 @@ begin
     begin
       P^ := '%'; Inc(P);
       StrFmt(P, '%.2x', [ord(s[i])]); Inc(P);
-    end
-    else
+    end else
       P^ := s[i];
     Inc(P);
   end;
+  {$else}
+  if L = 0 then
+    Exit('');
+
+  I := 1;
+  while I <= L do
+  begin
+    if IsSurrogate(S, I) then
+    begin
+      { Check the string is complete (Is there the second char?) }
+      if I < L then
+      begin
+        Utf16Char := S[I] + S[I + 1];
+        UTF8Char := UTF8String(Utf16Char);
+        for J := 1 to Length(UTF8Char) do
+        begin
+          Result := Result + '%' + Format('%.2x', [ord(UTF8Char[J])]);
+        end;
+      end;
+      Inc(I);
+    end else
+    begin
+      if not CharInSet(s[i], Allowed) then
+      begin
+        // Not surrogate but also not allowed
+        UTF8Char := UTF8String(S[I]);
+        for J := 1 to Length(UTF8Char) do
+        begin
+          Result := Result + '%' + Format('%.2x', [ord(UTF8Char[J])]);
+        end;
+      end else
+      begin
+        Result := Result + S[I];
+      end;
+    end;
+
+    Inc(I);
+  end;
+  {$endif FPC}
 end;
 
 { other routines ------------------------------------------------------------- }
@@ -883,7 +975,7 @@ const
   ValidPathChars = Unreserved + SubDelims + ['@', ':', '/'];
 var
   I: Integer;
-  FilenamePart: string;
+  FilenamePart: String;
 begin
   FileName := ExpandFileNameFixed(FileName);
 

--- a/src/files/castleuriutils.pas
+++ b/src/files/castleuriutils.pas
@@ -959,8 +959,7 @@ function FilenameToURISafe(FileName: string): string;
     - guarantees that if input ends with directory separator,
       then output will end with it too.
       This is necessary on Delphi+Posix.
-    - for S = '', outputs current dir.
-    - converts drive letter to uppercase like FPC }
+    - for S = '', outputs current dir. }
   function ExpandFileNameFixed(const S: String): String;
   begin
     if S = '' then
@@ -968,18 +967,11 @@ function FilenameToURISafe(FileName: string): string;
 
     Result := ExpandFileName(S);
     {$ifndef FPC}
-    if (S <> '') then
-    begin
-      if CharInSet(S[Length(S)], AllowDirectorySeparators) and
+    if (S <> '') and
+       CharInSet(S[Length(S)], AllowDirectorySeparators) and
        ( (Result = '') or
          (not CharInSet(Result[Length(Result)], AllowDirectorySeparators) ) ) then
         Result := InclPathDelim(Result);
-
-      { FPC converts drive letter to uppercase so we want have the same
-        behavior on delphi }
-      if (Length(Result) > 2) and (not IsSurrogate(Result[1])) and (Result[2] = ':') then
-        Result[1] := TCharacter.ToUpper(Result[1]);
-    end;
     {$endif}
   end;
 

--- a/src/files/castleuriutils.pas
+++ b/src/files/castleuriutils.pas
@@ -410,9 +410,9 @@ function Unescape(const S: String): String;
   function HexValue(C: Char): Integer;
   begin
     case C of
-      '0'..'9': Result := Ord(C) - ord('0');
-      'A'..'F': Result := Ord(C) - (ord('A') - 10);
-      'a'..'f': Result := Ord(C) - (ord('a') - 10);
+      '0'..'9': Result := Ord(C) - Ord('0');
+      'A'..'F': Result := Ord(C) - (Ord('A') - 10);
+      'a'..'f': Result := Ord(C) - (Ord('a') - 10);
     else
       Result := 0;
     end;

--- a/src/files/castleuriutils.pas
+++ b/src/files/castleuriutils.pas
@@ -387,7 +387,7 @@ function RelativeToCastleDataURL(const URL: String; out WasInsideData: Boolean):
   @exclude }
 function InternalUriEscape(const S: String; const Allowed: TSysCharSet): String;
 
-{ Decode string encoded by percent encoding (https://en.wikipedia.org/wiki/Percent-encoding)
+{ Decode string encoded by percent encoding (https://en.wikipedia.org/wiki/Percent-encoding )
   @exclude }
 function InternalUriUnescape(const S: String): String;
 
@@ -959,7 +959,8 @@ function FilenameToURISafe(FileName: string): string;
     - guarantees that if input ends with directory separator,
       then output will end with it too.
       This is necessary on Delphi+Posix.
-    - for S = '', outputs current dir. }
+    - for S = '', outputs current dir.
+    - converts drive letter to uppercase like FPC }
   function ExpandFileNameFixed(const S: String): String;
   begin
     if S = '' then
@@ -967,11 +968,18 @@ function FilenameToURISafe(FileName: string): string;
 
     Result := ExpandFileName(S);
     {$ifndef FPC}
-    if (S <> '') and
-       CharInSet(S[Length(S)], AllowDirectorySeparators) and
+    if (S <> '') then
+    begin
+      if CharInSet(S[Length(S)], AllowDirectorySeparators) and
        ( (Result = '') or
          (not CharInSet(Result[Length(Result)], AllowDirectorySeparators) ) ) then
-      Result := InclPathDelim(Result);
+        Result := InclPathDelim(Result);
+
+      { FPC converts drive letter to uppercase so we want have the same
+        behavior on delphi }
+      if (Length(Result) > 2) and (not IsSurrogate(Result[1])) and (Result[2] = ':') then
+        Result[1] := TCharacter.ToUpper(Result[1]);
+    end;
     {$endif}
   end;
 

--- a/tests/code/testcastleuriutils.pas
+++ b/tests/code/testcastleuriutils.pas
@@ -152,13 +152,13 @@ begin
   {$ifdef MSWINDOWS}
   Filename := 'C:\Users\cge\AppData\Local\test_local_filename_chars\config with Polish chars ćma źrebak żmija wąż królik.txt';
   FilenameAsUri := FilenameToURISafe(Filename);
-  AssertEquals(FilenameAsUri, 'file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
+  AssertEquals('file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt', FilenameAsUri);
   FilenameFromUri := URIToFilenameSafe(FilenameAsUri);
   AssertEquals(Filename, FilenameFromUri);
 
   FilenamePart := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars ćma źrebak żmija wąż królik.txt';
   FilenamePartPercent := InternalUriEscape(FilenamePart, ValidPathChars);
-  AssertEquals(FilenamePartPercent, 'C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
+  AssertEquals('C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt', FilenamePartPercent);
   FilenamePartUnescaped := InternalUriUnescape(FilenamePartPercent);
   AssertEquals(FilenamePart, FilenamePartUnescaped);
   {$endif}

--- a/tests/code/testcastleuriutils.pas
+++ b/tests/code/testcastleuriutils.pas
@@ -104,6 +104,7 @@ begin
 end;
 
 procedure TTestURIUtils.TestPercentEncoding;
+{$ifdef MSWINDOWS}
 var
   FilenamePart: String;
   FilenamePartPercent: String;
@@ -117,6 +118,7 @@ const
   DIGIT = ['0'..'9'];
   Unreserved = ALPHA + DIGIT + ['-', '.', '_', '~'];
   ValidPathChars = Unreserved + SubDelims + ['@', ':', '/'];
+{$endif}
 begin
   { FilenameToURISafe must percent-encode,
     URIToFilenameSafe must decode it back. }
@@ -149,10 +151,6 @@ begin
 
   {$ifdef MSWINDOWS}
   Filename := 'C:\Users\cge\AppData\Local\test_local_filename_chars\config with Polish chars ćma źrebak żmija wąż królik.txt';
-  {$endif}
-  {$ifdef UNIX}
-  Filename := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars ćma źrebak żmija wąż królik.txt';
-  {$endif}
   FilenameAsUri := FilenameToURISafe(Filename);
   AssertEquals(FilenameAsUri, 'file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
   FilenameFromUri := URIToFilenameSafe(FilenameAsUri);
@@ -163,6 +161,7 @@ begin
   AssertEquals(FilenamePartPercent, 'C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
   FilenamePartUnescaped := InternalUriUnescape(FilenamePartPercent);
   AssertEquals(FilenamePart, FilenamePartUnescaped);
+  {$endif}
 end;
 
 procedure TTestURIUtils.TestCombineURIEncoding;

--- a/tests/code/testcastleuriutils.pas
+++ b/tests/code/testcastleuriutils.pas
@@ -104,6 +104,19 @@ begin
 end;
 
 procedure TTestURIUtils.TestPercentEncoding;
+var
+  FilenamePart: String;
+  FilenamePartPercent: String;
+  FilenamePartUnescaped: String;
+  Filename: String;
+  FilenameAsUri: String;
+  FilenameFromUri: String;
+const
+  SubDelims = ['!', '$', '&', '''', '(', ')', '*', '+', ',', ';', '='];
+  ALPHA = ['A'..'Z', 'a'..'z'];
+  DIGIT = ['0'..'9'];
+  Unreserved = ALPHA + DIGIT + ['-', '.', '_', '~'];
+  ValidPathChars = Unreserved + SubDelims + ['@', ':', '/'];
 begin
   { FilenameToURISafe must percent-encode,
     URIToFilenameSafe must decode it back. }
@@ -133,6 +146,23 @@ begin
     But it's Ok that %4d gets converted to M, as char "M" is safe inside URI. }
   AssertEquals('file:///fooM.txt', FilenameToURISafe(URIToFilenameSafe('file:///foo%4d.txt')));
   {$endif}
+
+  {$ifdef MSWINDOWS}
+  Filename := 'C:\Users\cge\AppData\Local\test_local_filename_chars\config with Polish chars ćma źrebak żmija wąż królik.txt';
+  {$endif}
+  {$ifdef UNIX}
+  Filename := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars ćma źrebak żmija wąż królik.txt';
+  {$endif}
+  FilenameAsUri := FilenameToURISafe(Filename);
+  AssertEquals(FilenameAsUri, 'file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
+  FilenameFromUri := URIToFilenameSafe(FilenameAsUri);
+  AssertEquals(Filename, FilenameFromUri);
+
+  FilenamePart := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars ćma źrebak żmija wąż królik.txt';
+  FilenamePartPercent := InternalUriEscape(FilenamePart, ValidPathChars);
+  AssertEquals(FilenamePartPercent, 'C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
+  FilenamePartUnescaped := InternalUriUnescape(FilenamePartPercent);
+  AssertEquals(FilenamePart, FilenamePartUnescaped);
 end;
 
 procedure TTestURIUtils.TestCombineURIEncoding;

--- a/tests/delphi_tests/delphi_tests.dpr
+++ b/tests/delphi_tests/delphi_tests.dpr
@@ -148,7 +148,7 @@ const
   ValidPathChars = Unreserved + SubDelims + ['@', ':', '/'];
 begin
   {$ifdef MSWINDOWS}
-  AssertEquals('file:///C:/foo%254d.txt', FilenameToURISafe('c:\foo%4d.txt'));
+  AssertEquals('file:///c:/foo%254d.txt', FilenameToURISafe('c:\foo%4d.txt'));
   AssertEquals('C:\fooM.txt', URIToFilenameSafe('file:///C:/foo%4d.txt'));
   AssertEquals('C:\foo%.txt', URIToFilenameSafe('file:///C:/foo%25.txt'));
   {$endif}
@@ -160,7 +160,7 @@ begin
 
   { Always URIToFilenameSafe and FilenameToURISafe should reverse each other. }
   {$ifdef MSWINDOWS}
-  AssertEquals('C:\foo%4d.txt', URIToFilenameSafe(FilenameToURISafe('c:\foo%4d.txt')));
+  AssertEquals('c:\foo%4d.txt', URIToFilenameSafe(FilenameToURISafe('c:\foo%4d.txt')));
   { Actually this would be valid too:
     AssertEquals('file:///C:/foo%4d.txt', FilenameToURISafe(URIToFilenameSafe('file:///C:/foo%4d.txt')));
     But it's Ok that %4d gets converted to M, as char "M" is safe inside URI. }

--- a/tests/delphi_tests/delphi_tests.dpr
+++ b/tests/delphi_tests/delphi_tests.dpr
@@ -132,6 +132,39 @@ begin
   Assert('myfile.html' = URI.Document);
 end;
 
+procedure TestURIEncodeDecode;
+var
+  FilenamePart: String;
+  FilenamePartPercent: String;
+  FilenamePartUnescaped: String;
+const
+  SubDelims = ['!', '$', '&', '''', '(', ')', '*', '+', ',', ';', '='];
+  ALPHA = ['A'..'Z', 'a'..'z'];
+  DIGIT = ['0'..'9'];
+  Unreserved = ALPHA + DIGIT + ['-', '.', '_', '~'];
+  ValidPathChars = Unreserved + SubDelims + ['@', ':', '/'];
+begin
+  FilenamePart := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars æma Ÿrebak ¿mija w¹¿ królik.txt';
+  FilenamePartPercent := InternalUriEscape(FilenamePart, ValidPathChars);
+  Assert(FilenamePartPercent = 'C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
+  FilenamePartUnescaped := InternalUriUnescape(FilenamePartPercent);
+  Assert(FilenamePart = FilenamePartUnescaped);
+end;
+
+procedure TestFilenameToURISafe;
+var
+  Filename: String;
+  FilenameAsUri: String;
+  FilenameFromUri: String;
+begin
+  Filename := 'C:\Users\cge\AppData\Local\test_local_filename_chars\config with Polish chars æma Ÿrebak ¿mija w¹¿ królik.txt';
+  FilenameAsUri := FilenameToURISafe(Filename);
+  Assert(FilenameAsUri = 'file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
+  FilenameFromUri := URIToFilenameSafe(FilenameAsUri);
+  Assert(Filename = FilenameFromUri);
+end;
+
+
 procedure TestTextRead;
 begin
   Writeln('test txt file reading: ', FileToString('castle-data:/test-file.txt'));
@@ -266,6 +299,8 @@ begin
   TestRects;
   TestPaths;
   TestURI;
+  TestURIEncodeDecode;
+  TestFilenameToURISafe;
   TestTextRead;
   TestXmlRead;
   TestImage;

--- a/tests/delphi_tests/delphi_tests.dpr
+++ b/tests/delphi_tests/delphi_tests.dpr
@@ -133,6 +133,7 @@ begin
 end;
 
 procedure TestPercentEncoding;
+{$ifdef MSWINDOWS}
 var
   FilenamePart: String;
   FilenamePartPercent: String;
@@ -146,6 +147,7 @@ const
   DIGIT = ['0'..'9'];
   Unreserved = ALPHA + DIGIT + ['-', '.', '_', '~'];
   ValidPathChars = Unreserved + SubDelims + ['@', ':', '/'];
+{$endif}
 begin
   {$ifdef MSWINDOWS}
   AssertEquals('file:///c:/foo%254d.txt', FilenameToURISafe('c:\foo%4d.txt'));
@@ -176,10 +178,6 @@ begin
 
   {$ifdef MSWINDOWS}
   Filename := 'C:\Users\cge\AppData\Local\test_local_filename_chars\config with Polish chars ćma źrebak żmija wąż królik.txt';
-  {$endif}
-  {$ifdef UNIX}
-  Filename := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars ćma źrebak żmija wąż królik.txt';
-  {$endif}
   FilenameAsUri := FilenameToURISafe(Filename);
   Assert(FilenameAsUri = 'file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
   FilenameFromUri := URIToFilenameSafe(FilenameAsUri);
@@ -190,6 +188,7 @@ begin
   Assert(FilenamePartPercent = 'C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
   FilenamePartUnescaped := InternalUriUnescape(FilenamePartPercent);
   Assert(FilenamePart = FilenamePartUnescaped);
+  {$endif}
 end;
 
 

--- a/tests/delphi_tests/delphi_tests.dpr
+++ b/tests/delphi_tests/delphi_tests.dpr
@@ -1,4 +1,4 @@
-{
+ï»¿{
   Copyright 2020-2021 Michalis Kamburelis.
 
   This file is part of "Castle Game Engine".
@@ -175,17 +175,17 @@ begin
   {$endif}
 
   {$ifdef MSWINDOWS}
-  Filename := 'C:\Users\cge\AppData\Local\test_local_filename_chars\config with Polish chars æma Ÿrebak ¿mija w¹¿ królik.txt';
+  Filename := 'C:\Users\cge\AppData\Local\test_local_filename_chars\config with Polish chars Ä‡ma Åºrebak Å¼mija wÄ…Å¼ krÃ³lik.txt';
   {$endif}
   {$ifdef UNIX}
-  Filename := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars æma Ÿrebak ¿mija w¹¿ królik.txt';
+  Filename := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars Ä‡ma Åºrebak Å¼mija wÄ…Å¼ krÃ³lik.txt';
   {$endif}
   FilenameAsUri := FilenameToURISafe(Filename);
   Assert(FilenameAsUri = 'file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
   FilenameFromUri := URIToFilenameSafe(FilenameAsUri);
   Assert(Filename = FilenameFromUri);
 
-  FilenamePart := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars æma Ÿrebak ¿mija w¹¿ królik.txt';
+  FilenamePart := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars Ä‡ma Åºrebak Å¼mija wÄ…Å¼ krÃ³lik.txt';
   FilenamePartPercent := InternalUriEscape(FilenamePart, ValidPathChars);
   Assert(FilenamePartPercent = 'C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
   FilenamePartUnescaped := InternalUriUnescape(FilenamePartPercent);

--- a/tests/delphi_tests/delphi_tests.dpr
+++ b/tests/delphi_tests/delphi_tests.dpr
@@ -179,13 +179,13 @@ begin
   {$ifdef MSWINDOWS}
   Filename := 'C:\Users\cge\AppData\Local\test_local_filename_chars\config with Polish chars ćma źrebak żmija wąż królik.txt';
   FilenameAsUri := FilenameToURISafe(Filename);
-  Assert(FilenameAsUri = 'file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
+  Assert('file:///C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt' = FilenameAsUri);
   FilenameFromUri := URIToFilenameSafe(FilenameAsUri);
   Assert(Filename = FilenameFromUri);
 
   FilenamePart := 'C:/Users/cge/AppData/Local/test_local_filename_chars/config with Polish chars ćma źrebak żmija wąż królik.txt';
   FilenamePartPercent := InternalUriEscape(FilenamePart, ValidPathChars);
-  Assert(FilenamePartPercent = 'C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt');
+  Assert('C:/Users/cge/AppData/Local/test_local_filename_chars/config%20with%20Polish%20chars%20%C4%87ma%20%C5%BArebak%20%C5%BCmija%20w%C4%85%C5%BC%20kr%C3%B3lik.txt' = FilenamePartPercent);
   FilenamePartUnescaped := InternalUriUnescape(FilenamePartPercent);
   Assert(FilenamePart = FilenamePartUnescaped);
   {$endif}


### PR DESCRIPTION
I added some tests only for Windows, I will do more test (for unix) when when castle-tester will be ready.