### PR TITLE
Fixed Qt OpenGLWidget framebuffers handling in our Qt library example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ castle-game-engine-*.fpm
 /examples/curves/use_designed_curve/use_designed_curve
 /examples/delphi/fmx/CastleFmx
 /examples/deprecated_library/build-qt_library_tester-*
+/examples/deprecated_library/qt_library_tester/build
 /examples/deprecated_library/cpp_winapi_library_tester/Debug
 /examples/deprecated_library/cpp_winapi_library_tester/Release
 /examples/deprecated_library/cpp_winapi_library_tester/x64

--- a/examples/deprecated_library/qt_library_tester/glwidget.cpp
+++ b/examples/deprecated_library/qt_library_tester/glwidget.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2014 Jan Adamec, Michalis Kamburelis.
+  Copyright 2014-2024 Jan Adamec, Michalis Kamburelis.
 
   This file is part of "Castle Game Engine".
 
@@ -129,7 +129,12 @@ void GLWidget::OnUpdateTimer()
 {
     if (!m_bAfterInit) return;
 
+    makeCurrent();  // be sure we have the right context set
+
     CGE_Update();
+
+    doneCurrent();
+
     if (!m_bLimitFPS || m_bNeedsDisplay)
     {
         m_bNeedsDisplay = false;
@@ -139,7 +144,7 @@ void GLWidget::OnUpdateTimer()
 
 void GLWidget::updateGL()
 {
-    update(); // TODO: Qt6 really?
+    update();
 }
 
 void GLWidget::paintGL()

--- a/examples/deprecated_library/qt_library_tester/mainwindow.cpp
+++ b/examples/deprecated_library/qt_library_tester/mainwindow.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2014 Jan Adamec, Michalis Kamburelis.
+  Copyright 2014-2024 Jan Adamec, Michalis Kamburelis.
 
   This file is part of "Castle Game Engine".
 
@@ -37,6 +37,11 @@ MainWindow::MainWindow(QWidget *parent) :
 
     QSurfaceFormat aFormat;
     aFormat.setSamples(4);
+    aFormat.setDepthBufferSize(24);
+    aFormat.setStencilBufferSize(8);
+    aFormat.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
+    aFormat.setSwapInterval(1);
+    QSurfaceFormat::setDefaultFormat(aFormat);
 
     m_pGlWidget = new GLWidget(aFormat, this);    // init with multisampling
     setCentralWidget(m_pGlWidget);
@@ -234,8 +239,12 @@ void MainWindow::MenuShowWarningClick()
 
 void MainWindow::MenuOpenGLInfoClick()
 {
+    m_pGlWidget->makeCurrent();
+
     char szBuf[8192];
     CGE_GetOpenGLInformation(szBuf, 8192);
+
+    m_pGlWidget->doneCurrent();
 
     QDialog aDlg(this);
     aDlg.setWindowTitle(tr("OpenGL Information"));


### PR DESCRIPTION
This also fixes most issues with invalid Qt framebuffers passed to CGE on all platforms.