### PR TITLE
Enable Quick Test GH Action running on Windows

### DIFF
--- a/.github/workflows/quick-test.yml
+++ b/.github/workflows/quick-test.yml
@@ -19,14 +19,10 @@ jobs:
     name: Quick Test of Tools
     strategy:
       matrix:
-        # TODO: Not including windows-latest, as it fails:
-        # ./tools/build-tool/castle-engine_compile.sh: line 43: fpc: command not found
-        # Looks like https://github.com/gcarreno/setup-lazarus doesn't put FPC on $PATH on Windows?
-        #
         # Not using macos-latest as it randomly fails because of timeouts
         # (e.g. https://github.com/castle-engine/castle-engine/actions/runs/2771175624 )
         # Looks like GH hosted macOS runner is just too busy.
-        operating-system: [ubuntu-latest]
+        operating-system: [ubuntu-latest, windows-latest]
         lazarus-versions: [stable]
     runs-on: ${{ matrix.operating-system }}
     steps:
@@ -43,8 +39,13 @@ jobs:
         run: brew install gnu-sed coreutils
       - name: Set environment
         run: echo "CASTLE_ENGINE_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-      - name: Build Tool
+      - name: Build Tool (Unix)
+        if: ${{ matrix.operating-system == 'ubuntu-latest' || matrix.operating-system == 'macos-latest' }}
         run: ./tools/build-tool/castle-engine_compile.sh
+      - name: Build Tool (Windows)
+        if: ${{ matrix.operating-system == 'windows-latest' }}
+        shell: pwsh
+        run: ./tools/build-tool/castle-engine_compile.ps1
       - name: Build Editor
         run: ./tools/build-tool/castle-engine compile --project ./tools/castle-editor/
       - name: Build FPS Game


### PR DESCRIPTION
GH Action for Quick Test is now working on Windows. If you don't defined `shell: pwsh` the bash script is executed with gitbash, where `%PATH%` is different on Windows machines.