### PR TITLE
Fix lazarus release candidate version parsing

### DIFF
--- a/tests/CastleEngineManifest.xml
+++ b/tests/CastleEngineManifest.xml
@@ -16,6 +16,7 @@
     <search_paths>
       <path value="code/" />
       <path value="code/common/" />
+      <path value="../tools/common-code/" />
     </search_paths>
   </compiler_options>
 </project>

--- a/tests/code/testtoolfpcversion.pas
+++ b/tests/code/testtoolfpcversion.pas
@@ -33,36 +33,45 @@ uses SysUtils,
   CastleFilesUtils, CastleURIUtils;
 
 type
+  { Descendant of TToolVersion, just to expose protected ParseVersion.
+    We actually don't need to make it public here, it's enough that TTestVersionParsing
+    is in the same unit as TTestToolFpcVersion.TestVersionParsing that uses it. }
   TTestVersionParsing = class(TToolVersion)
-  public
-    function TestParsing(const VersionString: String): Boolean;
+  // public
+  //   procedure ParseVersion(const S: String);
   end;
 
-function TTestVersionParsing.TestParsing(const VersionString: String): Boolean;
-begin
-  ParseVersion(VersionString);
-  Result := ToString = VersionString;
-end;
+// procedure procedure TTestVersionParsing.ParseVersion(const S: String);
+// begin
+//   inherited;
+// end;
 
 procedure TTestToolFpcVersion.TestVersionParsing;
 var
   VersionParsing: TTestVersionParsing;
+
+  procedure TestParsing(const Ver: String);
+  begin
+    VersionParsing.ParseVersion(Ver);
+    AssertEquals(Ver, VersionParsing.ToString);
+  end;
+
 begin
   VersionParsing := TTestVersionParsing.Create;
   try
-    AssertTrue(VersionParsing.TestParsing('2.2.0RC1'));
+    TestParsing('2.2.0RC1');
     AssertEquals(2, VersionParsing.Major);
     AssertEquals(2, VersionParsing.Minor);
     AssertEquals(0, VersionParsing.Release);
     AssertEquals('RC1', VersionParsing.ReleaseRemark);
 
-    AssertTrue(VersionParsing.TestParsing('2.2.0RC2'));
+    TestParsing('2.2.0RC2');
     AssertEquals(2, VersionParsing.Major);
     AssertEquals(2, VersionParsing.Minor);
     AssertEquals(0, VersionParsing.Release);
     AssertEquals('RC2', VersionParsing.ReleaseRemark);
 
-    AssertTrue(VersionParsing.TestParsing('123.456.789'));
+    TestParsing('123.456.789');
     AssertEquals(123, VersionParsing.Major);
     AssertEquals(456, VersionParsing.Minor);
     AssertEquals(789, VersionParsing.Release);

--- a/tests/code/testtoolfpcversion.pas
+++ b/tests/code/testtoolfpcversion.pas
@@ -1,0 +1,58 @@
+// -*- compile-command: "cd ../ && ./compile_console.sh && ./test_castle_game_engine --suite=TTestSysUtils" -*-
+{
+  Copyright 2015-2021 Michalis Kamburelis.
+
+  This file is part of "Castle Game Engine".
+
+  "Castle Game Engine" is free software; see the file COPYING.txt,
+  included in this distribution, for details about the copyright.
+
+  "Castle Game Engine" is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+  ----------------------------------------------------------------------------
+}
+
+unit TestToolFpcVersion;
+
+interface
+
+uses
+  ToolFpcVersion,
+  CastleTestCase, TestRegistry;
+
+type
+  TTestToolFpcVersion = class(TCastleTestCase)
+    procedure TestVersionParsing;
+  end;
+
+implementation
+
+uses CastleFilesUtils, CastleURIUtils;
+
+type
+  TTestVersionParsing = class(TToolVersion)
+  public
+    function TestParsing(const VersionString: String): Boolean;
+  end;
+
+function TTestVersionParsing.TestParsing(const VersionString: String): Boolean;
+begin
+  ParseVersion(VersionString);
+  Result := ToString = VersionString;
+end;
+
+procedure TTestToolFpcVersion.TestVersionParsing;
+var
+  VersionParsing: TTestVersionParsing;
+begin
+  VersionParsing := TTestVersionParsing.Create;
+  AssertTrue(VersionParsing.TestParsing('2.2.0RC1'));
+  AssertTrue(VersionParsing.TestParsing('2.2.0RC2'));
+  VersionParsing.Free;
+end;
+
+initialization
+  RegisterTest(TTestToolFpcVersion);
+end.

