### PR TITLE
fix a typo in comment

### DIFF
--- a/src/ui/castleinternalsettings.pas
+++ b/src/ui/castleinternalsettings.pas
@@ -286,7 +286,7 @@ type
         Result := TCastleFont.Create(Container);
         TCastleFont(Result).OptimalSize := NewFontOptimalSize;
         TCastleFont(Result).AntiAliased := NewFontAntiAliased;
-        TCastleFont(Result).LoadBasicCharacters := false; // if neded, they are included in UnicodeCharList
+        TCastleFont(Result).LoadBasicCharacters := false; // if needed, they are included in UnicodeCharList
         TCastleFont(Result).LoadCharacters := UnicodeCharList.ToString;
         TCastleFont(Result).URL := NewFontUrl;
       end;


### PR DESCRIPTION
Fix a tiny typo "neded" -> "needed" in comment