### PR TITLE
Add scene saving function to deprecated library interface

### DIFF
--- a/src/deprecated_library/castleengine.h
+++ b/src/deprecated_library/castleengine.h
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013-2023 Jan Adamec, Michalis Kamburelis.
+  Copyright 2013-2024 Jan Adamec, Michalis Kamburelis.
 
   This file is part of "Castle Game Engine".
 
@@ -310,6 +310,7 @@ extern void CGE_KeyDown(int /*ECgeKey*/ eKey);
 extern void CGE_KeyUp(int /*ECgeKey*/ eKey);
 
 extern void CGE_LoadSceneFromFile(const char *szFile);                     // name od the file has to be utf-8 encoded
+extern void CGE_SaveSceneToFile(const char *szFile);
 
 extern int CGE_GetViewpointsCount(void);
 extern void CGE_GetViewpointName(int iViewpointIdx, char *szName, int nBufSize);    // szName is buffer of size nBufSize, and is filled with utf-8 encoded string

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -136,11 +136,6 @@ begin
 
     CGEApp_Open(InitialWidth, InitialHeight, 0, Dpi);
 
-    {$ifdef DARWIN}
-    if (GLVersion <> nil) and GLVersion.AtLeast(3, 2) then
-        TGLFeatures.RequestCapabilities := rcForceModern;
-    {$endif}
-
     Crosshair := TCrosshairManager.Create;
   except
     on E: TObject do WritelnWarning('Window', 'CGE_Open: ' + ExceptMessage(E));

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -1,6 +1,6 @@
 { -*- compile-command: "./castleengine_compile.sh" -*- }
 {
-  Copyright 2013-2023 Jan Adamec, Michalis Kamburelis.
+  Copyright 2013-2024 Jan Adamec, Michalis Kamburelis.
 
   This file is part of "Castle Game Engine".
 
@@ -34,7 +34,7 @@
 library castleengine;
 
 uses CTypes, Math, SysUtils, CastleUtils,
-  Classes, CastleKeysMouse, CastleCameras, CastleVectors, CastleGLUtils,
+  Classes, CastleKeysMouse, CastleCameras, CastleVectors, CastleGLUtils, CastleGLVersion,
   CastleImages, CastleSceneCore, CastleUIControls, X3DNodes, X3DFields, CastleLog,
   CastleBoxes, CastleControls, CastleInputs, CastleApplicationProperties,
   CastleWindow, CastleViewport, CastleScene, CastleTransform;
@@ -135,6 +135,11 @@ begin
     PreviousNavigationType := Viewport.NavigationType;
 
     CGEApp_Open(InitialWidth, InitialHeight, 0, Dpi);
+
+    {$ifdef DARWIN}
+    if (GLVersion <> nil) and GLVersion.AtLeast(3, 2) then
+        TGLFeatures.RequestCapabilities := rcForceModern;
+    {$endif}
 
     Crosshair := TCrosshairManager.Create;
   except
@@ -352,6 +357,17 @@ begin
     Viewport.AssignDefaultNavigation;
   except
     on E: TObject do WritelnWarning('Window', 'CGE_LoadSceneFromFile: ' + ExceptMessage(E));
+  end;
+end;
+
+procedure CGE_SaveSceneToFile(szFile: pcchar); cdecl;
+begin
+  if not CGE_VerifyScene('CGE_SaveSceneToFile') then
+    exit;
+  try
+    MainScene.Save(StrPas(PChar(szFile)));
+  except
+    on E: TObject do WritelnWarning('Window', 'CGE_SaveSceneToFile: ' + ExceptMessage(E));
   end;
 end;
 
@@ -946,6 +962,7 @@ exports
   CGE_KeyDown,
   CGE_KeyUp,
   CGE_LoadSceneFromFile,
+  CGE_SaveSceneToFile,
   CGE_SetNavigationInputShortcut,
   CGE_GetNavigationType,
   CGE_SetNavigationType,

--- a/src/deprecated_library/castlelib_dynloader.pas
+++ b/src/deprecated_library/castlelib_dynloader.pas
@@ -275,6 +275,7 @@ procedure CGE_MouseWheel(zDelta: cFloat; bVertical: cBool); cdecl; external 'cas
 procedure CGE_KeyDown(eKey: CInt32); cdecl; external 'castleengine';
 procedure CGE_KeyUp(eKey: CInt32); cdecl; external 'castleengine';
 procedure CGE_LoadSceneFromFile(szFile: pcchar); cdecl; external 'castleengine';
+procedure CGE_SaveSceneToFile(szFile: pcchar); cdecl; external 'castleengine';
 function CGE_GetViewpointsCount(): cInt32; cdecl; external 'castleengine';
 procedure CGE_GetViewpointName(iViewpointIdx: cInt32; szName: pchar; nBufSize: cInt32); cdecl; external 'castleengine';
 procedure CGE_MoveToViewpoint(iViewpointIdx: cInt32; bAnimated: cBool); cdecl; external 'castleengine';


### PR DESCRIPTION
It is handy to have the function to save scene to file (X3D, STL) in the (deprecated) library interface.

I've also added command to force modern rendering (GLFeatures.RequestCapabilities := rcForceModern;) for macOS, which is exactly on par how CastleControl and Cocoa backend work on macOS after requesting OpenGL CoreProfile.

Thanks.