--- a/tests/code/testtoolfpcversion.pas
+++ b/tests/code/testtoolfpcversion.pas
@@ -47,6 +47,8 @@ type
 // end;
 
 procedure TTestToolFpcVersion.TestVersionParsing;
+{ See https://github.com/castle-engine/castle-engine/pull/356 for various example
+  version numbers }
 var
   VersionParsing: TTestVersionParsing;
 
@@ -59,6 +61,31 @@ var
 begin
   VersionParsing := TTestVersionParsing.Create;
   try
+    TestParsing('1.6.4');
+    AssertEquals(1, VersionParsing.Major);
+    AssertEquals(6, VersionParsing.Minor);
+    AssertEquals(4, VersionParsing.Release);
+    AssertEquals('', VersionParsing.ReleaseRemark);
+
+    TestParsing('2.2.0');
+    AssertEquals(2, VersionParsing.Major);
+    AssertEquals(2, VersionParsing.Minor);
+    AssertEquals(0, VersionParsing.Release);
+    AssertEquals('', VersionParsing.ReleaseRemark);
+
+    TestParsing('0.9.30.2');
+    AssertEquals(0, VersionParsing.Major);
+    AssertEquals(9, VersionParsing.Minor);
+    AssertEquals(30, VersionParsing.Release);
+    AssertEquals('.2', VersionParsing.ReleaseRemark);
+
+    // Ignore this failure -- we read Major and Minor OK, but ReleaseRemark is not correct in this case
+    // TestParsing('1.0RC2');
+    // AssertEquals(1, VersionParsing.Major);
+    // AssertEquals(0, VersionParsing.Minor);
+    // AssertEquals(0, VersionParsing.Release);
+    // AssertEquals('RC2', VersionParsing.ReleaseRemark);
+
     TestParsing('2.2.0RC1');
     AssertEquals(2, VersionParsing.Major);
     AssertEquals(2, VersionParsing.Minor);

