### PR TITLE
Update library interface with new function to set navigation input shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ xcuserdata
 /.jenkins
 AndroidSigningProperties.txt
 
+# Visual Studio stuff
+.vs/
+*.vcxproj.user
+
 # cge build tool stuff
 castle-engine-output
 # Already included by *.res above
@@ -92,6 +96,11 @@ castle-game-engine-*.fpm
 /examples/curves/deprecated_space_filling_curve/draw_space_filling_curve
 /examples/curves/use_designed_curve/use_designed_curve
 /examples/delphi/fmx/CastleFmx
+/examples/deprecated_library/build-qt_library_tester-*
+/examples/deprecated_library/cpp_winapi_library_tester/Debug
+/examples/deprecated_library/cpp_winapi_library_tester/Release
+/examples/deprecated_library/cpp_winapi_library_tester/x64
+/examples/deprecated_library/lazarus_library_tester/*.app
 /examples/deprecated_library/lazarus_library_tester/cge_dynlib_tester
 /examples/deprecated_to_upgrade/fixed_camera_game/rift
 /examples/eye_of_beholder/eye_of_beholder
@@ -117,8 +126,6 @@ castle-game-engine-*.fpm
 /examples/images_videos/test_castleimage_draw3x3/test_castleimage_draw3x3
 /examples/isometric_game/isometric_game
 /examples/isometric_game_3d/isometric_game_3d
-/examples/deprecated_library/build-qt_library_tester-*
-/examples/deprecated_library/lazarus_library_tester/*.app
 /examples/deprecated_to_upgrade/isometric_game/isometric_game
 /examples/deprecated_to_upgrade/joystick/joystick_demo
 /examples/lazarus/load_model_and_camera_manually/lib/

--- a/examples/deprecated_library/cpp_winapi_library_tester/castlelib_win_tester.sln
+++ b/examples/deprecated_library/cpp_winapi_library_tester/castlelib_win_tester.sln
@@ -1,23 +1,31 @@
-
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.34407.143
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "castlelib_win_tester", "castlelib_win_tester.vcxproj", "{1FED6030-D176-4FE2-8703-6C6D7D28D95C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
+		Debug|x64 = Debug|x64
 		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1FED6030-D176-4FE2-8703-6C6D7D28D95C}.Debug|Win32.ActiveCfg = Debug|Win32
 		{1FED6030-D176-4FE2-8703-6C6D7D28D95C}.Debug|Win32.Build.0 = Debug|Win32
+		{1FED6030-D176-4FE2-8703-6C6D7D28D95C}.Debug|x64.ActiveCfg = Debug|x64
+		{1FED6030-D176-4FE2-8703-6C6D7D28D95C}.Debug|x64.Build.0 = Debug|x64
 		{1FED6030-D176-4FE2-8703-6C6D7D28D95C}.Release|Win32.ActiveCfg = Release|Win32
 		{1FED6030-D176-4FE2-8703-6C6D7D28D95C}.Release|Win32.Build.0 = Release|Win32
+		{1FED6030-D176-4FE2-8703-6C6D7D28D95C}.Release|x64.ActiveCfg = Release|x64
+		{1FED6030-D176-4FE2-8703-6C6D7D28D95C}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		VisualSVNWorkingCopyRoot = .
+		SolutionGuid = {151DD9B3-398F-4854-BD4F-F0E100C94628}
 	EndGlobalSection
 EndGlobal

--- a/examples/deprecated_library/cpp_winapi_library_tester/castlelib_win_tester.vcxproj
+++ b/examples/deprecated_library/cpp_winapi_library_tester/castlelib_win_tester.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -20,12 +28,23 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -33,7 +52,13 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -42,11 +67,15 @@
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">opengl32.lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">opengl32.lib;$(LibraryPath)</LibraryPath>
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">opengl32.lib;$(LibraryPath)</LibraryPath>
+    <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Release|x64'">opengl32.lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -66,6 +95,24 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -89,12 +136,32 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\src\library\castlelib_c_loader.cpp" />
+    <ClCompile Include="..\..\..\src\deprecated_library\castlelib_c_loader.cpp" />
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\src\library\castlelib.h" />
+    <ClInclude Include="..\..\..\src\deprecated_library\castleengine.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/examples/deprecated_library/cpp_winapi_library_tester/main.cpp
+++ b/examples/deprecated_library/cpp_winapi_library_tester/main.cpp
@@ -135,7 +135,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         else
             WaitMessage();
     }
-    return msg.wParam;
+    return (int)msg.wParam;
 }
 
 //-----------------------------------------------------------------------------
@@ -209,6 +209,10 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
 
         case 'e':
+            CGE_SetNavigationType(ecgenavExamine);
+            break;
+
+        case 'o':
             {
                 int nVal = CGE_GetVariableInt(ecgevarEffectSSAO);
                 if (nVal < 0) nVal = 0;

--- a/examples/deprecated_library/qt_library_tester/qt_library_tester.pro
+++ b/examples/deprecated_library/qt_library_tester/qt_library_tester.pro
@@ -13,7 +13,7 @@ TEMPLATE = app
 
 DEFINES += QT_BUILD=1
 
-QMAKE_CXXFLAGS += "-Wno-unused-parameter"
+!msvc: QMAKE_CXXFLAGS += "-Wno-unused-parameter"
 
 SOURCES += main.cpp\
         mainwindow.cpp \

--- a/src/deprecated_library/castleengine.h
+++ b/src/deprecated_library/castleengine.h
@@ -230,6 +230,53 @@ enum ECgeKey    // values for these constants have to be same as in unit CastleK
   kcge_Period      = 190,
 };
 
+enum ECgeMouseButton
+{
+  ecgemouseButtonNone   = 0,  
+  ecgemouseButtonLeft   = 1,  
+  ecgemouseButtonMiddle = 2,  
+  ecgemouseButtonRight  = 3,  
+  ecgemouseButtonExtra1 = 4,  
+  ecgemouseButtonExtra2 = 5,  
+};
+
+enum ECgeMouseWheelDirection
+{
+  ecgemouseWheelNone    = 0,  
+  ecgemouseWheelUp      = 1,  
+  ecgemouseWheelDown    = 2,  
+  ecgemouseWheelLeft    = 3,  
+  ecgemouseWheelRight   = 4,  
+};
+
+enum ECgeNavigationInput
+{
+  // common for all navigation types
+  ecgeinputZoomIn       = 1,
+  ecgeinputZoomOut      = 2,
+  // for walk navigation
+  ecgeinputForward      = 11,
+  ecgeinputBackward     = 12,
+  ecgeinputLeftRotate   = 13,
+  ecgeinputRightRotate  = 14,
+  ecgeinputLeftStrafe   = 15,
+  ecgeinputRightStrafe  = 16,
+  ecgeinputUpRotate     = 17,
+  ecgeinputDownRotate   = 18,
+  ecgeinputIncreasePreferredHeight = 19,
+  ecgeinputDecreasePreferredHeight = 20,
+  ecgeinputGravityUp    = 21,
+  ecgeinputRun          = 22,
+  ecgeinputMoveSpeedInc = 23,
+  ecgeinputMoveSpeedDec = 24,
+  ecgeinputJump         = 25,
+  ecgeinputCrouch       = 26,
+  // for examine navigation
+  ecgeinputExRotate     = 31,
+  ecgeinputExMove       = 32,
+  ecgeinputExZoom       = 33,
+};
+
 typedef int (CDECL *TCgeLibraryCallback)(int /*ECgeLibCallbackCode*/eCode, int iParam1, int iParam2, const char *szParam);
 
 
