### PR TITLE
Set WalkNavigation MouseDragMode to rotate in deprecated library when automatic touch interface is set

### DIFF
--- a/examples/deprecated_library/cpp_winapi_library_tester/main.cpp
+++ b/examples/deprecated_library/cpp_winapi_library_tester/main.cpp
@@ -382,7 +382,7 @@ bool Init()
         CGE_Initialize(applicationConfigDirectory);
         CGE_Open(ecgeofLog, g_windowWidth, g_windowHeight, 96);
         CGE_SetLibraryCallbackProc(OpenGlLibraryCallback);
-        CGE_SetUserInterface(true);
+        CGE_SetAutoTouchInterface(false);
         //CGE_LoadSceneFromFile("c:\\projects\\humanoid_stand.wrl");
         ShowOpenFileDialog();
         return true;

--- a/examples/deprecated_library/lazarus_library_tester/cge_dynlib_tester_form.pas
+++ b/examples/deprecated_library/lazarus_library_tester/cge_dynlib_tester_form.pas
@@ -144,7 +144,7 @@ begin
   CGE_Initialize(PCChar(PChar(GetAppConfigDir(false))));
   CGE_Open(ecgeofLog, OpenGLControl1.Width, OpenGLControl1.Height, 96);
   CGE_SetLibraryCallbackProc(@OpenGlLibraryCallback);
-  CGE_SetUserInterface(true);
+  CGE_SetAutoTouchInterface(false);
   sFile := 'data/bridge_level/bridge_final.x3dv';
   CGE_LoadSceneFromFile(@sFile[1]);
   UpdateUIAfterOpen;

--- a/examples/deprecated_library/qt_library_tester/glwidget.cpp
+++ b/examples/deprecated_library/qt_library_tester/glwidget.cpp
@@ -118,7 +118,7 @@ void GLWidget::initializeGL()
     QString configDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
     CGE_Initialize(configDir.toUtf8());
     CGE_Open(ecgeofLog, width()*dPixRatio, height()*dPixRatio, logicalDpiY());
-    CGE_SetUserInterface(false);
+    CGE_SetAutoTouchInterface(false);
     CGE_SetLibraryCallbackProc(OpenGlLibraryCallback);
     m_bAfterInit = true;
     if (!m_sSceneToOpen.isEmpty())

--- a/src/deprecated_library/castleengine.h
+++ b/src/deprecated_library/castleengine.h
@@ -58,7 +58,7 @@ enum ECgeVariable   // used for querying engine parameters in CGE_Set/GetVariabl
     ecgevarMouseLook       = 2,   // activate mouse look viewing mode, desktop interface only (int, 1 or 0)
     ecgevarCrossHair       = 3,   // show crosshair in the center of the screen (int, 1 or 0)
     ecgevarAnimationRunning = 4,  // (read-only) engine would like to progress with the animation (int, 1 or 0)
-    ecgevarWalkTouchCtl    = 5,   // walking touch control (int, one of ECgeTouchCtlInterface values)
+    ecgevarAutoWalkTouchInterface = 5,   // walking touch control (int, one of ECgeTouchCtlInterface values)
     ecgevarScenePaused     = 6,   // pause Viewport (int, 1 = on, 0 = off)
     ecgevarAutoRedisplay   = 7,   // automatically redraws the window all the time (int, 1 = on, 0 = off)
     ecgevarHeadlight       = 8,   // avatar's headlight (int, 1 = on, 0 = off)
@@ -79,11 +79,18 @@ enum ECgeNavigationType
 
 enum ECgeTouchCtlInterface
 {
-    ecgetciNone              = 0,
-    ecgetciCtlWalkCtlRotate  = 1,
-    ecgetciCtlWalkDragRotate = 2,
-    etciCtlFlyCtlWalkDragRotate = 3,
-    etciCtlPanXYDragRotate   = 4,
+    ecgetiNone       = 0,   // no touch controls
+    ecgetiWalk       = 1,   // right control for walking
+    ecgetiWalkRotate = 2,   // right control for walking, left for rotation 
+    ecgetiFlyWalk    = 3,   
+    ecgetiPan        = 4,
+};
+
+enum ECgeMouseDragMode
+{
+    ecgemdWalkRotate = 0,   // moves and rotates avatar depending on the direction of mouse drag
+    ecgemdRotate     = 1,   // rotates the head when mouse is moved
+    ecgemdNone       = 2,   // ignores the dragging
 };
 
 enum ECgeUIScaling