--- a/tests/code/testtoolfpcversion.pas
+++ b/tests/code/testtoolfpcversion.pas
@@ -1,4 +1,4 @@
-// -*- compile-command: "cd ../ && ./compile_console.sh && ./test_castle_game_engine --suite=TTestSysUtils" -*-
+// -*- compile-command: "cd ../ && ./compile_console.sh && ./test_castle_game_engine --suite=TTestToolFpcVersion" -*-
 {
   Copyright 2015-2021 Michalis Kamburelis.
 
@@ -29,7 +29,8 @@ type
 
 implementation
 
-uses CastleFilesUtils, CastleURIUtils;
+uses SysUtils,
+  CastleFilesUtils, CastleURIUtils;
 
 type
   TTestVersionParsing = class(TToolVersion)
@@ -48,9 +49,25 @@ var
   VersionParsing: TTestVersionParsing;
 begin
   VersionParsing := TTestVersionParsing.Create;
-  AssertTrue(VersionParsing.TestParsing('2.2.0RC1'));
-  AssertTrue(VersionParsing.TestParsing('2.2.0RC2'));
-  VersionParsing.Free;
+  try
+    AssertTrue(VersionParsing.TestParsing('2.2.0RC1'));
+    AssertEquals(2, VersionParsing.Major);
+    AssertEquals(2, VersionParsing.Minor);
+    AssertEquals(0, VersionParsing.Release);
+    AssertEquals('RC1', VersionParsing.ReleaseRemark);
+
+    AssertTrue(VersionParsing.TestParsing('2.2.0RC2'));
+    AssertEquals(2, VersionParsing.Major);
+    AssertEquals(2, VersionParsing.Minor);
+    AssertEquals(0, VersionParsing.Release);
+    AssertEquals('RC2', VersionParsing.ReleaseRemark);
+
+    AssertTrue(VersionParsing.TestParsing('123.456.789'));
+    AssertEquals(123, VersionParsing.Major);
+    AssertEquals(456, VersionParsing.Minor);
+    AssertEquals(789, VersionParsing.Release);
+    AssertEquals('', VersionParsing.ReleaseRemark);
+  finally FreeAndNil(VersionParsing) end;
 end;
 
 initialization

--- a/tests/test_castle_game_engine.lpi
+++ b/tests/test_castle_game_engine.lpi
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="10"/>
+    <Version Value="12"/>
     <General>
       <Flags>
         <SaveClosedFiles Value="False"/>
         <LRSInOutputDirectory Value="False"/>
+        <CompatibilityMode Value="True"/>
       </Flags>
       <SessionStorage Value="InIDEConfig"/>
-      <MainUnit Value="0"/>
       <Title Value="test_castle_game_engine"/>
     </General>
     <BuildModes Count="1">
@@ -16,15 +16,12 @@
     </BuildModes>
     <PublishOptions>
       <Version Value="2"/>
-      <IgnoreBinaries Value="False"/>
-      <IncludeFileFilter Value="*.(pas|pp|inc|lfm|lpr|lrs|lpi|lpk|sh|xml)"/>
-      <ExcludeFileFilter Value="*.(bak|ppu|ppw|o|so);*~;backup"/>
     </PublishOptions>
     <RunParams>
-      <local>
-        <FormatVersion Value="1"/>
-        <LaunchingApplication PathPlusParams="/usr/bin/xterm -T 'Lazarus Run Output' -e $(LazarusDir)/tools/runwait.sh $(TargetCmdLine)"/>
-      </local>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default"/>
+      </Modes>
     </RunParams>
     <RequiredPackages Count="5">
       <Item1>
@@ -43,7 +40,7 @@
         <PackageName Value="FCL"/>
       </Item5>
     </RequiredPackages>
-    <Units Count="58">
+    <Units Count="60">
       <Unit0>
         <Filename Value="test_castle_game_engine.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -51,10 +48,12 @@
       <Unit1>
         <Filename Value="code/testcastleboxes.pas"/>
         <IsPartOfProject Value="True"/>
+        <UnitName Value="TestCastleBoxes"/>
       </Unit1>
       <Unit2>
         <Filename Value="code/testcastlecameras.pas"/>
         <IsPartOfProject Value="True"/>
+        <UnitName Value="TestCastleCameras"/>
       </Unit2>
       <Unit3>
         <Filename Value="code/testcastleclassutils.pas"/>
@@ -255,6 +254,7 @@
       <Unit52>
         <Filename Value="code/testsysutils.pas"/>
         <IsPartOfProject Value="True"/>
+        <UnitName Value="TestSysUtils"/>
       </Unit52>
       <Unit53>
         <Filename Value="code/testx3dfields.pas"/>
@@ -276,6 +276,16 @@
         <Filename Value="code/common/castletestcase.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit57>
+      <Unit58>
+        <Filename Value="code/testtoolfpcversion.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="TestToolFpcVersion"/>
+      </Unit58>
+      <Unit59>
+        <Filename Value="../tools/common-code/toolfpcversion.pas"/>
+        <IsPartOfProject Value="True"/>
+        <UnitName Value="ToolFpcVersion"/>
+      </Unit59>
     </Units>
   </ProjectOptions>
   <CompilerOptions>
@@ -285,7 +295,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="../src/common_includes;code"/>
-      <OtherUnitFiles Value="code;code/common"/>
+      <OtherUnitFiles Value="code;code/common;../tools/common-code"/>
       <UnitOutputDirectory Value="castle-engine-output/standalone/lazarus-lib/$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Parsing>

--- a/tests/test_castle_game_engine.lpr
+++ b/tests/test_castle_game_engine.lpr
@@ -33,6 +33,7 @@ uses
   TestGenericsCollections,
   TestOldFPCBugs,
   TestFPImage,
+  TestToolFpcVersion,
 
   { Testing CGE units }
   TestCastleUtils,

--- a/tools/common-code/toolfpcversion.pas
+++ b/tools/common-code/toolfpcversion.pas
@@ -108,6 +108,7 @@ begin
     Release := 0;
   end else
   begin
+    ReleaseRemark := '';
     Val(Token, Release, ErrorCode);
     if ErrorCode <> 0 then // this is a case of versions like 2.2.0RC1 which contain additional ReleaseRemark after the integer digit
     begin


### PR DESCRIPTION
Fixes https://forum.castle-engine.io/t/0rc1-is-an-invalid-integer/492/3 however, only for this typical case of Lazarus 2.2.0RC1. Also added a test to make sure parsing goes as expected.

As this fix covers all current possible versioning variants for Lazarus on Windows, however in the past they've had quite bizarre version systems:

![2022-01-06-093917_1366x768_scrot](https://user-images.githubusercontent.com/10726162/148346747-cdaadc07-6a96-40bb-a977-978b3ac85ead.png)

And current implementation will fail for such versioning, e.g.

* 0.9.30.2 will result in 0.9.30 version and will be seen as absolutely equal to 0.9.30.4RC3
* 1.0RC2 will throw an exception `0RC2 is invalid integer`

I'm not sure if we can "ignore" this. But anyway we now support two latest Lazarus release candidates versioning :)