### PR TITLE
Font texture cache fix (hack) to solve OpenGL texture resources freeing when first TCastleText is released

### DIFF
--- a/src/scene/castlesceneinternalshape.pas
+++ b/src/scene/castlesceneinternalshape.pas
@@ -212,7 +212,21 @@ end;
 function TGLShape.UnprepareTexture(Shape: TShape; Texture: TAbstractTextureNode): Pointer;
 begin
   Result := nil; // let EnumerateTextures to enumerate all textures
-  if not (Texture is TInternalCachedPixelTextureNode) then
+
+  { Do not call TTextureResources.Unprepare
+    (which would do Texture.InternalRendererResourceFree in the end)
+    when Texture is TInternalReusedPixelTextureNode,
+    since this texture may be reused by other scenes.
+
+    Testcase:
+    - create in editor viewport, add TCastleText
+    - add another TCastleText
+    - remove one (any one) TCastleText --
+      the other TCastleText display will be broken
+      if condition "if not (Texture is TInternalReusedPixelTextureNode) then"
+      below gets removed.
+  }
+  if not (Texture is TInternalReusedPixelTextureNode) then
     TTextureResources.Unprepare(Texture);
 end;
 

--- a/src/scene/castlesceneinternalshape.pas
+++ b/src/scene/castlesceneinternalshape.pas
@@ -212,7 +212,8 @@ end;
 function TGLShape.UnprepareTexture(Shape: TShape; Texture: TAbstractTextureNode): Pointer;
 begin
   Result := nil; // let EnumerateTextures to enumerate all textures
-  TTextureResources.Unprepare(Texture);
+  if not (Texture is TInternalCachedPixelTextureNode) then
+    TTextureResources.Unprepare(Texture);
 end;
 
 function TGLShape.PrepareTexture(Shape: TShape; Texture: TAbstractTextureNode): Pointer;

--- a/src/scene/x3d/x3dnodes_standard_texturing.inc
+++ b/src/scene/x3d/x3dnodes_standard_texturing.inc
@@ -391,6 +391,13 @@
   {$I auto_generated_node_helpers/x3dnodes_pixeltexture.inc}
   end;
 
+  { This class only means that this instance of texture should not be unprepared
+    when TCastleScene is destroyed and TGLShape.UnprepareTexture() removes all
+    textures because it can be sused in many TCastleScenes }
+  TInternalCachedPixelTextureNode = class(TPixelTextureNode)
+
+  end;
+
   { 2D texture coordinates used by vertex-based geometry nodes. }
   TTextureCoordinateNode = class(TAbstractSingleTextureCoordinateNode)
   {$I auto_generated_node_helpers/x3dnodes_texturecoordinate.inc}

--- a/src/scene/x3d/x3dnodes_standard_texturing.inc
+++ b/src/scene/x3d/x3dnodes_standard_texturing.inc
@@ -391,10 +391,11 @@
   {$I auto_generated_node_helpers/x3dnodes_pixeltexture.inc}
   end;
 
-  { This class only means that this instance of texture should not be unprepared
-    when TCastleScene is destroyed and TGLShape.UnprepareTexture() removes all
-    textures because it can be used in many TCastleScenes }
-  TInternalCachedPixelTextureNode = class(TPixelTextureNode)
+  { Internal TPixelTextureNode descendant for nodes that may be used
+    by many scenes at once (right now this just means: FontTexture),
+    Such nodes need special protection to not free their rendering resources
+    too early (e.g. when TCastleScene using them is destroyed). }
+  TInternalReusedPixelTextureNode = class(TPixelTextureNode)
 
   end;
 

--- a/src/scene/x3d/x3dnodes_standard_texturing.inc
+++ b/src/scene/x3d/x3dnodes_standard_texturing.inc
@@ -393,7 +393,7 @@
 
   { This class only means that this instance of texture should not be unprepared
     when TCastleScene is destroyed and TGLShape.UnprepareTexture() removes all
-    textures because it can be sused in many TCastleScenes }
+    textures because it can be used in many TCastleScenes }
   TInternalCachedPixelTextureNode = class(TPixelTextureNode)
 
   end;

--- a/src/scene/x3d/x3dnodes_x3dfonttexturescache.inc
+++ b/src/scene/x3d/x3dnodes_x3dfonttexturescache.inc
@@ -17,6 +17,7 @@
 {$ifdef read_interface}
 
   TPixelTextureNode = class;
+  TInternalCachedPixelTextureNode = class;
 
   { Cache for font texture nodes (TPixelTextureNode that we need for each font).
     Descends from TX3DNodesCache, so can also cache textures, movies, any X3D nodes. }
@@ -29,7 +30,7 @@
         Font: TCastleFont;
         Blending: Boolean;
         References: Cardinal;
-        FontTexture: TPixelTextureNode;
+        FontTexture: TInternalCachedPixelTextureNode;
       end;
 
       TCachedFontTextureList = {$ifdef FPC}specialize{$endif} TObjectList<TCachedFontTexture>;
@@ -103,7 +104,7 @@ begin
     end;
   end;
 
