### PR TITLE
Fix crash when drag'n'drop nodes in hierarchy on Windows

### DIFF
--- a/src/3d/castletransform.pas
+++ b/src/3d/castletransform.pas
@@ -2762,10 +2762,6 @@ begin
       if ListenPressRelease then
         FWorld.RegisterPressRelease(Self);
     end;
-
-    // otherwise changing TCastleSceneCore.ExposeTransforms would not update CGE editor hierarchy view
-    if not (csTransient in ComponentStyle) then
-      InternalCastleDesignInvalidate := true;
   end;
 end;
 

--- a/src/x3d/castlescenecore.pas
+++ b/src/x3d/castlescenecore.pas
@@ -8683,10 +8683,6 @@ end;
 procedure TCastleSceneCore.SetExposeTransforms(const Value: TStrings);
 begin
   FExposeTransforms.Assign(Value);
-
-  // otherwise changing TCastleSceneCore.ExposeTransforms would not update CGE editor hierarchy view
-  if not (csTransient in ComponentStyle) then
-    InternalCastleDesignInvalidate := true;
 end;
 
 procedure TCastleSceneCore.ExposeTransformsChange(Sender: TObject);
@@ -8743,6 +8739,10 @@ begin
       TransformChild := TCastleTransform.Create(Owner);
       TransformChild.Name := TransformNamePascal;
       Add(TransformChild);
+
+      // otherwise changing TCastleSceneCore.ExposeTransforms would not update CGE editor hierarchy view
+      if not (csTransient in ComponentStyle) then
+        InternalCastleDesignInvalidate := true;
     end;
 
     // create TExposedTransform

--- a/src/x3d/castlescenecore.pas
+++ b/src/x3d/castlescenecore.pas
@@ -8683,6 +8683,10 @@ end;
 procedure TCastleSceneCore.SetExposeTransforms(const Value: TStrings);
 begin
   FExposeTransforms.Assign(Value);
+
+  // otherwise changing TCastleSceneCore.ExposeTransforms would not update CGE editor hierarchy view
+  if not (csTransient in ComponentStyle) then
+    InternalCastleDesignInvalidate := true;
 end;
 
 procedure TCastleSceneCore.ExposeTransformsChange(Sender: TObject);

--- a/tools/castle-editor/code/framedesign.pas
+++ b/tools/castle-editor/code/framedesign.pas
@@ -314,8 +314,12 @@ type
       -- but it is also rather "brutal" solution, rebuilding the hierarchy tree
       from scratch, resetting tree expand/collapsed state, resetting selection.
       When possible, use a different, "less brutal" solution
-      to update the hierarchy. }
+      to update the hierarchy.
+      To validate hierarchy tree use TDesignFrame.ValidateHierarchy. }
     procedure UpdateDesign;
+    { Returns a warning and false value when hierarchy tree (ControlsTree) differs from
+      castle design hierarchy (DesignRoot). }
+    function ValidateHierarchy: Boolean;
     procedure UpdateSelectedControl;
     function ProposeName(const ComponentClass: TComponentClass;
       const ComponentsOwner: TComponent): String;
@@ -2592,6 +2596,269 @@ begin
   InternalCastleDesignInvalidate := false;
 end;
 
