### PR TITLE
An option to get free pascal standard units paths from build tool

### DIFF
--- a/tools/build-tool/castle-engine.dpr
+++ b/tools/build-tool/castle-engine.dpr
@@ -187,6 +187,7 @@ begin
             '    Output some environment information (independent of any project).' + NL +
             '    Next parameter determines the information:' + NL +
             '      fpc-exe' + NL +
+            '      fpc-standard-units-paths' + NL +
             NL+
             'cache' +NL+
             '    Create cache to speed up future compilations.' + NL +

--- a/tools/build-tool/castle-engine.dpr
+++ b/tools/build-tool/castle-engine.dpr
@@ -187,7 +187,7 @@ begin
             '    Output some environment information (independent of any project).' + NL +
             '    Next parameter determines the information:' + NL +
             '      fpc-exe' + NL +
-            '      fpc-standard-units-paths' + NL +
+            '      fpc-standard-units-path' + NL +
             NL+
             'cache' +NL+
             '    Create cache to speed up future compilations.' + NL +

--- a/tools/common-code/toolcompilerinfo.pas
+++ b/tools/common-code/toolcompilerinfo.pas
@@ -156,7 +156,8 @@ var
   StandardUnitsPaths: String;
 begin
   case OutputKey of
-    'fpc-exe': Writeln(FindExeFpcCompiler(false));
+    'fpc-exe':
+      Writeln(FindExeFpcCompiler(false));
     'fpc-standard-units-paths':
     begin
       FindExeFpcCompiler(false, StandardUnitsPaths);

--- a/tools/common-code/toolcompilerinfo.pas
+++ b/tools/common-code/toolcompilerinfo.pas
@@ -153,15 +153,15 @@ end;
 
 procedure DoOutputEnvironment(const OutputKey: String);
 var
-  StandardUnitsPaths: String;
+  StandardUnitsPath: String;
 begin
   case OutputKey of
     'fpc-exe':
       Writeln(FindExeFpcCompiler(false));
-    'fpc-standard-units-paths':
+    'fpc-standard-units-path':
     begin
-      FindExeFpcCompiler(false, StandardUnitsPaths);
-      Writeln(StandardUnitsPaths);
+      FindExeFpcCompiler(false, StandardUnitsPath);
+      Writeln(StandardUnitsPath);
     end
     else raise Exception.CreateFmt('Unsupported output key: "%s"', [OutputKey]);
   end;

--- a/tools/common-code/toolcompilerinfo.pas
+++ b/tools/common-code/toolcompilerinfo.pas
@@ -152,9 +152,16 @@ begin
 end;
 
 procedure DoOutputEnvironment(const OutputKey: String);
+var
+  StandardUnitsPaths: String;
 begin
   case OutputKey of
     'fpc-exe': Writeln(FindExeFpcCompiler(false));
+    'fpc-standard-units-paths':
+    begin
+      FindExeFpcCompiler(false, StandardUnitsPaths);
+      Writeln(StandardUnitsPaths);
+    end
     else raise Exception.CreateFmt('Unsupported output key: "%s"', [OutputKey]);
   end;
 end;


### PR DESCRIPTION
Added an option to get free pascal standard units paths used by vscode extension when freepascal installation does not have fpc.cfg.