### PR TITLE
Add quotation marks to XML quote

### DIFF
--- a/tools/castle-editor/code/projectutils.pas
+++ b/tools/castle-editor/code/projectutils.pas
@@ -110,8 +110,8 @@ procedure AddMacroXmlQuote(const Macros: TStringStringMap; const MacroName: Stri
   function XmlQuote(const S: String): String;
   begin
     Result := SReplacePatterns(S,
-      ['&', '<', '>'],
-      ['&amp;', '&lt;', '&gt;'],
+      ['&', '<', '>', '"'],
+      ['&amp;', '&lt;', '&gt;', '&quot;'],
       false { IgnoreCase; can be false, it doesn't matter, as our patterns are not letters }
     );
   end;


### PR DESCRIPTION
Add also quotation marks as possible symbols in project name. See https://trello.com/c/6vmn9JKj/196-bug-project-name-caption-cannot-contain-special-characters