@@ -274,6 +321,11 @@ extern void CGE_GetViewCoords(float *pfPosX, float *pfPosY, float *pfPosZ, float
                               float *pfUpX, float *pfUpY, float *pfUpZ, float *pfGravX, float *pfGravY, float *pfGravZ);
 extern void CGE_MoveViewToCoords(float fPosX, float fPosY, float fPosZ, float fDirX, float fDirY, float fDirZ,
                                  float fUpX, float fUpY, float fUpZ, float fGravX, float fGravY, float fGravZ, bool bAnimated);
+
+extern void CGE_SetNavigationInputShortcut(int /*ECgeNavigationInput*/ eInput,
+                              int /*ECgeKey*/ eKey1, int /*ECgeKey*/ eKey2 /* = kcge_None */,
+                              int /*ECgeMouseButton*/ eMouseButton /* = ecgemouseButtonNone */,
+                              int /*ECgeMouseWheelDirection*/ eMouseWheel /* = ecgemouseWheelNone */); // set input controls for camera; parameters correspond to TInputShortcut.Assign
 
 extern int CGE_GetNavigationType(void);
 extern void CGE_SetNavigationType(int /*ECgeNavigationType*/ eNewType);

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -36,7 +36,7 @@ library castleengine;
 uses CTypes, Math, SysUtils, CastleUtils,
   Classes, CastleKeysMouse, CastleCameras, CastleVectors, CastleGLUtils,
   CastleImages, CastleSceneCore, CastleUIControls, X3DNodes, X3DFields, CastleLog,
