### PR TITLE
Fix #453

### DIFF
--- a/src/lcl/castlecontrol.pas
+++ b/src/lcl/castlecontrol.pas
@@ -23,7 +23,7 @@ interface
 
 uses
   Classes, SysUtils,
-  StdCtrls, OpenGLContext, Controls, Forms, LCLVersion, LCLType,CustomTimer,
+  StdCtrls, OpenGLContext, Controls, Forms, LCLVersion, LCLType, CustomTimer,
   CastleRectangles, CastleVectors, CastleKeysMouse, CastleUtils, CastleTimeUtils,
   CastleUIControls, CastleRenderOptions,
   CastleImages, CastleGLVersion, CastleLCLUtils,
@@ -153,7 +153,7 @@ type
     FOnUpdate: TNotifyEvent;
     FKeyPressHandler: TLCLKeyPressHandler;
     FAutoFocus: Boolean;
-    FPaintTimer:TCustomTimer;
+    FPaintTimer: TCustomTimer;
 
     { Sometimes, releasing shift / alt / ctrl keys will not be reported
       properly to KeyDown / KeyUp. Example: opening a menu
@@ -245,7 +245,7 @@ type
     procedure AggressiveUpdate;
   private
     class function GetMainContainer: TCastleContainer;
-    procedure OnTimerPaint(Sender : TObject);
+    procedure OnTimerPaint(Sender: TObject);
   protected
     procedure DestroyHandle; override;
     procedure DoExit; override;


### PR DESCRIPTION
```
class procedure TCastleApplicationIdle.ApplicationIdle(Sender: TObject; var Done: Boolean);
...
begin
  ...
  { Call DoUpdate for all TCastleControl instances. }
  for I := 0 to ControlsList.Count - 1 do
  begin
    C := ControlsList[I] as TCastleControl;
    C.DoUpdate;
  end;
  ...
end; 
```
In `C.DoUpdate`, `Invalidate` will be called, and `InvalidateRect` winAPI will be called on windows. The `ApplicationIdle` method will be called **thousands of times** per second (about 6000 times on my computer), exhausting the CPU.
I only used a simple Timer dedicated to handling `Invalidate`, and the cpu usage of the editor is close to 0% after testing.