### PR TITLE
Setting UIScaling to EncloseReferenceSizeAutoOrientation in simple_3d_demo

### DIFF
--- a/examples/mobile/simple_3d_demo/data/CastleSettings.xml
+++ b/examples/mobile/simple_3d_demo/data/CastleSettings.xml
@@ -7,7 +7,7 @@
 
 <castle_settings>
   <ui_scaling
-    mode="EncloseReferenceSize"
+    mode="EncloseReferenceSizeAutoOrientation"
     reference_width="1600"
     reference_height="900"
   />


### PR DESCRIPTION
... works much better on iOS
As discussed in issue #634 . This PR solves that issue.