@@ -306,7 +313,6 @@ extern void CGE_Open(unsigned uiFlags, unsigned initialWidth, unsigned initialHe
 extern void CGE_Close(bool quitWhenLastWindowClosed);
 extern void CGE_GetOpenGLInformation(char *szBuffer, int nBufSize);        // szBuffer is filled inside the function with max size of nBufSize
 extern void CGE_GetCastleEngineVersion(char *szBuffer, int nBufSize);      // szBuffer is filled inside the function with max size of nBufSize
-extern void CGE_SetUserInterface(bool bAutomaticTouchInterface); // should be called at the start of the program. Touch interface controls will be updated automatically then.
 
 extern void CGE_Resize(unsigned uiViewWidth, unsigned uiViewHeight);       // let the library know about the viewport size changes
 extern void CGE_Render(void);                                                  // paints the 3d scene into the context
@@ -343,8 +349,9 @@ extern void CGE_SetNavigationInputShortcut(int /*ECgeNavigationInput*/ eInput,
 
 extern int CGE_GetNavigationType(void);
 extern void CGE_SetNavigationType(int /*ECgeNavigationType*/ eNewType);
-
 extern void CGE_SetTouchInterface(int /*ECgeTouchCtlInterface*/ eMode);
+extern void CGE_SetAutoTouchInterface(bool bAutomaticTouchInterface); // should be called at the start of the program. Touch interface controls will be updated automatically then.
+extern void CGE_SetWalkNavigationMouseDragMode(int /*ECgeMouseDragMode*/ eMode);
 
 extern void CGE_SetVariableInt(int /*ECgeVariable*/ eVar, int nValue);
 extern int CGE_GetVariableInt(int /*ECgeVariable*/ eVar);

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -624,23 +624,23 @@ end;
 function cgehelper_TouchInterfaceFromConst(eMode: cInt32): TTouchInterface;
 begin
   case eMode of
-    0: Result := tiNone;
-    1: Result := tiWalk;
-    2: Result := tiWalkRotate;
-    3: Result := tiFlyWalk;
-    4: Result := tiPan;
+    0: Result := tiNone;       // ecgetciNone
+    1: Result := tiWalkRotate; // ecgetciCtlWalkCtlRotate
+    2: Result := tiWalk;       // ecgetciCtlWalkDragRotate
+    3: Result := tiFlyWalk;    // etciCtlFlyCtlWalkDragRotate
+    4: Result := tiPan;        // etciCtlPanXYDragRotate
     else raise EInternalError.CreateFmt('cgehelper_TouchInterfaceFromConst: Invalid touch interface mode %d', [eMode]);
   end;
 end;
 
 function cgehelper_ConstFromTouchInterface(eMode: TTouchInterface): cInt32;
 begin
-  Result := 0;
+  Result := 0;    // ecgetciNone
   case eMode of
-    tiWalk: Result := 1;
-    tiWalkRotate: Result := 2;
-    tiFlyWalk: Result := 3;
-    tiPan: Result := 4;
+    tiWalk: Result := 2;       // ecgetciCtlWalkDragRotate
+    tiWalkRotate: Result := 1; // ecgetciCtlWalkCtlRotate
+    tiFlyWalk: Result := 3;    // etciCtlFlyCtlWalkDragRotate
+    tiPan: Result := 4;        // etciCtlPanXYDragRotate
   end;
 end;
 
@@ -657,10 +657,6 @@ procedure CGE_SetUserInterface(bAutomaticTouchInterface: cBool); cdecl;
 begin
   try
     TouchNavigation.AutoTouchInterface := bAutomaticTouchInterface;
-    if bAutomaticTouchInterface then
-       Viewport.InternalWalkNavigation.MouseDragMode := mdRotate
-    else
-       Viewport.InternalWalkNavigation.MouseDragMode := mdWalkRotate;
   except
     on E: TObject do WritelnWarning('Window', 'CGE_SetUserInterface: ' + ExceptMessage(E));
   end;
@@ -735,6 +731,12 @@ begin
 
       5: begin    // ecgevarWalkTouchCtl
            TouchNavigation.AutoWalkTouchInterface := cgehelper_TouchInterfaceFromConst(nValue);
+
+           // also set the mouse dragging for constants with *DragRotate
+           if (nValue = 2 {ecgetciCtlWalkDragRotate}) or (nValue = 3 {etciCtlFlyCtlWalkDragRotate}) or (nValue = 4 {etciCtlPanXYDragRotate}) then
+             Viewport.InternalWalkNavigation.MouseDragMode := mdRotate
+           else
+             Viewport.InternalWalkNavigation.MouseDragMode := mdWalkRotate;
          end;
 
       6: begin    // ecgevarScenePaused

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -624,23 +624,23 @@ end;
 function cgehelper_TouchInterfaceFromConst(eMode: cInt32): TTouchInterface;
 begin
   case eMode of
-    0: Result := tiNone;       // ecgetciNone
-    1: Result := tiWalkRotate; // ecgetciCtlWalkCtlRotate
-    2: Result := tiWalk;       // ecgetciCtlWalkDragRotate
-    3: Result := tiFlyWalk;    // etciCtlFlyCtlWalkDragRotate
-    4: Result := tiPan;        // etciCtlPanXYDragRotate
+    0: Result := tiNone;
+    1: Result := tiWalk;
+    2: Result := tiWalkRotate;
+    3: Result := tiFlyWalk;
+    4: Result := tiPan;
     else raise EInternalError.CreateFmt('cgehelper_TouchInterfaceFromConst: Invalid touch interface mode %d', [eMode]);
   end;
 end;
 
 function cgehelper_ConstFromTouchInterface(eMode: TTouchInterface): cInt32;
 begin
-  Result := 0;    // ecgetciNone
+  Result := 0;
   case eMode of
-    tiWalk: Result := 2;       // ecgetciCtlWalkDragRotate
-    tiWalkRotate: Result := 1; // ecgetciCtlWalkCtlRotate
-    tiFlyWalk: Result := 3;    // etciCtlFlyCtlWalkDragRotate
-    tiPan: Result := 4;        // etciCtlPanXYDragRotate
+    tiWalk: Result := 1;
+    tiWalkRotate: Result := 2;
+    tiFlyWalk: Result := 3;
+    tiPan: Result := 4;
   end;
 end;
 
@@ -653,12 +653,29 @@ begin
   end;
 end;
 
-procedure CGE_SetUserInterface(bAutomaticTouchInterface: cBool); cdecl;
+procedure CGE_SetAutoTouchInterface(bAutomaticTouchInterface: cBool); cdecl;
 begin
   try
     TouchNavigation.AutoTouchInterface := bAutomaticTouchInterface;
   except
-    on E: TObject do WritelnWarning('Window', 'CGE_SetUserInterface: ' + ExceptMessage(E));
+    on E: TObject do WritelnWarning('Window', 'CGE_SetAutoTouchInterface: ' + ExceptMessage(E));
+  end;
+end;
+
+procedure CGE_SetWalkNavigationMouseDragMode(eMode: cInt32); cdecl;
+var
+  NewMode: TMouseDragMode;
+begin
+  try
+    case eMode of
+      0: NewMode := mdWalkRotate;
+      1: NewMode := mdRotate;
+      2: NewMode := mdNone;
+      else raise EInternalError.CreateFmt('Invalid MouseDragMode mode %d', [eMode]);
+    end;
+    Viewport.InternalWalkNavigation.MouseDragMode := NewMode;
+  except
+    on E: TObject do WritelnWarning('Window', 'CGE_SetWalkNavigationMouseDragMode: ' + ExceptMessage(E));
   end;
 end;
 
@@ -729,14 +746,8 @@ begin
            end;
          end;
 
-      5: begin    // ecgevarWalkTouchCtl
+      5: begin    // ecgevarAutoWalkTouchInterface
            TouchNavigation.AutoWalkTouchInterface := cgehelper_TouchInterfaceFromConst(nValue);
-
-           // also set the mouse dragging for constants with *DragRotate
-           if (nValue = 2 {ecgetciCtlWalkDragRotate}) or (nValue = 3 {etciCtlFlyCtlWalkDragRotate}) or (nValue = 4 {etciCtlPanXYDragRotate}) then
-             Viewport.InternalWalkNavigation.MouseDragMode := mdRotate
-           else
-             Viewport.InternalWalkNavigation.MouseDragMode := mdWalkRotate;
          end;
 
       6: begin    // ecgevarScenePaused
@@ -836,7 +847,7 @@ begin
              Result := 0;
          end;
 
-      5: begin    // ecgevarWalkTouchCtl
+      5: begin    // ecgevarAutoWalkTouchInterface
            Result := cgehelper_ConstFromTouchInterface(TouchNavigation.AutoWalkTouchInterface);
          end;
 
@@ -1024,7 +1035,8 @@ exports
   CGE_MoveViewToCoords,
   CGE_SaveScreenshotToFile,
   CGE_SetTouchInterface,
-  CGE_SetUserInterface,
+  CGE_SetAutoTouchInterface,
+  CGE_SetWalkNavigationMouseDragMode,
   CGE_IncreaseSceneTime,
   CGE_SetVariableInt,
   CGE_GetVariableInt,

--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -427,9 +427,8 @@ begin
   try
     if not CGE_VerifyScene('CGE_AddViewpointFromCurrentView') then exit;
 
-    if Viewport.Navigation <> nil then
-      MainScene.AddViewpointFromNavigation(
-        Viewport.Navigation, StrPas(PChar(szName)));
+    MainScene.AddViewpointFromNavigation(
+      Viewport.RequiredNavigation, StrPas(PChar(szName)));
   except
     on E: TObject do WritelnWarning('Window', 'CGE_AddViewpointFromCurrentView: ' + ExceptMessage(E));
   end;
@@ -530,7 +529,7 @@ begin
     end;
 
     InputShortcut := nil;
-    Nav := Viewport.Navigation;
+    Nav := Viewport.RequiredNavigation;
     if Nav is TCastleWalkNavigation then
     begin
       WalkNavigation := TCastleWalkNavigation(Nav);
@@ -658,6 +657,10 @@ procedure CGE_SetUserInterface(bAutomaticTouchInterface: cBool); cdecl;
 begin
   try
     TouchNavigation.AutoTouchInterface := bAutomaticTouchInterface;
+    if bAutomaticTouchInterface then
+       Viewport.InternalWalkNavigation.MouseDragMode := mdRotate
+    else
+       Viewport.InternalWalkNavigation.MouseDragMode := mdWalkRotate;
   except
     on E: TObject do WritelnWarning('Window', 'CGE_SetUserInterface: ' + ExceptMessage(E));
   end;
@@ -680,7 +683,7 @@ function GetWalkNavigation: TCastleWalkNavigation;
 var
   Nav: TCastleNavigation;
 begin
-  Nav := Viewport.Navigation;
+  Nav := Viewport.RequiredNavigation;
   if Nav is TCastleWalkNavigation then
     Result := TCastleWalkNavigation(Nav)
   else

--- a/src/deprecated_library/castlelib_c_loader.cpp
+++ b/src/deprecated_library/castlelib_c_loader.cpp
@@ -83,7 +83,8 @@ typedef void (CDECL *PFNRD_CGE_SetNavigationInputShortcut)(int eInput, int eKey1
 typedef int (CDECL *PFNRD_CGE_GetNavigationType)();
 typedef void (CDECL *PFNRD_CGE_SetNavigationType)(int eNewType);
 typedef void (CDECL *PFNRD_CGE_SetTouchInterface)(int eMode);
-typedef void (CDECL *PFNRD_CGE_SetUserInterface)(bool bAutomaticTouchInterface);
+typedef void (CDECL *PFNRD_CGE_SetAutoTouchInterface)(bool bAutomaticTouchInterface);
+typedef void (CDECL *PFNRD_CGE_SetWalkNavigationMouseDragMode)(int eMode);
 
 typedef void (CDECL *PFNRD_CGE_SetVariableInt)(int eVar, int nValue);
 typedef int (CDECL *PFNRD_CGE_GetVariableInt)(int eVar);
@@ -122,7 +123,8 @@ PFNRD_CGE_SetNavigationInputShortcut pfrd_CGE_SetNavigationInputShortcut = NULL;
 PFNRD_CGE_GetNavigationType pfrd_CGE_GetNavigationType = NULL;
 PFNRD_CGE_SetNavigationType pfrd_CGE_SetNavigationType = NULL;
 PFNRD_CGE_SetTouchInterface pfrd_CGE_SetTouchInterface = NULL;
-PFNRD_CGE_SetUserInterface pfrd_CGE_SetUserInterface = NULL;
+PFNRD_CGE_SetAutoTouchInterface pfrd_CGE_SetAutoTouchInterface = NULL;
+PFNRD_CGE_SetWalkNavigationMouseDragMode pfrd_CGE_SetWalkNavigationMouseDragMode = NULL;
 PFNRD_CGE_SetVariableInt pfrd_CGE_SetVariableInt = NULL;
 PFNRD_CGE_GetVariableInt pfrd_CGE_GetVariableInt = NULL;
 PFNRD_CGE_SetNodeFieldValue pfrd_CGE_SetNodeFieldValue = NULL;
@@ -195,7 +197,8 @@ void CGE_LoadLibrary()
     pfrd_CGE_GetNavigationType = (PFNRD_CGE_GetNavigationType)cge_GetProc(hCgeDll, "CGE_GetNavigationType");
     pfrd_CGE_SetNavigationType = (PFNRD_CGE_SetNavigationType)cge_GetProc(hCgeDll, "CGE_SetNavigationType");
     pfrd_CGE_SetTouchInterface = (PFNRD_CGE_SetTouchInterface)cge_GetProc(hCgeDll, "CGE_SetTouchInterface");
-    pfrd_CGE_SetUserInterface = (PFNRD_CGE_SetUserInterface)cge_GetProc(hCgeDll, "CGE_SetUserInterface");
+    pfrd_CGE_SetAutoTouchInterface = (PFNRD_CGE_SetAutoTouchInterface)cge_GetProc(hCgeDll, "CGE_SetAutoTouchInterface");
+    pfrd_CGE_SetWalkNavigationMouseDragMode = (PFNRD_CGE_SetWalkNavigationMouseDragMode)cge_GetProc(hCgeDll, "CGE_SetWalkNavigationMouseDragMode");
     pfrd_CGE_SetVariableInt = (PFNRD_CGE_SetVariableInt)cge_GetProc(hCgeDll, "CGE_SetVariableInt");
     pfrd_CGE_GetVariableInt = (PFNRD_CGE_GetVariableInt)cge_GetProc(hCgeDll, "CGE_GetVariableInt");
     pfrd_CGE_SetNodeFieldValue = (PFNRD_CGE_SetNodeFieldValue)cge_GetProc(hCgeDll, "CGE_SetNodeFieldValue");
@@ -419,10 +422,17 @@ void CGE_SetTouchInterface(int /*ECgeTouchCtlInterface*/ eMode)
 }
 
 //-----------------------------------------------------------------------------
-void CGE_SetUserInterface(bool bAutomaticTouchInterface)
+void CGE_SetAutoTouchInterface(bool bAutomaticTouchInterface)
 {
-    if (pfrd_CGE_SetUserInterface!=NULL)
-        (*pfrd_CGE_SetUserInterface)(bAutomaticTouchInterface);
+    if (pfrd_CGE_SetAutoTouchInterface!=NULL)
+        (*pfrd_CGE_SetAutoTouchInterface)(bAutomaticTouchInterface);
+}
+
+//-----------------------------------------------------------------------------
+void CGE_SetWalkNavigationMouseDragMode(int /*ECgeMouseDragMode*/ eMode)
+{
+    if (pfrd_CGE_SetWalkNavigationMouseDragMode!=NULL)
+        (*pfrd_CGE_SetWalkNavigationMouseDragMode)(eMode);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/deprecated_library/castlelib_dynloader.pas
+++ b/src/deprecated_library/castlelib_dynloader.pas
@@ -56,7 +56,7 @@ const
   ecgevarMouseLook       = 2;   // activate mouse look viewing mode, desktop interface only (int, 1 or 0)
   ecgevarCrossHair       = 3;   // show crosshair in the center of the screen (int, 1 or 0)
   ecgevarAnimationRunning = 4;  // (read-only) engine would like to progress with the animation (int, 1 or 0)
-  ecgevarWalkTouchCtl    = 5;   // walking touch control (int, one of ECgeTouchCtlInterface values)
+  ecgevarAutoWalkTouchInterface = 5;   // walking touch control (int, one of ECgeTouchCtlInterface values)
   ecgevarScenePaused     = 6;   // pause Viewport (int, 1 = on, 0 = off)
   ecgevarAutoRedisplay   = 7;   // automatically redraws the window all the time (int, 1 = on, 0 = off)
   ecgevarHeadlight       = 8;   // avatar's headlight (int, 1 = on, 0 = off)
@@ -72,12 +72,12 @@ const
   ecgenavTurntable = 3;
   ecgenavNone      = 4;
 
-  // touch interface modes
-  tiNone              = 0;
-  tiCtlWalkCtlRotate  = 1;
-  tiCtlWalkDragRotate = 2;
-  tiCtlFlyCtlWalkDragRotate = 3;
-  tiCtlPanXYDragRotate   = 4;
+  // touch interface modes (ECgeTouchInterface enum)
+  ecgetiNone       = 0;
+  ecgetiWalk       = 1;
+  ecgetiWalkRotate = 2;
+  ecgetiFlyWalk    = 3;
+  ecgetiPan        = 4;
 
   // UI Scaling (ECgeUIScaling enum)
   ecgeusNone                  = 0;
@@ -301,7 +301,8 @@ procedure CGE_SetNavigationInputShortcut(eInput, eKey1, eKey2, eMouseButton, eMo
 function CGE_GetNavigationType(): cInt32; cdecl; external 'castleengine';
 procedure CGE_SetNavigationType(NewType: cInt32); cdecl; external 'castleengine';
 procedure CGE_SetTouchInterface(eMode: cInt32); cdecl; external 'castleengine';
-procedure CGE_SetUserInterface(AutomaticTouchInterface: cBool); cdecl; external 'castleengine';
+procedure CGE_SetAutoTouchInterface(AutomaticTouchInterface: cBool); cdecl; external 'castleengine';
+procedure CGE_SetWalkNavigationMouseDragMode(eMode: cInt32); cdecl; external 'castleengine';
 
 procedure CGE_SetVariableInt(eVar: cInt32; nValue: cInt32); cdecl; external 'castleengine';
 function CGE_GetVariableInt(eVar: cInt32): cInt32; cdecl; external 'castleengine';

--- a/src/deprecated_library/compile-iOS.sh
+++ b/src/deprecated_library/compile-iOS.sh
@@ -1,123 +1,26 @@
 #!/bin/bash
 set -e
 
-# Compile CGE library for 4 iOS targets.
+# ----------------------------------------------------------------------------
+# Compile CGE library for iOS targets.
 # See https://castle-engine.io/ios
+#
+# Executes the build tool, which in turn will execute FPC.
+# The build tool searches for FPC on $PATH.
+#
+# Note that the compilation artifacts will be in ./castle-engine-output/ , and that's good,
+# we want separate compilation artifacts (from other projects) to:
+#
+# 1. make sure that CastleWindow unit is compiled with LIBRARY backend,
+# 2. make sure that every unit is recompiled with -fPIC (necessary for .so on x86_64).
+# ----------------------------------------------------------------------------
 
-# Configurable variables -----------------------------------------------------
+# Never use cache, as it will likely contain CastleWindow with different backend, and units without -fPIC.
+castle-engine cache-clean
 
-# Whether to compile a version for iPhoneSimulator
-COMPILE_SIM=1
+# Variant not using CastleEngineManifest.xml
+#castle-engine simple-compile --target=ios --ios-simulator --compiler-option=-fPIC --compiler-option=-dCASTLE_WINDOW_LIBRARY --verbose castleengine.lpr
+#libtool -static -o libcastleengine.a castle-engine-output/compilation/aarch64-ios/lib_cge_project.a castle-engine-output/compilation/x86_64-iphonesim/lib_cge_project.a
 
-# Whether to compile a version for a real device (32-bit arm7 or arm64)
-COMPILE_ARM=1
-
-# Commands to use to run FPC cross-compilers for the appropriate targets.
-# The -V3.0.3 parameters are necessary if you got FPC from the
-# fpc-3.0.3.intel-macosx.cross.ios.dmg (official "FPC for iOS" installation).
-FPC_SIM_COMPILER="fpc -Pi386 -V3.0.3"
-FPC_SIM64_COMPILER="fpc -Px86_64 -V3.0.3"
-FPC_ARM_COMPILER="fpc -Parm"
-FPC_ARM64_COMPILER="fpc -Paarch64"
-
-# debug or release (for the exact meaning, see ../../castle-fpc.cfg)
-#FPC_CONFIG="-dDEBUG"
-FPC_CONFIG="-dRELEASE"
-
-# You can pass additional FPC parameters as this script parameters
-# So you can call, for example, 'compile-iOS.sh -dSOME_SYMBOL'
-FPC_CONFIG="${FPC_CONFIG} $@"
-
-# Functions ------------------------------------------------------------------
-
-run_logging ()
-{
-  echo "----------------------------------------------------------------------"
-  echo "Running: " "$@"
-  "$@"
-}
-
-# Run libtool to create library from .o files referenced in $1/link.res.
-# Output library is $1/$EXECUTABLE_NAME
-# Also update global OUTPUT_LIBRARIES_COUNT and OUTPUT_LIBRARIES vars.
-run_libtool ()
-{
-  local DIR="$1"
-  shift 1
-
-  local LINK_RES="${DIR}/link.res"
-  local OUTPUT_LIB="${DIR}/${EXECUTABLE_NAME}"
-
-  grep '\.o$' "${LINK_RES}" > compile_ios_filelist.tmp
-  run_logging libtool -static -o "${OUTPUT_LIB}" -filelist compile_ios_filelist.tmp
-  if [ ! -e "${OUTPUT_LIB}" ]; then
-    echo "Error: Output ${OUTPUT_LIB} not found"
-    exit 1
-  fi
-  rm -f compile_ios_filelist.tmp
-
-  OUTPUT_LIBRARIES[$OUTPUT_LIBRARIES_COUNT]="${OUTPUT_LIB}"
-  OUTPUT_LIBRARIES_COUNT=$(( $OUTPUT_LIBRARIES_COUNT + 1 ))
-}
-
-# Run fpc and libtool to build library inside dir $1.
-# The $2 and following parameters should specify OS/CPU specific
-# FPC command and switches.
-run_build ()
-{
-  local OUTPUT_DIR="$1"
-  shift 1
-
-  mkdir -p "${OUTPUT_DIR}"
-  # Note: $FPC_CONFIG must be specified before $FPC_COMMON,
-  # as $FPC_CONFIG contains -dDEBUG / -dRELEASE that determines
-  # switches set by $FPC_COMMON inside @castle-fpc.cfg.
-  run_logging "$@" $FPC_CONFIG $FPC_COMMON \
-    "-FU${OUTPUT_DIR}" "-o${OUTPUT_DIR}/${EXECUTABLE_NAME}" "${FPC_MAIN_FILE}"
-  run_libtool "${OUTPUT_DIR}"
-}
-
-# Main code ------------------------------------------------------------------
-
-# Go to the main CGE directory,
-# because the paths inside castle-fpc.cfg are relative to that directory,
-# so we have to execute "fpc @castle-fpc.cfg ..." from there.
-cd ../..
-
-EXECUTABLE_NAME="cge_library.a"
-FPC_MAIN_FILE="src/deprecated_library/castleengine.lpr"
-FPC_COMMON="-Cn -WP5.1 ${CASTLE_FPC_OPTIONS:-} @castle-fpc.cfg -dCASTLE_WINDOW_LIBRARY"
-LIBRARY_PATH="src/deprecated_library"
-OUTPUT_SIM="${LIBRARY_PATH}/ios-output/i386-iphonesim"
-OUTPUT_SIM64="${LIBRARY_PATH}/ios-output/x86_64-iphonesim"
-OUTPUT_ARM="${LIBRARY_PATH}/ios-output/arm-darwin"
-OUTPUT_ARM64="${LIBRARY_PATH}/ios-output/aarch64-darwin"
-SIMULATOR_SDK='/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk'
-DEVICE_SDK='/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk'
-
-declare -a OUTPUT_LIBRARIES
-OUTPUT_LIBRARIES_COUNT=0
-
-# compile for iPhone simulator
-if [ $COMPILE_SIM -eq 1 ]; then
-  run_build "${OUTPUT_SIM}"   $FPC_SIM_COMPILER   -Tiphonesim "-XR${SIMULATOR_SDK}"
-  run_build "${OUTPUT_SIM64}" $FPC_SIM64_COMPILER -Tiphonesim "-XR${SIMULATOR_SDK}"
-fi
-
-# compile for a physical device
-if [ $COMPILE_ARM -eq 1 ]; then
-  run_build "${OUTPUT_ARM}"   $FPC_ARM_COMPILER   -Tdarwin "-XR${DEVICE_SDK}" -Cparmv7 -Cfvfpv3
-  run_build "${OUTPUT_ARM64}" $FPC_ARM64_COMPILER -Tdarwin "-XR${DEVICE_SDK}"
-fi
-
-if [ $OUTPUT_LIBRARIES_COUNT -eq 0 ]; then
-  echo 'Nothing generated (you turned off generating output for both iPhoneSimulator and a real device)'
-  exit 1
-else
-  echo "----------------------------------------------------------------------"
-  echo "Combining together into a single library:"
-  run_logging libtool -static "${OUTPUT_LIBRARIES[@]}" -o "./$EXECUTABLE_NAME"
-  mv $EXECUTABLE_NAME "${LIBRARY_PATH}"
-  echo "----------------------------------------------------------------------"
-  echo "Done, output inside ${LIBRARY_PATH}/${EXECUTABLE_NAME}"
-fi
+# Variant using CastleEngineManifest.xml
+castle-engine compile --target ios --ios-simulator


### PR DESCRIPTION
Related to removing ControlMouseDragMode in commit https://github.com/castle-engine/castle-engine/commit/6ff0c154548e361d166a4a9616c99bd0485d00cf

We need to address this in the deprecated library. The AutoNavigationViewport used there, so it seems the sufficient solution is to set WalkNavigation MouseDragMode when CGE_SetUserInterface(true) is called to set the automatic touch interface.
