### PR TITLE
Avoid misleading log that config was saved when actually nothing was saved

### DIFF
--- a/src/files/castlexmlcfginternal.pas
+++ b/src/files/castlexmlcfginternal.pas
@@ -93,7 +93,7 @@ type
     procedure Clear;
     { Writes the config to XML file
       returns true if something was written
-      and false if there were no changes in config }
+      and false if there were no changes in config or it wasn't saved for some other reason }
     function Flush : Boolean;    // Writes the XML file
     function  GetValue(const APath, ADefault: String): String; overload;
     function  GetValue(const APath: String; ADefault: Integer): Integer; overload;

--- a/src/files/castlexmlcfginternal.pas
+++ b/src/files/castlexmlcfginternal.pas
@@ -91,10 +91,12 @@ type
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
     procedure Clear;
-    { Writes the config to XML file
-      returns true if something was written
-      and false if there were no changes in config or it wasn't saved for some other reason }
-    function Flush : Boolean;    // Writes the XML file
+    { Writes the config to XML file in @link(URL).
+      @returns(@true If the file was really written to disk.
+      Returns @false if file was not written,
+      which may happen if there were no changes in config since the last save/load,
+      or if the @link(URL) wasn't set.) }
+    function Flush : Boolean;
     function  GetValue(const APath, ADefault: String): String; overload;
     function  GetValue(const APath: String; ADefault: Integer): Integer; overload;
     function  GetValue(const APath: String; ADefault: Boolean): Boolean; overload;

--- a/src/files/castlexmlconfig.pas
+++ b/src/files/castlexmlconfig.pas
@@ -1120,12 +1120,12 @@ procedure TCastleConfig.Save;
 begin
   FOnSave.ExecuteAll(Self);
   if Flush then //use ancestor method to save
-    WriteLnLog('Config', 'Saving configuration to "%s"', [URL])
+    WriteLnLog('Config', 'Saving configuration to "%s"', [URIDisplay(URL)])
   else
-    if URL <> '' then
-      WriteLnLog('Config', 'No changes in config to save', [URL])
-    else
-      WriteLnWarning('Config', 'Configuration was not saved, because no URL is specified. Call TCastleConfig.Load before calling TCastleConfig.Save.');
+  if URL <> '' then
+    WriteLnLog('Config', 'No changes in config to save "%s"', [URIDisplay(URL)])
+  else
+    WriteLnWarning('Config', 'Configuration was not saved, because no URL is specified. Call TCastleConfig.Load or explicitly set TCastleConfig.URL before calling TCastleConfig.Save.');
 end;
 
 procedure TCastleConfig.Save(const Stream: TStream);

--- a/src/files/castlexmlconfig.pas
+++ b/src/files/castlexmlconfig.pas
@@ -1119,11 +1119,13 @@ end;
 procedure TCastleConfig.Save;
 begin
   FOnSave.ExecuteAll(Self);
-  Flush; // use ancestor method to save
-  if URL <> '' then
+  if Flush then //use ancestor method to save
     WriteLnLog('Config', 'Saving configuration to "%s"', [URL])
   else
-    WriteLnWarning('Config', 'Configuration was not saved, because no URL is specified. Call TCastleConfig.Load before calling TCastleConfig.Save.');
+    if URL <> '' then
+      WriteLnLog('Config', 'No changes in config to save', [URL])
+    else
+      WriteLnWarning('Config', 'Configuration was not saved, because no URL is specified. Call TCastleConfig.Load before calling TCastleConfig.Save.');
 end;
 
 procedure TCastleConfig.Save(const Stream: TStream);


### PR DESCRIPTION
Explicitly inform the user that "nothing was saved because there were no changes"