-  Result := TPixelTextureNode.Create;
+  Result := TInternalCachedPixelTextureNode.Create;
   Result.KeepExistingBegin; // never free it using ref-counting
   { although repeat=TRUE seems counter-intuitive, in fact:
     - We *can* use it, since CastleTextureFontData surrounds each glyph from
@@ -127,7 +128,7 @@ begin
   C.References := 1;
   C.Font := Font;
   C.Blending := Blending;
-  C.FontTexture := Result;
+  C.FontTexture := TInternalCachedPixelTextureNode(Result);
 
   if Log then
     WritelnLog('++', 'Font texture %s, blending %s : %d', [
@@ -168,6 +169,7 @@ begin
           i.e. TX3DNode internal child-parent references are not set.)
           But for safety we use "nice way" with KeepExistingEnd + FreeIfUnusedAndNil. }
         C.FontTexture.KeepExistingEnd;
+        C.FontTexture.InternalRendererResourceFree;
         FreeIfUnusedAndNil(C.FontTexture);
 
         CachedFontTextures.Delete(I);

--- a/src/scene/x3d/x3dnodes_x3dfonttexturescache.inc
+++ b/src/scene/x3d/x3dnodes_x3dfonttexturescache.inc
@@ -17,7 +17,7 @@
 {$ifdef read_interface}
 
   TPixelTextureNode = class;
-  TInternalCachedPixelTextureNode = class;
+  TInternalReusedPixelTextureNode = class;
 
   { Cache for font texture nodes (TPixelTextureNode that we need for each font).
     Descends from TX3DNodesCache, so can also cache textures, movies, any X3D nodes. }
@@ -30,7 +30,7 @@
         Font: TCastleFont;
         Blending: Boolean;
         References: Cardinal;
-        FontTexture: TInternalCachedPixelTextureNode;
+        FontTexture: TPixelTextureNode;
       end;
 
       TCachedFontTextureList = {$ifdef FPC}specialize{$endif} TObjectList<TCachedFontTexture>;
@@ -104,7 +104,7 @@ begin
     end;
   end;
 
-  Result := TInternalCachedPixelTextureNode.Create;
+  Result := TInternalReusedPixelTextureNode.Create;
   Result.KeepExistingBegin; // never free it using ref-counting
   { although repeat=TRUE seems counter-intuitive, in fact:
     - We *can* use it, since CastleTextureFontData surrounds each glyph from
@@ -128,7 +128,7 @@ begin
   C.References := 1;
   C.Font := Font;
   C.Blending := Blending;
-  C.FontTexture := TInternalCachedPixelTextureNode(Result);
+  C.FontTexture := Result;
 
   if Log then
     WritelnLog('++', 'Font texture %s, blending %s : %d', [
@@ -169,7 +169,8 @@ begin
           i.e. TX3DNode internal child-parent references are not set.)
           But for safety we use "nice way" with KeepExistingEnd + FreeIfUnusedAndNil. }
         C.FontTexture.KeepExistingEnd;
-        C.FontTexture.InternalRendererResourceFree;
+        { Note that freeing C.FontTexture will also do
+          C.FontTexture.InternalRendererResourceFree, and that's good. }
         FreeIfUnusedAndNil(C.FontTexture);
 
         CachedFontTextures.Delete(I);


### PR DESCRIPTION
Now when I know what the problem is, I'm surprised I didn't come up with the solution sooner :D
As we anticipated, the issue was in the cache, but in a different manner. After meticulously examining the `TX3DFontTexturesCache` code many times, I was convinced that the error lies elsewhere.

Each `TCastleScene` releases OpenGL resources when is destroyed. In that case cached, shared font texture is also removed on renderer side. That's why we don't have a crash but only visual garbage in other `TCastleText` instances. 

When `TCastleText` is destroyed it destroys also internal TCastleScene that in `TCastleTransform.Destroy()` calls `GLContextClose()`. That calls `TGLShape(Shape).GLContextClose;` Next `ShapesGLContextClose()` is called:

```
procedure TGLShape.GLContextClose;

  if TexturesPrepared then
  begin
    TexturesPrepared := false;
    EnumerateTextures({$ifdef FPC}@{$endif} UnprepareTexture); <--- here is the problem
  end;
```
and next:

```
function TGLShape.UnprepareTexture(Shape: TShape; Texture: TAbstractTextureNode): Pointer;
begin
  Result := nil; // let EnumerateTextures to enumerate all textures
  TTextureResources.Unprepare(Texture);
end;
```

The simplest fix is a little hacky but I believe that when OpenGLContext is really closed that code will tidy up GL resources
```
TAbstractTextureNode.SetInternalRendererResource(const Value: TInternalRendererResource); mamy:

      ApplicationProperties.OnGLContextCloseObject.Add(
        {$ifdef FPC}@{$endif} GLContextCloseEvent);
```
and we can call `InternalRendererResourceFree;` when font texture is destroyed in any other cases.

Font textures are `TPixelTextureNode` but I needed to make them stand out somehow so I created  `TInternalCachedPixelTextureNode` for that case:

```
function TGLShape.UnprepareTexture(Shape: TShape; Texture: TAbstractTextureNode): Pointer;
begin
  Result := nil; // let EnumerateTextures to enumerate all textures
  if not (Texture is TInternalCachedPixelTextureNode) then
    TTextureResources.Unprepare(Texture);
end;
```
I know that is a hack because when we will want to cache other things we will get the same problem again. But more clean fix needs an archtecture change (maybe we need some render resource manager) or maybe you will know better solution that I don't notice.
