### PR TITLE
Add Padding to Basic/Layout inspector tab for TCastleVerticalGroup and TCastleHorizontalGroup

### DIFF
--- a/src/ui/castlecontrols_groups.inc
+++ b/src/ui/castlecontrols_groups.inc
@@ -430,7 +430,7 @@ end;
 function TCastleHorizontalGroup.PropertySections(
   const PropertyName: String): TPropertySections;
 begin
-  if (PropertyName = 'Alignment') then
+  if ArrayContainsString(PropertyName, ['Alignment', 'Padding']) then
     Result := [psBasic, psLayout]
   else
     Result := inherited PropertySections(PropertyName);
@@ -503,7 +503,7 @@ end;
 function TCastleVerticalGroup.PropertySections(
   const PropertyName: String): TPropertySections;
 begin
-  if (PropertyName = 'Alignment') then
+  if ArrayContainsString(PropertyName, ['Alignment', 'Padding']) then
     Result := [psBasic, psLayout]
   else
     Result := inherited PropertySections(PropertyName);


### PR DESCRIPTION
I noticed that often when I add a group of controls, I have to go to the All tab to change paddings. I think they should be added to the Basic and Layout tabs, just like Spacing property. I added them to Vertical/Horizontal group because that property may be not important for other packed group descendants.