### PR TITLE
Use TFingerIndex in TCastleButton for consistency

### DIFF
--- a/src/ui/castlecontrols_button.inc
+++ b/src/ui/castlecontrols_button.inc
@@ -54,7 +54,7 @@
     FToggle: boolean;
     ClickStarted: boolean;
     ClickStartedPosition: TVector2;
-    ClickStartedFinger: Integer;
+    ClickStartedFinger: TFingerIndex;
     FMinImageWidth: Single;
     FMinImageHeight: Single;
     FImageLayout: TCastleButtonImageLayout;


### PR DESCRIPTION
Just noticed that `TCastleButton` uses `Integer` instead of `TFingerIndex`. No harm done, but for consistency... :)