### PR TITLE
Adding PreventInfiniteFallingDown option to deprecated library

### DIFF
--- a/examples/deprecated_library/qt_library_tester/mainwindow.cpp
+++ b/examples/deprecated_library/qt_library_tester/mainwindow.cpp
@@ -130,6 +130,8 @@ void MainWindow::UpdateAfterSceneLoaded()
     ui->actionHeadlight->setChecked(CGE_GetVariableInt(ecgevarHeadlight)>0);
     ui->actionSSAO->setChecked(CGE_GetVariableInt(ecgevarEffectSSAO)>0);
 
+    CGE_SetVariableInt(ecgevarPreventInfiniteFallingDown, 1);
+
     if (m_aNavKeeper.ApplyState())  // when scene loading was caused by reloading (changing multisampling, etc)
         UpdateNavigationButtons();
 }

--- a/src/deprecated_library/castleengine.h
+++ b/src/deprecated_library/castleengine.h
@@ -64,6 +64,7 @@ enum ECgeVariable   // used for querying engine parameters in CGE_Set/GetVariabl
     ecgevarHeadlight       = 8,   // avatar's headlight (int, 1 = on, 0 = off)
     ecgevarOcclusionCulling  = 9,   // occlusion culling (int, 1 = on, 0 = off)
     ecgevarPhongShading    = 10,  // phong shading (int, 1 = on, 0 = off)
+    ecgevarPreventInfiniteFallingDown = 11,  // prevent infinite falling down (int, 1 = on, 0 = off)
 };
 
 enum ECgeNavigationType

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -755,6 +755,9 @@ begin
             if MainScene <> nil then
                MainScene.RenderOptions.PhongShading := (nValue > 0);
           end;
+      11: begin    // ecgevarPreventInfiniteFallingDown
+            Viewport.PreventInfiniteFallingDown := (nValue > 0);
+          end;
     end;
   except
     on E: TObject do WritelnWarning('Window', 'CGE_SetVariableInt: ' + ExceptMessage(E));

--- a/src/deprecated_library/castlelib_dynloader.pas
+++ b/src/deprecated_library/castlelib_dynloader.pas
@@ -62,6 +62,7 @@ const
   ecgevarHeadlight       = 8;   // avatar's headlight (int, 1 = on, 0 = off)
   ecgevarOcclusionCulling = 9;  // occlusion culling (int, 1 = on, 0 = off)
   ecgevarPhongShading    = 10;  // phong shading (int, 1 = on, 0 = off)
+  ecgevarPreventInfiniteFallingDown = 11;  // prevent infinite falling down (int, 1 = on, 0 = off)
 
   // navigation types (ECgeNavigationType enum)
   ecgenavWalk      = 0;


### PR DESCRIPTION
This option is super handy. Is by default on in Castle Model Viewer, so it would be good to provide a way to switch it on even in the library interface.
Thanks.