### PR TITLE
Fix custom editor template

### DIFF
--- a/tools/build-tool/data/custom_editor_template/castle_editor.lpi
+++ b/tools/build-tool/data/custom_editor_template/castle_editor.lpi
@@ -27,7 +27,7 @@
     <RunParams>
       <FormatVersion Value="2"/>
     </RunParams>
-    <RequiredPackages Count="4">
+    <RequiredPackages Count="5">
       <Item1>
         <PackageName Value="castle_editor_components"/>
       </Item1>
@@ -40,7 +40,10 @@
       <Item4>
         <PackageName Value="LCL"/>
       </Item4>
-    <Item4> <PackageName Value="castle_editor_automatic_package"/> </Item4> </RequiredPackages>
+      <Item5> 
+		<PackageName Value="castle_editor_automatic_package"/>
+	  </Item5> 
+	</RequiredPackages>
     <Units Count="28">
       <Unit0>
         <Filename Value="castle_editor.lpr"/>

--- a/tools/build-tool/data/custom_editor_template/castle_editor.lpi
+++ b/tools/build-tool/data/custom_editor_template/castle_editor.lpi
@@ -41,9 +41,9 @@
         <PackageName Value="LCL"/>
       </Item4>
       <Item5> 
-		<PackageName Value="castle_editor_automatic_package"/>
-	  </Item5> 
-	</RequiredPackages>
+        <PackageName Value="castle_editor_automatic_package"/>
+      </Item5> 
+    </RequiredPackages>
     <Units Count="28">
       <Unit0>
         <Filename Value="castle_editor.lpr"/>


### PR DESCRIPTION
"custom_editor_template/castle_editor.lpi" is broken and cannot compile editor with custom controls. I fixed it and tested it.