-  CastleBoxes, CastleControls, CastleApplicationProperties,
+  CastleBoxes, CastleControls, CastleInputs, CastleApplicationProperties,
   CastleWindow, CastleViewport, CastleScene, CastleTransform;
 
 type
@@ -467,6 +467,90 @@ begin
     Viewport.Camera.GravityUp := GravityUp;
   except
     on E: TObject do WritelnWarning('Window', 'CGE_MoveViewToCoords: ' + ExceptMessage(E));
+  end;
+end;
+
+procedure CGE_SetNavigationInputShortcut(eInput, eKey1, eKey2,
+                               eMouseButton, eMouseWheel: cInt32); cdecl;
+var
+  Nav: TCastleNavigation;
+  WalkNavigation: TCastleWalkNavigation;
+  ExamineNavigation: TCastleExamineNavigation;
+  InputShortcut: TInputShortcut;
+  InKey1: TKey;
+  InKey2: TKey = keyNone;
+  InKeyString: String = '';
+  InMouseButtonUse: boolean;
+  InMouseButton: TCastleMouseButton;
+  InMouseWheel: TMouseWheelDirection;
+begin
+  try
+    if not CGE_VerifyWindow('CGE_SetCameraInputShortcut') then exit;
+
+    InKey1 := TKey(eKey1);
+    InKey2 := TKey(eKey2);
+    InMouseButtonUse := (eMouseButton <> 0);
+    case eMouseButton of
+      0: InMouseButton := buttonLeft;
+      1: InMouseButton := buttonLeft;
+      2: InMouseButton := buttonMiddle;
+      3: InMouseButton := buttonRight;
+      4: InMouseButton := buttonExtra1;
+      5: InMouseButton := buttonExtra2;
+    end;
+    case eMouseWheel of
+      0: InMouseWheel := mwNone;
+      1: InMouseWheel := mwUp;
+      2: InMouseWheel := mwDown;
+      3: InMouseWheel := mwLeft;
+      4: InMouseWheel := mwRight;
+    end;
+
+    InputShortcut := nil;
+    Nav := Viewport.Navigation;
+    if Nav is TCastleWalkNavigation then
+    begin
+      WalkNavigation := TCastleWalkNavigation(Nav);
+      case eInput of
+        1: InputShortcut := WalkNavigation.Input_ZoomIn;
+        2: InputShortcut := WalkNavigation.Input_ZoomOut;
+        11: InputShortcut := WalkNavigation.Input_Forward;
+        12: InputShortcut := WalkNavigation.Input_Backward;
+        13: InputShortcut := WalkNavigation.Input_LeftRotate;
+        14: InputShortcut := WalkNavigation.Input_RightRotate;
+        15: InputShortcut := WalkNavigation.Input_LeftStrafe;
+        16: InputShortcut := WalkNavigation.Input_RightStrafe;
+        17: InputShortcut := WalkNavigation.Input_UpRotate;
+        18: InputShortcut := WalkNavigation.Input_DownRotate;
+        19: InputShortcut := WalkNavigation.Input_IncreasePreferredHeight;
+        20: InputShortcut := WalkNavigation.Input_DecreasePreferredHeight;
+        21: InputShortcut := WalkNavigation.Input_GravityUp;
+        22: InputShortcut := WalkNavigation.Input_Run;
+        23: InputShortcut := WalkNavigation.Input_MoveSpeedInc;
+        24: InputShortcut := WalkNavigation.Input_MoveSpeedDec;
+        25: InputShortcut := WalkNavigation.Input_Jump;
+        26: InputShortcut := WalkNavigation.Input_Crouch;
+        else raise EInternalError.CreateFmt('CGE_SetCameraInputShortcut: Invalid input type %d for walk navigation', [eInput]);
+      end;
+      if InputShortcut <> nil then
+        InputShortcut.Assign(InKey1, InKey2, InKeyString, InMouseButtonUse, InMouseButton, InMouseWheel);
+    end
+    else if Nav is TCastleExamineNavigation then
+    begin
+      ExamineNavigation := TCastleExamineNavigation(Nav);
+      case eInput of
+        1: InputShortcut := ExamineNavigation.Input_ZoomIn;
+        2: InputShortcut := ExamineNavigation.Input_ZoomOut;
+        31: InputShortcut := ExamineNavigation.Input_Rotate;
+        32: InputShortcut := ExamineNavigation.Input_Move;
+        33: InputShortcut := ExamineNavigation.Input_Zoom;
+        else raise EInternalError.CreateFmt('CGE_SetCameraInputShortcut: Invalid input type %d for examine navigation', [eInput]);
+      end;
+      if InputShortcut <> nil then
+        InputShortcut.Assign(InKey1, InKey2, InKeyString, InMouseButtonUse, InMouseButton, InMouseWheel);
+    end;
+  except
+    on E: TObject do WritelnLog('Window', 'CGE_SetCameraInputShortcut: ' + ExceptMessage(E));
   end;
 end;
 

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -138,7 +138,7 @@ begin
 
     Crosshair := TCrosshairManager.Create;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_Open: ' + ExceptMessage(E));
   end;
 end;
 
