### PR TITLE
Fix `LoadTilesetFromURL`

### DIFF
--- a/examples/tiled/map_viewer_in_viewport/data/maps/test_tileset_path/desert_use_parent_dir_tsx.tmx
+++ b/examples/tiled/map_viewer_in_viewport/data/maps/test_tileset_path/desert_use_parent_dir_tsx.tmx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.10.0" orientation="orthogonal" renderorder="right-down" width="3" height="3" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
+ <tileset firstgid="1" source="../desert.tsx"/>
+ <layer id="1" name="Layer 1" width="3" height="3">
+  <data encoding="csv">
+1,2,3,
+9,10,11,
+17,18,19
+</data>
+ </layer>
+</map>

--- a/src/scene/castletiledmap_data.inc
+++ b/src/scene/castletiledmap_data.inc
@@ -313,7 +313,7 @@ type
     FStaggerIndex: TStaggerIndex;
     FBackgroundColor: TCastleColor;
     FRenderOrder: TMapRenderOrder;
-    BaseUrl: string;
+    FBaseUrl: string;
     FTilesets: TTilesetList;
     FProperties: TPropertyList;
     FLayers: TLayerList;
@@ -1017,7 +1017,7 @@ procedure TCastleTiledMapData.TTileset.Load(const Element: TDOMElement; const Ba
     try
       Check(LowerCase(Doc.DocumentElement.TagName) = 'tileset',
         'Root element of TSX file must be <tileset>');
-      Load(Doc.DocumentElement, BaseUrl);
+      Load(Doc.DocumentElement, URL);
     finally
       FreeAndNil(Doc);
     end;
@@ -1265,29 +1265,29 @@ begin
       if LowerTagName = 'tileset' then
       begin
         NewTileset := TTileset.Create;
-        NewTileset.Load(I.Current, BaseUrl);
+        NewTileset.Load(I.Current, FBaseUrl);
         FTilesets.Add(NewTileset);
       end else
       if LowerTagName = 'layer' then
       begin
         NewLayer := TLayer.Create;
-        NewLayer.Load(I.Current, BaseUrl);
+        NewLayer.Load(I.Current, FBaseUrl);
         FLayers.Add(NewLayer);
       end else
       if LowerTagName = 'objectgroup' then
       begin
         NewLayer := TObjectGroupLayer.Create;
-        NewLayer.Load(I.Current, BaseUrl);
+        NewLayer.Load(I.Current, FBaseUrl);
         FLayers.Add(NewLayer);
       end else
       if LowerTagName = 'imagelayer' then
       begin
         NewLayer := TImageLayer.Create;
-        NewLayer.Load(I.Current, BaseUrl);
+        NewLayer.Load(I.Current, FBaseUrl);
         FLayers.Add(NewLayer);
       end else
       if LowerTagName = 'properties' then
-        FProperties.Load(I.Current, BaseUrl);
+        FProperties.Load(I.Current, FBaseUrl);
     end;
   finally FreeAndNil(I) end;
 end;
@@ -1299,7 +1299,7 @@ begin
   FTilesets := TTilesetList.Create;
   FProperties := TPropertyList.Create;
   FLayers := TLayerList.Create(true);
-  BaseUrl := ABaseUrl;
+  FBaseUrl := ABaseUrl;
 
   //Load TMX
   LoadTMXFile(Stream, ABaseUrl);


### PR DESCRIPTION
The path read by LoadTilesetFromURL is wrong, we should use a path relative to .tsx, not .tmx.
Here is the original function:
```
  { TSX file loading. }
  procedure LoadTilesetFromURL;
  var
    Doc: TXMLDocument;
  begin
    Doc := URLReadXML(URL);
    try
      Check(LowerCase(Doc.DocumentElement.TagName) = 'tileset',
        'Root element of TSX file must be <tileset>');
      Load(Doc.DocumentElement, BaseUrl);
    finally
      FreeAndNil(Doc);
    end;
  end;   
```
I fixed it with `Load(Doc.DocumentElement, URL);`
I also created a test map, `/examples/tiled/map_viewer_in_viewport/data/maps/test_tileset_path/desert_use_parent_dir_tsx.tmx`.

And avoid confusion, renamed private var `BaseUrl` -> `FBaseUrl`.