+function TDesignFrame.ValidateHierarchy: Boolean;
+const
+  ExceptionMessage: String = 'Hierarchy view desynchronized with CGE internal hierarchy. 1. Please submit a bug, this should never happen. 2. To workaround it for now, save and reopen the design file.';
+
+  { Verify given component, and its children in C.NonVisualComponents }
+  procedure VerifyNonVisualComponent(const NonVisualComponentNode: TTreeNode;
+    const C: TComponent);
+  var
+    S: String;
+    Child: TComponent;
+    I: Integer;
+  begin
+    S := ComponentCaption(C);
+
+    { Check component caption and pointer in tree node }
+    if (NonVisualComponentNode.Data <> Pointer(C)) or (NonVisualComponentNode.Text <> S) then
+      raise Exception.Create(ExceptionMessage);
+
+    { Check tree node in node tree component map }
+    if TreeNodeMap[C] <> NonVisualComponentNode then
+      raise Exception.Create(ExceptionMessage);
+
+    I := 0;
+    if C is TCastleComponent then
+    begin
+      for Child in TCastleComponent(C).NonVisualComponentsEnumerate do
+      begin
+        if Selectable(Child) then
+        begin
+          { Check tree node has enough number of child items }
+          if NonVisualComponentNode.Count < I + 1 then
+            raise Exception.Create(ExceptionMessage);
+
+          { Check child and its children }
+          VerifyNonVisualComponent(NonVisualComponentNode.Items[I], Child);
+          Inc(I);
+        end;
+      end;
+
+      { Check maybe there are more tree items than components }
+      if NonVisualComponentNode.Count > I then
+        raise Exception.Create(ExceptionMessage);
+    end;
+  end;
+
+  { If C has some NonVisualComponents, then check a tree item
+    'Non-Visual Components' and its children. Returns last checked child index
+    of Parent or -1 for none }
+  function VerifyNonVisualComponentsSection(const Parent: TTreeNode; const C: TCastleComponent): Integer;
+  var
+    Child: TComponent;
+    GroupingNode: TTreeNode;
+    I: Integer;
+  begin
+    if C.NonVisualComponentsCount <> 0 then
+    begin
+      { Check tree node has enough number of child items }
+      if Parent.Count < 1 then
+        raise Exception.Create(ExceptionMessage);
+
+      { First child should be grouping tree node, check text and data }
+      GroupingNode := Parent.Items[0];
+      Result := 0;
+      if (GroupingNode.Text <> 'Non-Visual Components') or (GroupingNode.Data <> nil) then
+        raise Exception.Create(ExceptionMessage);
+
+      I := 0;
+      for Child in C.NonVisualComponentsEnumerate do
+      begin
+        if Selectable(Child) then
+        begin
+          { Check tree node has enough number of child items }
+          if GroupingNode.Count < I + 1 then
+            raise Exception.Create(ExceptionMessage);
+
+          { Check child and child children }
+          VerifyNonVisualComponent(GroupingNode.Items[I], Child);
+          Inc(I);
+        end;
+      end;
+
+      { Check maybe there are more tree items than components }
+      if GroupingNode.Count > I then
+        raise Exception.Create(ExceptionMessage);
+    end else
+      Result := -1;
+  end;
+
+  { If T has some Behaviors, then verify a tree item
+    'Behaviors' and next its children. }
+  function VerifyBehaviorsSection(LastCheckedChildNodeIndex: Integer;
+    const Parent: TTreeNode; const T: TCastleTransform): Integer;
+  var
+    Child: TCastleBehavior;
+    GroupingNode: TTreeNode;
+    I: Integer;
+  begin
+    if T.BehaviorsCount <> 0 then
+    begin
+      { Check tree node has enough number of child items }
+      if Parent.Count < LastCheckedChildNodeIndex + 2 then
+        raise Exception.Create(ExceptionMessage);
+
+      { LastCheckedChildNodeIndex + 1 should be grouping tree node, check
+        text and data }
+      GroupingNode := Parent.Items[LastCheckedChildNodeIndex + 1];
+      Result := 0;
+
+      if (GroupingNode.Text <> 'Behaviors') or (GroupingNode.Data <> nil) then
+        raise Exception.Create(ExceptionMessage);
+
+      I := 0;
+      for Child in T.BehaviorsEnumerate do
+      begin
+        if Selectable(Child) then
+        begin
+          { Check tree node has enough number of child items }
+          if GroupingNode.Count < I + 1 then
+            raise Exception.Create(ExceptionMessage);
+
+          { Check child and child children }
+           VerifyNonVisualComponent(GroupingNode.Items[I], Child);
+          Inc(I);
+        end;
+      end;
+
+      { Check maybe there are more tree items than components }
+      if GroupingNode.Count > I then
+        raise Exception.Create(ExceptionMessage);
+    end else
+      Result := LastCheckedChildNodeIndex;
+  end;
+
+  { Verify given transform, and its children
+    (transform children, T.NonVisualComponents, T.Behaviors). }
+  procedure VerifyTransform(const TransformNode: TTreeNode;
+    const T: TCastleTransform);
+  var
+    S: String;
+    I: Integer;
+    NodeIndex: Integer;
+    LastCheckedChildNodeIndex: Integer;
+  begin
+    S := ComponentCaption(T);
+
+    { Check component caption and pointer in tree node }
+    if (TransformNode.Data <> Pointer(T)) or (TransformNode.Text <> S) then
+      raise Exception.Create(ExceptionMessage);
+
+    { Check tree node in node tree component map }
+    if TreeNodeMap[T] <> TransformNode then
+      raise Exception.Create(ExceptionMessage);
+
+    LastCheckedChildNodeIndex := VerifyNonVisualComponentsSection(TransformNode, T);
+    LastCheckedChildNodeIndex := VerifyBehaviorsSection(LastCheckedChildNodeIndex,
+      TransformNode, T);
+
+    { VerifyNonVisualComponentsSection or VerifyBehaviorsSection returns -1 when
+      no non visual component/behaviors was there }
+    NodeIndex := LastCheckedChildNodeIndex + 1;
+
+    for I := 0 to T.Count - 1 do
+    begin
+      if Selectable(T[I]) then
+      begin
+        { Check tree node has enough number of child items }
+        if TransformNode.Count < NodeIndex + 1 then
+          raise Exception.Create(ExceptionMessage);
+
+        { Check child and its children }
+        VerifyTransform(TransformNode.Items[NodeIndex], T[I]);
+        Inc(NodeIndex);
+      end;
+    end;
+
+  end;
+
+  { Verify given UI control, and its children. }
+  procedure VerifyControl(const ControlNode: TTreeNode; const C: TCastleUserInterface);
+  var
+    S: String;
+    I: Integer;
+    NodeIndex: Integer;
+    LastCheckedChildNodeIndex: Integer;
+    Viewport: TCastleViewport;
+  begin
+    S := ComponentCaption(C);
+
+    { Check component caption and pointer in tree node }
+    if (ControlNode.Data <> Pointer(C)) or (ControlNode.Text <> S) then
+      raise Exception.Create(ExceptionMessage);
+
+    { Check tree node in node tree component map }
+    if TreeNodeMap[C] <> ControlNode then
+      raise Exception.Create(ExceptionMessage);
+
+    LastCheckedChildNodeIndex := VerifyNonVisualComponentsSection(ControlNode, C);
+    { VerifyNonVisualComponentsSection returns -1 when no non visual component
+      was there, or 0 when there was gropuping node }
+    NodeIndex := LastCheckedChildNodeIndex + 1;
+
+    for I := 0 to C.ControlsCount - 1 do
+    begin
+      if Selectable(C.Controls[I]) then
+      begin
+        { Check tree node has enough number of child items }
+        if ControlNode.Count < NodeIndex + 1 then
+          raise Exception.Create(ExceptionMessage);
+
+        { Check child and its children }
+        VerifyControl(ControlNode.Items[NodeIndex], C.Controls[I]);
+        Inc(NodeIndex);
+      end;
+    end;
+
+    { Verify the viewport case }
+    if C is TCastleViewport then
+    begin
+      Viewport := TCastleViewport(C);
+      if Selectable(Viewport.Items) then
+      begin
+        { Check tree node has enough number of child items }
+        if ControlNode.Count < NodeIndex + 1 then
+          raise Exception.Create(ExceptionMessage);
+
+        { Check Items transform and its children }
+        VerifyTransform(ControlNode.Items[NodeIndex], Viewport.Items);
+        Inc(NodeIndex);
+      end;
+    end;
+
+    { Check maybe there are more tree items than controls }
+    if ControlNode.Count > NodeIndex then
+      raise Exception.Create(ExceptionMessage);
+  end;
+
+begin
+  Result := true;
+
+  { Check tree has at least one node }
+  if ControlsTree.Items.Count < 1 then
+  begin
+    WritelnWarning(ExceptionMessage);
+    Exit(false);
+  end;
+
+  try
+    if DesignRoot is TCastleUserInterface then
+      VerifyControl(ControlsTree.Items[0], DesignRoot as TCastleUserInterface)
+    else
+    if DesignRoot is TCastleTransform then
+      VerifyTransform(ControlsTree.Items[0], DesignRoot as TCastleTransform)
+    else
+      VerifyNonVisualComponent(ControlsTree.Items[0], DesignRoot);
+  except
+    on E:Exception do
+    begin
+      Result := false;
+      WritelnWarning(E.Message);
+    end;
+  end;
+end;
+
 function TDesignFrame.SelectedFromNode(Node: TTreeNode): TComponent;
 begin
   // This should never be called with Node = nil
@@ -3217,6 +3484,7 @@ begin
         selection but TTreeView.Selected state is incorect }
       ControlsTree.Selected := Src;
     end;
+    ValidateHierarchy;
   end;
 end;
 


### PR DESCRIPTION
This PR fixes https://github.com/castle-engine/castle-engine/issues/353

Also fixed selection bug after drop and removed hierarchy reload after drag'n'drop TCastleInterface (transforms need still do hierarchy reload).