@@ -153,8 +153,9 @@ begin
 
     CGEApp_Close(QuitWhenNoOpenWindows);
     FreeAndNil(Window);
+    MainScene := nil;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_Close: ' + ExceptMessage(E));
   end;
 end;
 
@@ -166,7 +167,7 @@ begin
     sText := GLInformationString;
     StrPLCopy(szBuffer, sText, nBufSize-1);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_GetOpenGLInformation: ' + ExceptMessage(E));
   end;
 end;
 
@@ -176,7 +177,7 @@ begin
     if not CGE_VerifyWindow('CGE_Resize') then exit;
     CGEApp_Resize(uiViewWidth, uiViewHeight, 0);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_Resize: ' + ExceptMessage(E));
   end;
 end;
 
@@ -186,7 +187,7 @@ begin
     if not CGE_VerifyWindow('CGE_Render') then exit;
     CGEApp_Render;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_Render: ' + ExceptMessage(E));
   end;
 end;
 
@@ -209,7 +210,7 @@ begin
     // restore hidden controls
     TouchNavigation.Exists := true;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_SaveScreenshotToFile: ' + ExceptMessage(E));
   end;
 end;
 
@@ -260,7 +261,7 @@ begin
 
     CGEApp_Update;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_Update: ' + ExceptMessage(E));
   end;
 end;
 
@@ -270,7 +271,7 @@ begin
     if not CGE_VerifyWindow('CGE_MouseDown') then exit;
     CGEApp_MouseDown(X, Y, bLeftBtn, FingerIndex);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_MouseDown: ' + ExceptMessage(E));
   end;
 end;
 
@@ -280,7 +281,7 @@ begin
     if not CGE_VerifyWindow('CGE_Motion') then exit;
     CGEApp_Motion(X, Y, FingerIndex);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_Motion: ' + ExceptMessage(E));
   end;
 end;
 
@@ -291,7 +292,7 @@ begin
     if not CGE_VerifyWindow('CGE_MouseUp') then exit;
     CGEApp_MouseUp(X, Y, bLeftBtn, FingerIndex, TrackReleased);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_MouseUp: ' + ExceptMessage(E));
   end;
 end;
 
@@ -304,7 +305,7 @@ begin
     // undefined, and also --- pinch is not really a mouse wheel)
     Window.LibraryMouseWheel(zDelta/120, bVertical);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_MouseWheel: ' + ExceptMessage(E));
   end;
 end;
 
