### PR TITLE
Autodetect VS Code on macOS for the Castle Editor

### DIFF
--- a/tools/castle-editor/code/editorutils.pas
+++ b/tools/castle-editor/code/editorutils.pas
@@ -1063,6 +1063,10 @@ begin
 end;
 
 function FindExeVSCode(const ExceptionWhenMissing: Boolean): String;
+{$ifdef DARWIN}
+const
+  MacVSCodePath = '/Applications/Visual Studio Code.app/Contents/MacOS/Electron';
+{$endif}
 begin
   Result := FindExe('code');
 
@@ -1078,8 +1082,8 @@ begin
   *)
 
   {$ifdef DARWIN}
-  if (Result = '') and (FileExists('/Applications/Visual Studio Code.app/Contents/MacOS/Electron')) then
-    Result := '/Applications/Visual Studio Code.app/Contents/MacOS/Electron';
+  if (Result = '') and (FileExists(MacVSCodePath)) then
+    Result := MacVSCodePath;
   {$endif}
 
   if (Result = '') and ExceptionWhenMissing then

--- a/tools/castle-editor/code/editorutils.pas
+++ b/tools/castle-editor/code/editorutils.pas
@@ -1077,6 +1077,11 @@ begin
   {$endif}
   *)
 
+  {$ifdef DARWIN}
+  if (Result = '') and (FileExists('/Applications/Visual Studio Code.app/Contents/MacOS/Electron')) then
+    Result := '/Applications/Visual Studio Code.app/Contents/MacOS/Electron';
+  {$endif}
+
   if (Result = '') and ExceptionWhenMissing then
     raise EExecutableNotFound.Create('Cannot find Visual Studio Code. Make sure it is installed, and available on environment variable $PATH (there should be an option to set this up during VS Code installlation).');
 end;


### PR DESCRIPTION
This will add auto-detection of VS Code on macOS. By default, VS Code is in Applications, and to call it with parameters in RunCommandNoWait, it is OK to use the executable from within the Visual Studio Code.app (the executable is called Electron).

This will fix the Issue #598 