### PR TITLE
Allow Editor Theme Change with Windows Theme (Dark/Light)

### DIFF
--- a/tools/castle-editor/castle_editor.lpi
+++ b/tools/castle-editor/castle_editor.lpi
@@ -27,19 +27,22 @@
     <RunParams>
       <FormatVersion Value="2"/>
     </RunParams>
-    <RequiredPackages Count="4">
+    <RequiredPackages Count="5">
       <Item1>
-        <PackageName Value="castle_editor_components"/>
+        <PackageName Value="MetaDarkStyle"/>
       </Item1>
       <Item2>
-        <PackageName Value="AnchorDocking"/>
+        <PackageName Value="castle_editor_components"/>
       </Item2>
       <Item3>
-        <PackageName Value="castle_components"/>
+        <PackageName Value="AnchorDocking"/>
       </Item3>
       <Item4>
-        <PackageName Value="LCL"/>
+        <PackageName Value="castle_components"/>
       </Item4>
+      <Item5>
+        <PackageName Value="LCL"/>
+      </Item5>
     </RequiredPackages>
     <Units Count="30">
       <Unit0>

--- a/tools/castle-editor/castle_editor.lpr
+++ b/tools/castle-editor/castle_editor.lpr
@@ -37,6 +37,11 @@ uses
   Interfaces, // this includes the LCL widgetset
   // packages:
   castle_components,
+  {$ifdef windows}
+  uMetaDarkStyle,
+  uDarkStyleSchemes,
+  uDarkStyleParams,
+  {$endif Windows}
   // This line will be automatically uncommented by tools/build-tool/data/custom_editor_template_rebuild.sh
   //castle_editor_automatic_package,
   Forms, anchordockpkg, FormChooseProject, ProjectUtils, FormNewProject,
@@ -99,6 +104,10 @@ uses
 begin
   RequireDerivedFormResource := True;
   Application.Scaled := True;
+  {$ifdef windows}
+  PreferredAppMode:=pamAllowDark;
+  uMetaDarkStyle.ApplyMetaDarkStyle(DefaultDark);
+  {$endif windows}
   Application.Initialize;
   Application.CreateForm(TIcons, Icons);
   Application.CreateForm(TChooseProjectForm, ChooseProjectForm);


### PR DESCRIPTION
Using this [Package](https://github.com/zamtmn/metadarkstyle) We can use Dark/Light Theme on Windows.

Metadarkstyle Package needs to be installed on Lazarus.
Maybe It's better to change the color of the editor buttons' images a little.

![_gameviewplay castle-user-interface  test-3 _ Castle Game Engine 12_14_2023 2_24_44 PM](https://github.com/castle-engine/castle-engine/assets/40355105/4258a118-a166-498a-ae48-26b8110d6787)
