### PR TITLE
Avoid crash when TObjectGroupLayer is empty

### DIFF
--- a/src/scene/load/x3dloadinternaltiledmap.pas
+++ b/src/scene/load/x3dloadinternaltiledmap.pas
@@ -233,7 +233,7 @@ var
   AVector2List: TVector2List;
   I: Cardinal;
 begin
-  if not Assigned(ALayer as TCastleTiledMapData.TObjectGroupLayer).Objects then Exit;
+  if not Assigned((ALayer as TCastleTiledMapData.TObjectGroupLayer).Objects) then Exit;
 
   TiledObjectMaterial := nil;
   TiledObjectNode := nil;

--- a/src/scene/load/x3dloadinternaltiledmap.pas
+++ b/src/scene/load/x3dloadinternaltiledmap.pas
@@ -233,6 +233,8 @@ var
   AVector2List: TVector2List;
   I: Cardinal;
 begin
+  if not Assigned(ALayer as TCastleTiledMapData.TObjectGroupLayer).Objects then Exit;
+
   TiledObjectMaterial := nil;
   TiledObjectNode := nil;
   TiledObjectGeometry := nil;


### PR DESCRIPTION
`TObjectGroupLayer.Objects` is created in `TObjectGroupLayer.Load`, when TObjectGroupLayer is empty(very likely), `objects` will not be created ,Calling `TCastleTiledMapConverter.BuildObjectGroupLayerNode` the program will crash.
```
procedure TCastleTiledMapData.TObjectGroupLayer.Load(const Element: TDOMElement; const BaseUrl: String);
...
begin 
 ... 
  try
    while I.GetNext do
    begin
      if  LowerCase(I.Current.TagName) = 'object' then
      begin
        NewObject := TTiledObject.Create;
        NewObject.Load(I.Current, BaseUrl);
        if not Assigned(Objects) then
          Objects := TTiledObjectList.Create;
        Objects.Add(NewObject);
      end;
    end;
  finally FreeAndNil(I) end;
end;
```