### PR TITLE
Add {$warn 5027 off} to SaveToPascalCode

### DIFF
--- a/src/images/castleimages.pas
+++ b/src/images/castleimages.pas
@@ -2759,6 +2759,7 @@ begin
     'function ' +ImageName+ ': ' +ClassName+ ';' +nl + nl;
 
   CodeImplementation := CodeImplementation +
+    '{$warn 5027 off}' + NL + // To avoid 'Note: Local variable "..." is assigned but never used'
     'var' + NL +
     '  F' +ImageName+ ': ' +ClassName+ ';' + NL +
     'const' + NL +


### PR DESCRIPTION
Avoid 'Note: Local variable "..." is assigned but never used' in images generated by TCastleImage.SaveToPascalCode