### PR TITLE
Fix FormSpriteSheetEditor

### DIFF
--- a/tools/castle-editor/code/formspritesheeteditor.pas
+++ b/tools/castle-editor/code/formspritesheeteditor.pas
@@ -346,7 +346,7 @@ begin
     if IsFrameListItem(Item) then
       FSelectedFrames.Add(TCastleSpriteSheetFrame(Item.Data));
 
-    Item := FrameListView.GetNextItem(Item, sdBelow, [lisSelected]);
+    Item := FrameListView.GetNextItem(Item, sdAll, [lisSelected]);
   end;
 end;
 


### PR DESCRIPTION

https://user-images.githubusercontent.com/26040454/212646669-a2843b78-de35-4b4c-85e5-10b952a72e14.mp4


This bug caused an endless loop and some incorrect actions.

```
 while Item <> nil do
  begin
    if IsFrameListItem(Item) then
      FSelectedFrames.Add(TCastleSpriteSheetFrame(Item.Data));
     Item := FrameListView.GetNextItem(Item, sdBelow, [lisSelected]);
  end;
```

When there is only one item, the loop never exits.
And It canot enum all selected items except for the items below it.

It should be **sdAll** and not **sdBelow**.