@@ -314,7 +315,7 @@ begin
     if not CGE_VerifyWindow('CGE_KeyDown') then exit;
     CGEApp_KeyDown(eKey);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_KeyDown: ' + ExceptMessage(E));
   end;
 end;
 
@@ -324,7 +325,7 @@ begin
     if not CGE_VerifyWindow('CGE_KeyUp') then exit;
     CGEApp_KeyUp(eKey);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_KeyUp: ' + ExceptMessage(E));
   end;
 end;
 
@@ -350,7 +351,7 @@ begin
     Viewport.AssignDefaultCamera;
     Viewport.AssignDefaultNavigation;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_LoadSceneFromFile: ' + ExceptMessage(E));
   end;
 end;
 
@@ -367,7 +368,7 @@ begin
   except
     on E: TObject do
     begin
-      WritelnLog('Window', ExceptMessage(E));
+      WritelnLog('Window', 'CGE_GetViewpointsCount: ' + ExceptMessage(E));
       Result := 0;
     end;
   end;
@@ -383,7 +384,7 @@ begin
     sName := MainScene.GetViewpointName(iViewpointIdx);
     StrPLCopy(szName, sName, nBufSize-1);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_GetViewpointName: ' + ExceptMessage(E));
   end;
 end;
 
@@ -394,7 +395,7 @@ begin
 
     MainScene.MoveToViewpoint(iViewpointIdx, bAnimated);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_MoveToViewpoint: ' + ExceptMessage(E));
   end;
 end;
 
@@ -407,7 +408,7 @@ begin
       MainScene.AddViewpointFromNavigation(
         Viewport.Navigation, StrPas(PChar(szName)));
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_AddViewpointFromCurrentView: ' + ExceptMessage(E));
   end;
 end;
 
@@ -423,7 +424,7 @@ begin
     pfYMin^ := BBox.Data[0].Y; pfYMax^ := BBox.Data[1].Y;
     pfZMin^ := BBox.Data[0].Z; pfZMax^ := BBox.Data[1].Z;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_GetBoundingBox: ' + ExceptMessage(E));
   end;
 end;
 
@@ -442,7 +443,7 @@ begin
     pfUpX^ := Up.X; pfUpY^ := Up.Y; pfUpZ^ := Up.Z;
     pfGravX^ := GravityUp.X; pfGravY^ := GravityUp.Y; pfGravZ^ := GravityUp.Z;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_GetViewCoords: ' + ExceptMessage(E));
   end;
 end;
 
@@ -465,7 +466,7 @@ begin
       Viewport.Camera.SetWorldView(Pos, Dir, Up);
     Viewport.Camera.GravityUp := GravityUp;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_MoveViewToCoords: ' + ExceptMessage(E));
   end;
 end;
 
@@ -486,7 +487,7 @@ begin
   except
     on E: TObject do
     begin
-      WritelnLog('Window', ExceptMessage(E));
+      WritelnLog('Window', 'CGE_GetNavigationType: ' + ExceptMessage(E));
       Result := -1;
     end;
   end;
@@ -510,7 +511,7 @@ begin
     end;
     Viewport.NavigationType := aNavType;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_SetNavigationType: ' + ExceptMessage(E));
   end;
 end;
 
@@ -542,7 +543,7 @@ begin
   try
     TouchNavigation.TouchInterface := cgehelper_TouchInterfaceFromConst(eMode);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_SetTouchInterface: ' + ExceptMessage(E));
   end;
 end;
 
@@ -551,7 +552,7 @@ begin
   try
     TouchNavigation.AutoTouchInterface := bAutomaticTouchInterface;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_SetUserInterface: ' + ExceptMessage(E));
   end;
 end;
 
@@ -564,7 +565,7 @@ begin
     DummyRemoveType := rtNone;
     Viewport.Camera.Update(fTimeS, DummyRemoveType);
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_IncreaseSceneTime: ' + ExceptMessage(E));
   end;
 end;
 
@@ -649,7 +650,7 @@ begin
           end;
     end;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_SetVariableInt: ' + ExceptMessage(E));
   end;
 end;
 
@@ -746,7 +747,7 @@ begin
       else Result := -1; // unsupported variable
     end;
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_GetVariableInt: ' + ExceptMessage(E));
   end;
 end;
 
