### PR TITLE
Convert two ISO-8858-1 characters to UTF-8

### DIFF
--- a/src/transform/castleboxes.pas
+++ b/src/transform/castleboxes.pas
@@ -1553,7 +1553,7 @@ function TBox3D.IsTriangleCollision(const Triangle: TTriangle3): boolean;
 
 { Implementation based on
   [http://jgt.akpeters.com/papers/AkenineMoller01/tribox.html],
-  by Tomas Akenine-Möller, described
+  by Tomas Akenine-MÃ¶ller, described
   in his paper [http://jgt.akpeters.com/papers/AkenineMoller01/]
   "Fast 3D Triangle-Box Overlap Testing", downloadable from
   [http://www.cs.lth.se/home/Tomas_Akenine_Moller/pubs/tribox.pdf].

--- a/src/ui/castleinternalpk3dconnexion.pas
+++ b/src/ui/castleinternalpk3dconnexion.pas
@@ -5,7 +5,7 @@
   @Version 0.2.0
 -------------------------------------------------------------------------------}
 // *****************************************************************************
-// Copyright: © 2007 Patrick M. Kolla. All rights reserved.
+// Copyright: Â© 2007 Patrick M. Kolla. All rights reserved.
 // File:      pk3DConnexion.pas
 // License:   LGPL 2.1
 // Compiler:  Delphi 2006


### PR DESCRIPTION
The Debian linter (lintian) notes that two source files are not UTF-8. This PR fixes that.