### PR TITLE
Fixed sorting of layers in TiledLayersPropertyEditor.

### DIFF
--- a/src/lcl/castlepropedits_tiledlayers.inc
+++ b/src/lcl/castlepropedits_tiledlayers.inc
@@ -105,17 +105,7 @@ end;
 
 function TTiledLayersPropertyEditor.GetAttributes: TPropertyAttributes;
 begin
-  Result := (inherited GetAttributes)
-
-    { Don't sort, would make weird (for integers) string sorting like 0, 1, 11, 12, ... 19, 2, 20, ...
-
-      Later: Unfortunately, removing paSortList achieves nothing.
-      paSortList only controls sorting of GetValues.
-      It doesn't control sorting of rows, which is just not controllable (at least in Lazarus),
-      it's hardcoded to do string sorting by TPropInfoList.Sort. }
-    //- [paSortList]
-
-    + [paDialog];
+  Result := (inherited GetAttributes) + [paDialog];
 end;
 
 { TOneLayerPropertyEditor ---------------------------------------------------- }
@@ -129,5 +119,5 @@ end;
 
 function TOneLayerPropertyEditor.GetName: ShortString;
 begin
-  Result := IntToStr(FElementToShow);
+  Result := Format('%2d',[FElementToShow]);
 end;

--- a/src/lcl/castlepropedits_tiledlayers.inc
+++ b/src/lcl/castlepropedits_tiledlayers.inc
@@ -119,5 +119,8 @@ end;
 
 function TOneLayerPropertyEditor.GetName: ShortString;
 begin
+  { Show single-digit numbers like 1 with a leading space, ' 1',
+    so that the layers are nicely sorted 1, 2, ... 9, 10, 11, ... in the object
+    inspector. }
   Result := Format('%2d',[FElementToShow]);
 end;


### PR DESCRIPTION
By simply adding space when there is only one digit in number.
Before:

![obraz](https://github.com/castle-engine/castle-engine/assets/18555708/7d4941f0-c294-4506-b182-43341ca69efe)

After:
![obraz](https://github.com/castle-engine/castle-engine/assets/18555708/650ed3aa-f8aa-4b64-9fc5-6acbba31c1bb)
