### PR TITLE
MacOS Compatibility fixes

### DIFF
--- a/src/base/castleutils.pas
+++ b/src/base/castleutils.pas
@@ -75,6 +75,7 @@ interface
 uses
   {$ifdef MSWINDOWS} Windows, {$ifndef FPC} ShlObj, {$endif} {$endif}
   {$ifdef UNIX} {$ifdef FPC} BaseUnix, Unix, Dl, {$else} Posix.Unistd, {$endif} {$endif}
+  {$ifdef MACOS} {$ifdef FPC} BaseUnix, Unix, Dl, {$else} Posix.Unistd, {$endif} {$endif}
   {$ifndef FPC} Classes, {$endif}
   Variants, SysUtils, Math, Generics.Collections;
 
@@ -90,6 +91,7 @@ uses
 {$I castleutils_primitive_lists.inc}
 {$I castleutils_program_exit.inc}
 {$ifdef UNIX}      {$I castleutils_os_specific_unix.inc}    {$endif}
+{$ifdef MACOS}     {$I castleutils_os_specific_unix.inc}    {$endif}
 {$ifdef MSWINDOWS} {$I castleutils_os_specific_windows.inc} {$endif}
 {$I castleutils_math.inc}
 {$I castleutils_filenames.inc}
@@ -119,6 +121,7 @@ implementation
   For Lazarus package this would prevent maintaining single .lpk file,
   see ../packages/README. }
 {$ifdef UNIX}      {$I castleutils_os_specific_unix.inc}    {$endif}
+{$ifdef MACOS}     {$I castleutils_os_specific_unix.inc}    {$endif}
 {$ifdef MSWINDOWS} {$I castleutils_os_specific_windows.inc} {$endif}
 
 {$I castleutils_pointers.inc}

--- a/src/base/castleutils_delphi_compatibility.inc
+++ b/src/base/castleutils_delphi_compatibility.inc
@@ -225,6 +225,17 @@ begin
       '.config' + PathDelim +
       ApplicationName + PathDelim;
 {$endif}
+
+{$ifdef MACOS}
+begin
+  // TODO: simplest implementation hardcoded now, look how FPC implements it
+  if Global then
+    Result := '/etc/' + ApplicationName + PathDelim
+  else
+    Result := IncludeTrailingPathDelimiter(GetEnvironmentVariable('HOME')) +
+      '.config' + PathDelim +
+      ApplicationName + PathDelim;
+{$endif}
 end;
 
 function StringsReplace(const S: string; OldPattern, NewPattern: array of string;  Flags: TReplaceFlags): string;

--- a/src/base/castleutils_filenames.inc
+++ b/src/base/castleutils_filenames.inc
@@ -21,6 +21,7 @@
 const
   { Root dir name. Empty if not applicable to this OS. }
   RootDir = {$ifdef UNIX} '/' {$endif}
+            {$ifdef MACOS} '/' {$endif}
             {$ifdef MSWINDOWS} '' {$endif} ;
 
   ExeExtension = {$ifdef MSWINDOWS} '.exe' {$else} '' {$endif};
@@ -177,6 +178,7 @@ end;
 function IsPathAbsolute(const Path: string): boolean;
 begin
   Result := {$ifdef UNIX} SCharIs(Path, 1, PathDelim) {$endif}
+            {$ifdef MACOS} SCharIs(Path, 1, PathDelim) {$endif}
             {$ifdef MSWINDOWS} SCharIs(Path, 2, DriveDelim) {$endif};
 end;
 


### PR DESCRIPTION
These are some very minor additions to bring CGE back towards MACOS compatibility
Note that I used castleutils_os_specific_unix.inc for Mac (should be OK)
Not 100% about castleutils_filenames.inc so kindly check it