### PR TITLE
Unicode menu items

### DIFF
--- a/src/window/castlewindow_cocoa.inc
+++ b/src/window/castlewindow_cocoa.inc
@@ -1030,7 +1030,7 @@ procedure TCastleWindow.SetCaption(const Part: TCaptionPart; const Value: String
 begin
   FCaption[Part] := Value;
   if not Closed then
-    ref.setTitle(NSSTR(GetWholeCaption));
+    ref.setTitle(NSString.stringWithUTF8String(PChar(GetWholeCaption)));
 end;
 
 procedure TCastleWindow.BackendMakeCurrent;

--- a/src/window/castlewindow_cocoa_menu.inc
+++ b/src/window/castlewindow_cocoa_menu.inc
@@ -89,7 +89,7 @@ procedure TCastleWindow.BackendMenuInitialize;
       CocoaMenuKey(EntryItem.KeyString, EntryItem.Key, EntryItem.Modifiers,
         CocoaKeyEquivalent, CocoaKeyModifier);
       CocoaMenuItem := TCocoaMenuItem.alloc.initWithTitle_action_keyEquivalent(
-        NSSTR(SRemoveMnemonics(EntryItem.Caption)),
+        NSString.stringWithUTF8String(PChar(SRemoveMnemonics(EntryItem.Caption))),
         ObjCSelector('castleClick:'),
         NSSTR(CocoaKeyEquivalent)
       );
@@ -109,12 +109,12 @@ procedure TCastleWindow.BackendMenuInitialize;
     begin
       EntryMenu := TMenu(Entry);
       CocoaSubMenu := NSMenu.alloc.initWithTitle(
-        NSSTR(SRemoveMnemonics(EntryMenu.Caption)));
+        NSString.stringWithUTF8String(PChar(SRemoveMnemonics(EntryMenu.Caption))));
       CocoaSubMenu.setAutoenablesItems(false);
       for I := 0 to EntryMenu.Count - 1 do
         AddMenuItem(CocoaSubMenu, EntryMenu.Entries[I]);
       CocoaMenuItem := NSMenuItem.alloc.initWithTitle_action_keyEquivalent(
-        NSSTR(SRemoveMnemonics(EntryMenu.Caption)), nil,
+        NSString.stringWithUTF8String(PChar(SRemoveMnemonics(EntryMenu.Caption))), nil,
         NSSTR('')).autorelease;
       CocoaMenuItem.SetEnabled(EntryMenu.Enabled and (not MenuForcefullyDisabled));
       CocoaMenuItem.setSubmenu(CocoaSubMenu);

--- a/src/window/windows/castlewindow_winapi_menu.inc
+++ b/src/window/windows/castlewindow_winapi_menu.inc
@@ -87,7 +87,7 @@
 function MakeWinapiMenuCore(Menu: TMenu;
   MenuBar: boolean; ParentAllowsEnabled: boolean): HMenu;
 
-  function SMnemonicsToWin(const S: string): UnicodeString;
+  function SMnemonicsToWin(const S: string): string;
   var
     SPos, ResultPos: Integer;
   begin
@@ -139,7 +139,7 @@ function MakeWinapiMenuCore(Menu: TMenu;
     OSCheck( AppendMenuW(Result,
       MF_STRING or MF_POPUP or EnabledFlag(Menu.Enabled and ParentAllowsEnabled),
       UINT(MakeWinapiMenuCore(Menu, false, true)),
-      PWideChar(SMnemonicsToWin(Menu.Caption))) );
+      PWideChar(StringToUtf16(SMnemonicsToWin(Menu.Caption)))) );
   end;
 
   procedure AppendGLMenuItem(MenuItem: TMenuItem; ParentAllowsEnabled: boolean);
@@ -163,7 +163,7 @@ function MakeWinapiMenuCore(Menu: TMenu;
     { Don't use here MenuItem.CaptionWithKey.
       Instead use #9 to delimit key names.
       This way our key shortcuts will be drawn nicely. }
-    WinMenuCaption := SMnemonicsToWin(MenuItem.Caption);
+    WinMenuCaption := StringToUtf16(SMnemonicsToWin(MenuItem.Caption));
     if MenuItem.KeyToString(KeyStr) then
       WinMenuCaption := WinMenuCaption + #9 + UnicodeString(KeyStr);
 


### PR DESCRIPTION
This fixes the issue 100 in Castle Model Viewer (https://github.com/castle-engine/castle-model-viewer/issues/100), where UTF8 strings (e.g. viewpoints names, file names) with non-ASCII characters did not show correctly in menu items. 

Fixes:
1. WinAPI menu items (for viewpoint names and recent file names)
2. Cocoa menu items (for viewpoint names and recent file names)
3. Cocoa window title (for currently opened file name)

Not sure if NSString.stringWithUTF8String leaks or not, seems similar to NSSTR inline function (which calls CFStringMakeConstantString). I did a test in Activity monitor, did not see anything, so it should be probably fine or not so important.