### PR TITLE
Increase float digits display in Object Inspector from 2 to 5

### DIFF
--- a/src/base/castleutils_miscella.inc
+++ b/src/base/castleutils_miscella.inc
@@ -157,11 +157,11 @@ function FloatToStrFDot(const Value: Extended;
   absolute precision):
   always decimal,
   no digits after dot if not necessary,
-  show some digits (but not too many - right now 2) after dot if they are meaningful.
+  show some digits (default is 2) after dot if they are meaningful.
 
   Like other ...Dot routines, always uses dot (.) as a decimal separator,
   regardless of the user's locale settings. }
-function FloatToStrDisplay(const AValue: Extended): String;
+function FloatToStrDisplay(const AValue: Extended; const ADigits: Byte = 2): String;
 
 { Like standard TryStrToFloat, but always uses dot (.) as a decimal separator
   for the floating point numbers, regardless of the user's locale settings.
@@ -439,14 +439,14 @@ begin
   Result := FloatToStrF(Value, FloatFormat, Precision, Digits, FormatSettings);
 end;
 
-function FloatToStrDisplay(const AValue: Extended): String;
+function FloatToStrDisplay(const AValue: Extended; const ADigits: Byte = 2): String;
 begin
   Result := FloatToStrFDot(AValue, ffFixed,
     { With FPC, Precision = 0 is also OK, but with Delphi it's not,
       it will use scientific notation then early, e.g. for 123.0.
       See TTestCastleUtils.TestFloatToStrDisplay testcase. }
     20,
-    2);
+    ADigits);
 
   { We remove trailing zeroes after decimal separator, we don't need them.
     A less hacky way (that doesn't involve string fixing) would be nicer,

--- a/src/lcl/castlepropedits_vector.inc
+++ b/src/lcl/castlepropedits_vector.inc
@@ -55,9 +55,13 @@ end;
 function TCastleVector2PropertyEditor.GetValue: String;
 var
   VectorPersistent: TCastleVector2Persistent;
+  Vector: TVector2;
 begin
   VectorPersistent := (GetObjectValue as TCastleVector2Persistent);
-  Result := VectorPersistent.Value.ToString;
+  Vector := VectorPersistent.Value;
+  Result :=
+    FloatToStrDisplay(Vector.X, 5) + ' ' +
+    FloatToStrDisplay(Vector.Y, 5);
 end;
 
 procedure TCastleVector2PropertyEditor.SetAllValues(const NewValue: TVector2);
@@ -148,9 +152,14 @@ end;
 function TCastleVector3PropertyEditor.GetValue: String;
 var
   VectorPersistent: TCastleVector3Persistent;
+  Vector: TVector3;
 begin
   VectorPersistent := (GetObjectValue as TCastleVector3Persistent);
-  Result := VectorPersistent.Value.ToString;
+  Vector := VectorPersistent.Value;
+  Result :=
+    FloatToStrDisplay(Vector.X, 5) + ' ' +
+    FloatToStrDisplay(Vector.Y, 5) + ' ' +
+    FloatToStrDisplay(Vector.Z, 5);
 end;
 
 procedure TCastleVector3PropertyEditor.SetAllValues(const NewValue: TVector3);
@@ -394,9 +403,9 @@ begin
   ]);
   *)
   Result := FormatDot('%s %s %s deg(%s)', [
-    FloatToStrDisplay(Value.X),
-    FloatToStrDisplay(Value.Y),
-    FloatToStrDisplay(Value.Z),
-    FloatToStrDisplay(RadToDeg(Value.W))
+    FloatToStrDisplay(Value.X, 5),
+    FloatToStrDisplay(Value.Y, 5),
+    FloatToStrDisplay(Value.Z, 5),
+    FloatToStrDisplay(RadToDeg(Value.W), 5)
   ]);
 end;

--- a/tools/castle-editor/components/castleeditorpropedits.pas
+++ b/tools/castle-editor/components/castleeditorpropedits.pas
@@ -25,6 +25,7 @@ uses Classes, PropEdits, Forms, CastleColors, CastleTransform, CastlePropEdits;
 {$define read_interface}
 {$I castleeditorpropedits_color.inc}
 {$I castleeditorpropedits_physics_layer.inc}
+{$I castleeditorpropedits_float.inc}
 {$undef read_interface}
 
 procedure Register;
@@ -37,11 +38,13 @@ uses // FPC and LCL units
   ComponentEditors,
   // CGE units
   FormCastleColorPicker, FormLayerCollisionsPropertyEditor,
-  FormPhysicsLayerNamesPropertyEditor, CastleStringUtils;
+  FormPhysicsLayerNamesPropertyEditor, CastleStringUtils,
+  CastleUtils;
 
 {$define read_implementation}
 {$I castleeditorpropedits_color.inc}
 {$I castleeditorpropedits_physics_layer.inc}
+{$I castleeditorpropedits_float.inc}
 
 procedure Register;
 begin
@@ -56,6 +59,13 @@ begin
     TPhysicsLayerCollisionsPropertyEditor);
   RegisterPropertyEditor(TypeInfo(TCastleLayerNames), nil, '',
     TPhysicsLayerNamesPropertyEditor);
+
+  RegisterPropertyEditor(TypeInfo(Single), nil, '',
+    TCastleFloatPropertyEditor);
+  RegisterPropertyEditor(TypeInfo(Double), nil, '',
+    TCastleFloatPropertyEditor);
+  RegisterPropertyEditor(TypeInfo(Extended), nil, '',
+    TCastleFloatPropertyEditor);
 end;
 
 end.

--- a/tools/castle-editor/components/castleeditorpropedits_float.inc
+++ b/tools/castle-editor/components/castleeditorpropedits_float.inc
@@ -1,0 +1,49 @@
+{%MainUnit castleeditorpropedits.pas}
+{
+  Copyright 2024-2024 Trung Le (Kagamma).
+
+  This file is part of "Castle Game Engine".
+
+  "Castle Game Engine" is free software; see the file COPYING.txt,
+  included in this distribution, for details about the copyright.
+
+  "Castle Game Engine" is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+  ----------------------------------------------------------------------------
+}
+
+{ TCastleFloatPropertyEditor ------------------------------------------------- }
+
+{$ifdef read_interface}
+
+type
+  TCastleFloatPropertyEditor = class(TFloatPropertyEditor)
+  public
+    function FormatValue(const AValue: Extended): String;
+    function GetDefaultValue: AnsiString; override;
+    function GetValue: AnsiString; override;
+  end;
+{$endif read_interface}
+
+{$ifdef read_implementation}
+
+function TCastleFloatPropertyEditor.FormatValue(const AValue: Extended): String;
+begin
+  Result := FloatToStrDisplay(AValue, 5);
+end;
+
+function TCastleFloatPropertyEditor.GetDefaultValue: AnsiString;
+begin
+  if not HasDefaultValue then
+    raise EPropertyError.Create('No property default available');
+  Result := FormatValue(0);
+end;
+
+function TCastleFloatPropertyEditor.GetValue: AnsiString;
+begin
+  Result := FormatValue(GetFloatValue);
+end;
+
+{$endif read_implementation}


### PR DESCRIPTION
This PR partially fix https://github.com/castle-engine/castle-engine/issues/604, by increasing the number of display digits from 2 to 5.
Try to increase more than 5 will likely result in rounding issue in a lot of cases.
![image](https://github.com/user-attachments/assets/a68887a0-8939-4401-be4a-2e6090378f51)