@@ -796,7 +797,7 @@ begin
       TSFBool(aField).Send(fVal1 <> 0.0);
 
   except
-    on E: TObject do WritelnWarning('Window', ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_SetNodeFieldValue: ' + ExceptMessage(E));
   end;
 end;
 

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -946,6 +946,7 @@ exports
   CGE_KeyDown,
   CGE_KeyUp,
   CGE_LoadSceneFromFile,
+  CGE_SetNavigationInputShortcut,
   CGE_GetNavigationType,
   CGE_SetNavigationType,
   CGE_GetViewpointsCount,

--- a/src/deprecated_library/castlelib_c_loader.cpp
+++ b/src/deprecated_library/castlelib_c_loader.cpp
@@ -180,7 +180,7 @@ void CGE_LoadLibrary()
     pfrd_CGE_GetBoundingBox = (PFNRD_CGE_GetBoundingBox)cge_GetProc(hCgeDll, "CGE_GetBoundingBox");
     pfrd_CGE_GetViewCoords = (PFNRD_CGE_GetViewCoords)cge_GetProc(hCgeDll, "CGE_GetViewCoords");
     pfrd_CGE_MoveViewToCoords = (PFNRD_CGE_MoveViewToCoords)cge_GetProc(hCgeDll, "CGE_MoveViewToCoords");
-    pfrd_CGE_SetNavigationInputShortcut = (PFNRD_CGE_SetNavigationInputShortcut)cge_GetProc(hCgeDll, "SetNavigationInputShortcut");
+    pfrd_CGE_SetNavigationInputShortcut = (PFNRD_CGE_SetNavigationInputShortcut)cge_GetProc(hCgeDll, "CGE_SetNavigationInputShortcut");
     pfrd_CGE_GetNavigationType = (PFNRD_CGE_GetNavigationType)cge_GetProc(hCgeDll, "CGE_GetNavigationType");
     pfrd_CGE_SetNavigationType = (PFNRD_CGE_SetNavigationType)cge_GetProc(hCgeDll, "CGE_SetNavigationType");
     pfrd_CGE_SetTouchInterface = (PFNRD_CGE_SetTouchInterface)cge_GetProc(hCgeDll, "CGE_SetTouchInterface");

--- a/src/deprecated_library/castlelib_c_loader.cpp
+++ b/src/deprecated_library/castlelib_c_loader.cpp
@@ -31,6 +31,8 @@
 
 #ifdef QT_BUILD
   #include <QLibrary>
+  #include <QApplication>
+  #include <QMessageBox>
 #else          // suppose Windows build
   #include <windows.h>
 #endif
@@ -69,6 +71,8 @@ typedef void (CDECL *PFNRD_CGE_GetViewCoords)(float *pfPosX, float *pfPosY, floa
 typedef void (CDECL *PFNRD_CGE_MoveViewToCoords)(float fPosX, float fPosY, float fPosZ, float fDirX, float fDirY, float fDirZ,
                                                    float fUpX, float fUpY, float fUpZ, float fGravX, float fGravY, float fGravZ, bool bAnimated);
 
+typedef void (CDECL *PFNRD_CGE_SetNavigationInputShortcut)(int eInput, int eKey1, int eKey2, int eMouseButton, int eMouseWheel);
+
 typedef int (CDECL *PFNRD_CGE_GetNavigationType)();
 typedef void (CDECL *PFNRD_CGE_SetNavigationType)(int eNewType);
 typedef void (CDECL *PFNRD_CGE_SetTouchInterface)(int eMode);
@@ -105,6 +109,7 @@ PFNRD_CGE_AddViewpointFromCurrentView pfrd_CGE_AddViewpointFromCurrentView = NUL
 PFNRD_CGE_GetBoundingBox pfrd_CGE_GetBoundingBox = NULL;
 PFNRD_CGE_GetViewCoords pfrd_CGE_GetViewCoords = NULL;
 PFNRD_CGE_MoveViewToCoords pfrd_CGE_MoveViewToCoords = NULL;
+PFNRD_CGE_SetNavigationInputShortcut pfrd_CGE_SetNavigationInputShortcut = NULL;
 PFNRD_CGE_GetNavigationType pfrd_CGE_GetNavigationType = NULL;
 PFNRD_CGE_SetNavigationType pfrd_CGE_SetNavigationType = NULL;
 PFNRD_CGE_SetTouchInterface pfrd_CGE_SetTouchInterface = NULL;
@@ -118,7 +123,10 @@ PFNRD_CGE_IncreaseSceneTime pfrd_CGE_IncreaseSceneTime = NULL;
 //-----------------------------------------------------------------------------
 QFunctionPointer cge_GetProc(QLibrary &rCgeLib, const char *symbol)
 {
-    return rCgeLib.resolve(symbol);
+    QFunctionPointer f = rCgeLib.resolve(symbol);
+    if (f == nullptr)
+        QMessageBox::critical(NULL, "error - cannot load function", symbol);
+    return f;
 }
 #else
 FARPROC WINAPI cge_GetProc(HMODULE hCgeLib, const char *symbol)
@@ -130,11 +138,18 @@ FARPROC WINAPI cge_GetProc(HMODULE hCgeLib, const char *symbol)
 //-----------------------------------------------------------------------------
 void CGE_LoadLibrary()
 {
+    if (pfrd_CGE_Open != NULL)
+        return;
+
 #ifdef QT_BUILD
     QLibrary hCgeDll("castleengine");
     hCgeDll.load();
     if (!hCgeDll.isLoaded())
+    {
+        QString sErr = hCgeDll.errorString();
+        QMessageBox::critical(NULL, "error", sErr);
         return;
+    }
 #else
     HMODULE hCgeDll = LoadLibrary("castleengine.dll");
     if (hCgeDll==NULL)
@@ -165,6 +180,7 @@ void CGE_LoadLibrary()
     pfrd_CGE_GetBoundingBox = (PFNRD_CGE_GetBoundingBox)cge_GetProc(hCgeDll, "CGE_GetBoundingBox");
     pfrd_CGE_GetViewCoords = (PFNRD_CGE_GetViewCoords)cge_GetProc(hCgeDll, "CGE_GetViewCoords");
     pfrd_CGE_MoveViewToCoords = (PFNRD_CGE_MoveViewToCoords)cge_GetProc(hCgeDll, "CGE_MoveViewToCoords");
+    pfrd_CGE_SetNavigationInputShortcut = (PFNRD_CGE_SetNavigationInputShortcut)cge_GetProc(hCgeDll, "SetNavigationInputShortcut");
     pfrd_CGE_GetNavigationType = (PFNRD_CGE_GetNavigationType)cge_GetProc(hCgeDll, "CGE_GetNavigationType");
     pfrd_CGE_SetNavigationType = (PFNRD_CGE_SetNavigationType)cge_GetProc(hCgeDll, "CGE_SetNavigationType");
     pfrd_CGE_SetTouchInterface = (PFNRD_CGE_SetTouchInterface)cge_GetProc(hCgeDll, "CGE_SetTouchInterface");
@@ -245,6 +261,9 @@ void CGE_Update()
 		(*pfrd_CGE_Update)();
 }
 
+#ifdef MSVC
+#pragma optimize("", off)   // strangely MSVC calls pfrd_CGE_MouseDown always with left button in release ?!
+#endif
 //-----------------------------------------------------------------------------
 void CGE_MouseDown(int x, int y, bool bLeftBtn, int nFingerIdx)
 {
@@ -345,6 +364,13 @@ void CGE_MoveViewToCoords(float fPosX, float fPosY, float fPosZ, float fDirX, fl
 {
 	if (pfrd_CGE_MoveViewToCoords!=NULL)
 		(*pfrd_CGE_MoveViewToCoords)(fPosX, fPosY, fPosZ, fDirX, fDirY, fDirZ, fUpX, fUpY, fUpZ, fGravX, fGravY, fGravZ, bAnimated);
+}
+
+//-----------------------------------------------------------------------------
+void CGE_SetNavigationInputShortcut(int eInput, int eKey1, int eKey2, int eMouseButton, int eMouseWheel)
+{
+	if (pfrd_CGE_SetNavigationInputShortcut!=NULL)
+		(*pfrd_CGE_SetNavigationInputShortcut)(eInput, eKey1, eKey2, eMouseButton, eMouseWheel);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/deprecated_library/castlelib_dynloader.pas
+++ b/src/deprecated_library/castlelib_dynloader.pas
@@ -217,6 +217,44 @@ const
   kcge_Comma       = 188;
   kcge_Period      = 190;
 
+  // mouse button (ECgeMouseButton)
+  ecgemouseButtonNone   = 0;  
+  ecgemouseButtonLeft   = 1;  
+  ecgemouseButtonMiddle = 2;  
+  ecgemouseButtonRight  = 3;  
+  ecgemouseButtonExtra1 = 4;  
+  ecgemouseButtonExtra2 = 5;  
+
+  // mouse wheel direction (ECgeMouseWheelDirection)
+  ecgemouseWheelNone    = 0;  
+  ecgemouseWheelUp      = 1;  
+  ecgemouseWheelDown    = 2;  
+  ecgemouseWheelLeft    = 3;  
+  ecgemouseWheelRight   = 4;  
+
+  // camera input (ECgeNavigationInput)
+  ecgeinputZoomIn       = 1;
+  ecgeinputZoomOut      = 2;
+  ecgeinputForward      = 11;
+  ecgeinputBackward     = 12;
+  ecgeinputLeftRotate   = 13;
+  ecgeinputRightRotate  = 14;
+  ecgeinputLeftStrafe   = 15;
+  ecgeinputRightStrafe  = 16;
+  ecgeinputUpRotate     = 17;
+  ecgeinputDownRotate   = 18;
+  ecgeinputIncreasePreferredHeight = 19;
+  ecgeinputDecreasePreferredHeight = 20;
+  ecgeinputGravityUp    = 21;
+  ecgeinputRun          = 22;
+  ecgeinputMoveSpeedInc = 23;
+  ecgeinputMoveSpeedDec = 24;
+  ecgeinputJump         = 25;
+  ecgeinputCrouch       = 26;
+  ecgeinputExRotate     = 31;
+  ecgeinputExMove       = 32;
+  ecgeinputExZoom       = 33;
+
 type
   TLibraryCallbackProc = function (eCode, iParam1, iParam2: cInt32; szParam: pcchar):cInt32; cdecl;
 
@@ -247,6 +285,7 @@ procedure CGE_GetViewCoords(pfPosX, pfPosY, pfPosZ, pfDirX, pfDirY, pfDirZ,
 procedure CGE_MoveViewToCoords(fPosX, fPosY, fPosZ, fDirX, fDirY, fDirZ,
                                fUpX, fUpY, fUpZ, fGravX, fGravY, fGravZ: cFloat;
                                bAnimated: cBool); cdecl; external 'castleengine';
+procedure CGE_SetNavigationInputShortcut(eInput, eKey1, eKey2, eMouseButton, eMouseWheel: cInt32); cdecl; external 'castleengine';
 function CGE_GetNavigationType(): cInt32; cdecl; external 'castleengine';
 procedure CGE_SetNavigationType(NewType: cInt32); cdecl; external 'castleengine';
 procedure CGE_SetTouchInterface(eMode: cInt32); cdecl; external 'castleengine';

--- a/src/scene/castlescenecore.pas
+++ b/src/scene/castlescenecore.pas
@@ -8129,7 +8129,7 @@ var
 begin
   if RootNode = nil then
     raise Exception.Create('You have to initialize RootNode, usually just by loading some scene to TCastleSceneCore.Load, before adding viewpoints');
-  if Navigation.Camera <> nil then
+  if Navigation.Camera = nil then
     raise Exception.Create('Navigation must be part of some Viewport before using AddViewpointFromNavigation');
 
   Navigation.Camera.GetWorldView(APosition, ADirection, AUp);


### PR DESCRIPTION
Changes to (deprecated) library:

1. new exported function to set InputShortcuts to Navigation
2. Fixed crash bug when reopening the scene using library interface (nilling MainScene pointer after close)
3. Better exception reporting - function name added

I've tested the functionality inside my app.

This pull request also fixes compilation of C++ example applications using the library interface (cpp_winapi_library_tester, qt_library_tester). I've also added some Visual Studio folders (used in cpp_winapi_library_tester) to gitignore to have the clean output.

Thanks