### PR TITLE
declare RemoveRoute

### DIFF
--- a/src/scene/x3d/x3dnodes_x3dnode.inc
+++ b/src/scene/x3d/x3dnodes_x3dnode.inc
@@ -905,8 +905,8 @@
     function RoutesCount: Integer;
     procedure AddRoute(const Value: TX3DRoute); overload;
     procedure AddRoute(const Source, Destination: TX3DFieldOrEvent); overload;
-    function RemoveRoute(const Value: TX3DRoute): Boolean; overload;
-    function RemoveRoute(const Index: Integer): Boolean; overload;
+    procedure RemoveRoute(const Value: TX3DRoute); overload;
+    procedure RemoveRoute(const Index: Integer); overload;
 
     property ImportsList [const Index: Integer]: TX3DImport read GetImports;
     function ImportsCount: Integer;
@@ -3460,19 +3460,19 @@ begin
   AddRoute(Route);
 end;
 
-function TX3DNode.RemoveRoute(const Value: TX3DRoute): Boolean;
+procedure TX3DNode.RemoveRoute(const Value: TX3DRoute);
 begin
-  if FRoutes = nil then Exit(False);
-  Result := RemoveRoute(FRoutes.IndexOf(Value));
+  Assert(FRoutes <> nil);
+
+  RemoveRoute(FRoutes.IndexOf(Value));
 end;
 
-function TX3DNode.RemoveRoute(const Index: Integer): Boolean;
+procedure TX3DNode.RemoveRoute(const Index: Integer);
 begin
-  Result := False;
-  if FRoutes = nil then Exit;
-  if (Index < 0) or (Index >= FRoutes.Count) then Exit;
+  Assert(FRoutes <> nil);
+  Assert(Between(Index, 0, FRoutes.Count - 1));
+
   FRoutes.Delete(Index);
-  Result := True;
 end;
 
 function TX3DNode.GetImports(const Index: Integer): TX3DImport;

--- a/src/scene/x3d/x3dnodes_x3dnode.inc
+++ b/src/scene/x3d/x3dnodes_x3dnode.inc
@@ -905,6 +905,8 @@
     function RoutesCount: Integer;
     procedure AddRoute(const Value: TX3DRoute); overload;
     procedure AddRoute(const Source, Destination: TX3DFieldOrEvent); overload;
+    function RemoveRoute(const Value: TX3DRoute): Boolean; overload;
+    function RemoveRoute(const Index: Integer): Boolean; overload;
 
     property ImportsList [const Index: Integer]: TX3DImport read GetImports;
     function ImportsCount: Integer;
@@ -3456,6 +3458,21 @@ begin
   Route.SetSourceDirectly(Source);
   Route.SetDestinationDirectly(Destination);
   AddRoute(Route);
+end;
+
+function TX3DNode.RemoveRoute(const Value: TX3DRoute): Boolean;
+begin
+  if FRoutes = nil then Exit(False);
+  Result := RemoveRoute(FRoutes.IndexOf(Value));
+end;
+
+function TX3DNode.RemoveRoute(const Index: Integer): Boolean;
+begin
+  Result := False;
+  if FRoutes = nil then Exit;
+  if (Index < 0) or (Index >= FRoutes.Count) then Exit;
+  FRoutes.Delete(Index);
+  Result := True;
 end;
 
 function TX3DNode.GetImports(const Index: Integer): TX3DImport;


### PR DESCRIPTION
This function is used to synchronize between different sprites.
Delete the original `TTimeSensor` route, and add the main sprite's `TTimeSensor` route.
I have tested it with examples, no problem.