### PR TITLE
[steam] Test Steam 1.61 additions

### DIFF
--- a/src/base/castledynlib.pas
+++ b/src/base/castledynlib.pas
@@ -23,7 +23,7 @@ interface
 uses SysUtils
   {$ifdef FPC}
     { With FPC, use cross-platform DynLibs unit. }
-    {$ifndef WASI}, DynLibs{$endif}
+    , DynLibs
   {$else}
     { With Delphi, use Windows functions directly.
       On non-Windows, Delphi SysUtils defines compatible functions
@@ -37,12 +37,7 @@ type
 
 const
   { Invalid TDynLibHandle value (meaning : LoadLibrary failed) }
-  InvalidDynLibHandle: TDynLibHandle =
-    {$if defined(FPC) and not defined(WASI)}
-    DynLibs.NilHandle
-    {$else}
-    0 // used with Delphi or FPC+WebAssembly
-    {$endif};
+  InvalidDynLibHandle: TDynLibHandle = {$ifdef FPC} DynLibs.NilHandle {$else} 0 {$endif};
 
 type
   { }
@@ -272,7 +267,7 @@ begin
     { On macOS, search for dynamic libraries in the bundle too.
       This fallback makes sense for libpng, libvorbisfile, libsteam_api...
       It seems that for everything, so just do it always. }
-    {$ifdef DARWIN}
+    {$if defined(DARWIN)}
     if (Handle = InvalidDynLibHandle) and (BundlePath <> '') then
       Handle := LoadLibrary(PChar(BundlePath + 'Contents/MacOS/' + AName));
     {$endif}

--- a/src/services/steam/castleinternalsteamapi.pas
+++ b/src/services/steam/castleinternalsteamapi.pas
@@ -44,6 +44,22 @@
     have provided in hunting down the specific calls
     that work and a few tricks to make them work properly.
 }
+
+{ USE_TESTING_API allows switching between an established tested API
+  and a newer API that is being tested. It makes upgrading between two
+  APIs far simpler as when defined an exception may be raised when
+  loading the library. The 'testing' library should be renamed to
+  include it's version as a suffix e.g. steam_api64.dll would be
+  renamed to steam_api64_161.dll and STEAMLIBVER, below, set to the matching
+  suffix.
+
+  After successful testing the constants below should all be the same
+  until a new API upgrade is required - essentially making the define = !define
+  and STEAMLIBVER should be an empty string ('')
+
+  II SHOULD NORMALLY NOT BE DEFINED - note also in CastleSteam while testing
+}
+
 unit CastleInternalSteamApi;
 
 {$I castleconf.inc}
@@ -70,8 +86,10 @@ type
   { It's a struct in C headers but can be passed as UInt64,
     defined in C headers with explicit ability to be typecasted as 64-bit int. }
   CGameID = UInt64;
+  CUserID = UInt64;
   EResult = UInt32;
   TAppId = UInt32;
+  PSteamErrMsg = PChar;
 
   { Express all "bool" from Steam API using this type.
 
@@ -89,15 +107,40 @@ type
     for non-1 values. }
   TSteamBool = ByteBool;
   PSteamBool = ^TSteamBool;
+  TCallbackBool = LongBool;
+  PCallbackBool = ^TCallbackBool;
 
 const
   { Versions of Steam API interfaces.
-    Correspond to Steamworks 1.57 version. }
+    Correspond to Steamworks 1.xx controlled by API_XXX with fallback to 1.57 version. }
+{$if defined(USE_TESTING_API)}
+  STEAMCLIENT_INTERFACE_VERSION = 'SteamClient021'; //< isteamclient.h
+  STEAMUSER_INTERFACE_VERSION = 'SteamUser023'; //< isteamuser.h
+  STEAMUSERSTATS_INTERFACE_VERSION = 'STEAMUSERSTATS_INTERFACE_VERSION013'; //< isteamuserstats.h
+  STEAMFRIENDS_INTERFACE_VERSION = 'SteamFriends017'; //< isteamuserstats.h
+  STEAMUTILS_INTERFACE_VERSION = 'SteamUtils010'; //< isteamuser.h
+  STEAMINPUT_INTERFACE_VERSION = 'SteamInput006'; //< isteaminput.h
+  STEAMAPPS_INTERFACE_VERSION = 'SteamApps008'; //< isteaminput.h
+  VersionSteamUtils = '010'; //< matches STEAMUTILS_INTERFACE_VERSION *and* accessor in steam_api_flat.h
+  VersionSteamApps = '008'; //< matches STEAMAPPS_INTERFACE_VERSION *and* accessor in steam_api_flat.h
+  VersionSteamUser = '023'; //< matches STEAMUTILS_INTERFACE_VERSION *and* accessor in steam_api_flat.h
+  VersionSteamFriends = '017'; //< matches STEAMFRIENDS_INTERFACE_VERSION *and* accessor in steam_api_flat.h
+  VersionSteamInput = '006'; //< matches STEAMINPUT_INTERFACE_VERSION *and* accessor in steam_api_flat.h
+  STEAMLIBVER = '_161';
+{$else}
   STEAMCLIENT_INTERFACE_VERSION = 'SteamClient020'; //< isteamclient.h
   STEAMUSER_INTERFACE_VERSION = 'SteamUser023'; //< isteamuser.h
   STEAMUSERSTATS_INTERFACE_VERSION = 'STEAMUSERSTATS_INTERFACE_VERSION012'; //< isteamuserstats.h
+  STEAMFRIENDS_INTERFACE_VERSION = 'SteamFriends017'; //< isteamuserstats.h
+  STEAMUTILS_INTERFACE_VERSION = 'SteamUtils010'; //< isteamuser.h
+  STEAMINPUT_INTERFACE_VERSION = 'SteamInput006'; //< isteaminput.h
   VersionSteamUtils = '010'; //< matches STEAMUTILS_INTERFACE_VERSION *and* accessor in steam_api_flat.h
   VersionSteamApps = '008'; //< matches STEAMAPPS_INTERFACE_VERSION *and* accessor in steam_api_flat.h
+  VersionSteamUser = '023'; //< matches STEAMUTILS_INTERFACE_VERSION *and* accessor in steam_api_flat.h
+  VersionSteamFriends = '017'; //< matches STEAMAPPS_INTERFACE_VERSION *and* accessor in steam_api_flat.h
+  VersionSteamInput = '006'; //< matches accessor in steam_api_flat.h
+  STEAMLIBVER = '';
+{$endif}
 
 type
   SteamAPIWarningMessageHook = procedure (nSeverity: Integer; pchDebugText: PAnsiChar); Cdecl;
@@ -168,7 +211,20 @@ const
 
   k_uAPICallInvalid = TSteamAPICall(0);
 
+  k_cchLeaderboardNameMax = 128;
+  k_cchStatNameMax = 128;
+  k_cLeaderboardDetailsMax = 64;
+
 type
+  TStatName = Array [0..(k_cchStatNameMax - 1)] of AnsiChar;
+  PStatName = ^TStatName;
+
+  TSteamAPIInitResult = (	k_ESteamAPIInitResult_OK = 0, // Success
+    k_ESteamAPIInitResult_FailedGeneric = 1, // Some other failure
+    k_ESteamAPIInitResult_NoSteamClient = 2, // We cannot connect to Steam, steam probably isn't running
+    k_ESteamAPIInitResult_VersionMismatch = 3 // Steam client appears to be out of date
+  );
+
   // Purpose: called when a SteamAsyncCall_t has completed (or failed)
   TSteamAPICallCompleted = record
   const
@@ -195,17 +251,42 @@ type
   end;
   PUserStatsReceived = ^TUserStatsReceived;
 
+  // Purpose: called when the latests stats and achievements have been received
+  // from the server
+  TUserAchievementIconFetched = packed record
+  const
+    k_iCallback = k_iSteamUserStatsCallbacks + 9;
+  var
+    // The Game ID this achievement is for.
+    m_nGameID: CGameID;
+    // The name of the achievement that this callback is for.
+    m_rgchAchievementName: TStatName;
+    // Returns whether the icon for the achieved (true) or unachieved (false) version.
+    m_bAchieved: TCallbackBool;
+    // Handle to the image, which can be used with ISteamUtils::GetImageRGBA to get the image data.
+    // 0 means no image is set for the achievement.
+    m_nIconHandle: Int32;
+  end;
+  PUserAchievementIconFetched = ^TUserAchievementIconFetched;
+
   // Pointer to ISteamApps interface from Steam API.
   // For our translation, this is just a pointer to an opaque structure.
   // Defined as a record to be incompatible with e.g. ISteamUtils.
   ISteamApps = record Ptr: Pointer; end;
+  ISteamFriends = record Ptr: Pointer; end;
+  ISteamUser = record Ptr: Pointer; end;
+  ISteamInput = record Ptr: Pointer; end;
 
   // Pointer to ISteamUtils interface from Steam API.
   ISteamUtils = record Ptr: Pointer; end;
 
 var
   // steam_api.h translation (full documentation at https://partner.steamgames.com/doc/api/steam_api )
+  {$if defined(USE_TESTING_API)}
+  SteamAPI_InitFlat: function (pOutErrMsg: PSteamErrMsg): TSteamAPIInitResult; CDecl;
+  {$else}
   SteamAPI_Init: function (): TSteamBool; CDecl;
+  {$endif}
   SteamAPI_ReleaseCurrentThreadMemory: procedure (); CDecl; // TODO: UNTESTED
   SteamAPI_RestartAppIfNecessary: function (unOwnAppID: TAppId): TSteamBool; CDecl;
   SteamAPI_RunCallbacks: procedure (); CDecl;
@@ -228,42 +309,68 @@ var
 
   // ISteamClient
   SteamAPI_ISteamClient_SetWarningMessageHook: procedure (SteamClient: Pointer; WarningMessageHook: SteamAPIWarningMessageHook); CDecl;
-  SteamAPI_ISteamClient_GetISteamUser: function (SteamClient: Pointer; SteamUserHandle: HSteamUser; SteamPipeHandle: HSteamPipe; const SteamUserInterfaceVersion: PAnsiChar): Pointer; CDecl;
+  // SteamUtils has no SteamUser
+  SteamAPI_ISteamClient_GetISteamUtils: function (SteamClient: Pointer; SteamPipeHandle: HSteamPipe; const SteamUtilsInterfaceVersion: PAnsiChar): Pointer; CDecl;
+  // Steam_ISteamClient_GetISteam...... use SteamUser
+  SteamAPI_ISteamClient_GetISteamUser:      function (SteamClient: Pointer; SteamUserHandle: HSteamUser; SteamPipeHandle: HSteamPipe; const SteamUserInterfaceVersion: PAnsiChar): Pointer; CDecl;
+  SteamAPI_ISteamClient_GetISteamApps:      function (SteamClient: Pointer; SteamUserHandle: HSteamUser; SteamPipeHandle: HSteamPipe; const SteamAppsInterfaceVersion: PAnsiChar): Pointer; CDecl;
   SteamAPI_ISteamClient_GetISteamUserStats: function (SteamClient: Pointer; SteamUserHandle: HSteamUser; SteamPipeHandle: HSteamPipe; const SteamUserStatsInterfaceVersion: PAnsiChar): Pointer; CDecl;
+  SteamAPI_ISteamClient_GetISteamFriends:   function (SteamClient: Pointer; SteamUserHandle: HSteamUser; SteamPipeHandle: HSteamPipe; const SteamFriendsInterfaceVersion: PAnsiChar): Pointer; CDecl;
+  SteamAPI_ISteamClient_GetISteamInput:     function (SteamClient: Pointer; SteamUserHandle: HSteamUser; SteamPipeHandle: HSteamPipe; const SteamInputInterfaceVersion: PAnsiChar): Pointer; CDecl;
 
   // ISteamUserStats
+  {$if not defined(USE_TESTING_API)}
   SteamAPI_ISteamUserStats_RequestCurrentStats: function (SteamUserStats: Pointer): TSteamBool; CDecl;
+  {$endif}
+
   SteamAPI_ISteamUserStats_GetAchievement: function (SteamUserStats: Pointer; const AchievementName: PAnsiChar; Achieved: PSteamBool): TSteamBool; CDecl;
   SteamAPI_ISteamUserStats_SetAchievement: function (SteamUserStats: Pointer; const AchievementName: PAnsiChar): TSteamBool; CDecl;
   SteamAPI_ISteamUserStats_ClearAchievement: function (SteamUserStats: Pointer; const AchievementName: PAnsiChar): TSteamBool; CDecl;
   SteamAPI_ISteamUserStats_GetNumAchievements: function (SteamUserStats: Pointer): UInt32; CDecl;
-  // It returns string-ID of the achievement, not a human readable name
+  // Returns string-ID of the achievement, not a human readable name
   SteamAPI_ISteamUserStats_GetAchievementName: function (SteamUserStats: Pointer; AchievementId: UInt32 ): PAnsiChar; CDecl;
+  // Returns attribute of the achievement, AchievementKey may be name, desc or hidden which return UTF8 string with "0" or "1" indicating hidden state
+  SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute: function (SteamUserStats: Pointer; const AchievementName: PAnsiChar; const AchievementKey: PAnsiChar ): PAnsiChar; CDecl;
+  // Returns whether the achievement has been completed and the Date/Time of completion if Achieved = True
+  SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime: function (SteamUserStats: Pointer; const AchievementName: PAnsiChar; const Achieved: PSteamBool; UnlockTime: PUInt32): TSteamBool; CDecl;
+  // Returns a handle for the Achievement's image - needs further processing via callback
+  SteamAPI_ISteamUserStats_GetAchievementIcon: function (SteamUserStats: Pointer; const AchievementName: PAnsiChar): UInt32; CDecl;
   // Show Steam popup "achievement : 30/100", see https://partner.steamgames.com/doc/api/ISteamUserStats#IndicateAchievementProgress
   SteamAPI_ISteamUserStats_IndicateAchievementProgress: function (SteamUserStats: Pointer; const AchievementName: PAnsiChar; CurrentProgress: UInt32; MaxProgress: UInt32): TSteamBool; CDecl;
   // Call this after changing stats or achievements
   SteamAPI_ISteamUserStats_StoreStats: function (SteamUserStats: Pointer): TSteamBool; CDecl;
 
+  // ISteamInput
+  // A versioned accessor is exported by the library
+  SteamAPI_SteamInput: function (): ISteamInput; CDecl;
+
+
   // ISteamUtils
   // A versioned accessor is exported by the library
-  //SteamAPI_SteamUtils_v<VersionSteamUtils>: function (): ISteamUtils; CDecl;
+  // SteamAPI_SteamUtils_v<VersionSteamUtils>: function (): ISteamUtils; CDecl;
   // Unversioned accessor to get the current version.
   // In Pascal translation, this is just an alias to 'SteamAPI_SteamUtils_v' + VersionSteamUtils.
   SteamAPI_SteamUtils: function (): ISteamUtils; CDecl;
+  // Returns the Raw Bitmap Data in pubDest of image Handle iImage. Must call GetImageSize
+  // before calling thius in order to allocate memory for buffer that will be filled
+  // the destination buffer size should be 4 * height * width * sizeof(char)
+  SteamAPI_ISteamUtils_GetImageRGBA: function (Self: Pointer; iImage: CInt; pubDest: PByte; nDestBufferSize: Int32): TSteamBool; CDecl;
+  // Returns the Width + Height of image Handle iImage - bust be called bnefore GetImageRGBA
+  SteamAPI_ISteamUtils_GetImageSize: function (Self: Pointer; iImage: CInt; pnWidth: PUInt32; pnHeight: PUInt32): TSteamBool; CDecl;
   // returns the 2 digit ISO 3166-1-alpha-2 format country code this client
   // is running in (as looked up via an IP-to-location database) e.g "US" or "UK".
-  SteamAPI_ISteamUtils_GetIPCountry: function (Self: ISteamUtils): PAnsiChar; CDecl;
+  SteamAPI_ISteamUtils_GetIPCountry: function (Self: Pointer): PAnsiChar; CDecl;
   // Returns true if the overlay is running & the user can access it. The overlay process could take a few seconds to
   // start & hook the game process, so this function will initially return false while the overlay is loading.
-  SteamAPI_ISteamUtils_IsOverlayEnabled: function (Self: ISteamUtils): TSteamBool; CDecl;
+  SteamAPI_ISteamUtils_IsOverlayEnabled: function (Self: Pointer): TSteamBool; CDecl;
   // returns true if Steam itself is running in VR mode
-  SteamAPI_ISteamUtils_IsSteamRunningInVR: function (Self: ISteamUtils): TSteamBool; CDecl;
+  SteamAPI_ISteamUtils_IsSteamRunningInVR: function (Self: Pointer): TSteamBool; CDecl;
   // returns true if currently running on the Steam Deck device
-  SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck: function (Self: ISteamUtils): TSteamBool; CDecl;
+  SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck: function (Self: Pointer): TSteamBool; CDecl;
 
   // ISteamApps
   // A versioned accessor is exported by the library
-  //SteamAPI_SteamApps_v<VersionSteamApps>: function (): ISteamApps; CDecl;
+  // SteamAPI_SteamApps_v<VersionSteamApps>: function (): ISteamApps; CDecl;
   // Unversioned accessor to get the current version.
   // In Pascal translation, this is just an alias to 'SteamAPI_SteamApps_v' + VersionSteamApps.
   SteamAPI_SteamApps: function (): ISteamApps; CDecl;
@@ -274,19 +381,38 @@ var
   // returns the current game language
   SteamAPI_ISteamApps_GetCurrentGameLanguage: function (Self: ISteamApps): PAnsiChar; CDecl;
 
+  // ISteamFriends
+  // A versioned accessor is exported by the library
+  // SteamAPI_SteamFriends_v<VersionSteamFriends>: function (): ISteamFriends; CDecl;
+  // Unversioned accessor to get the current version.
+  // In Pascal translation, this is just an alias to 'SteamAPI_SteamFriends_v' + VersionSteamApps.
+  SteamAPI_SteamFriends: function (): ISteamFriends; CDecl;
+  // Returns Handle to Large Friend Avatar Image for use with SteamAPI_ISteamUtils_GetImageRGBA
+  SteamAPI_ISteamFriends_GetLargeFriendAvatar: function (Self: Pointer; steamIDFriend: CUserID): CInt; CDecl;
+  // Returns Handle to Medium Friend Avatar Image for use with SteamAPI_ISteamUtils_GetImageRGBA
+  SteamAPI_ISteamFriends_GetMediumFriendAvatar: function (Self: Pointer; steamIDFriend: CUserID): CInt; CDecl;
+  // Returns Handle to Small Friend Avatar Image for use with SteamAPI_ISteamUtils_GetImageRGBA
+  SteamAPI_ISteamFriends_GetSmallFriendAvatar: function (Self: Pointer; steamIDFriend: CUserID): CInt; CDecl;
+
+  // ISteamUser
+  // A versioned accessor is exported by the library
+  SteamAPI_SteamUser: function (): ISteamUser; CDecl;
+  // Returns Steam User ID of currently logged in user
+  SteamAPI_ISteamUser_GetSteamID: function (Self: Pointer): CUserID; CDecl;
+
 var
   SteamLibrary: TDynLib;
 
 const
   SteamLibraryName =
     {$if defined(DARWIN)} // macOS
-    'libsteam_api.dylib'
+    'libsteam_api' + STEAMLIBVER + '.dylib'
     {$elseif defined(UNIX)}
-    'libsteam_api.so'
+    'libsteam_api' + STEAMLIBVER + '.so'
     {$elseif defined(MSWINDOWS) and defined(CPUX64)}
-    'steam_api64.dll'
+    'steam_api64' + STEAMLIBVER + '.dll'
     {$elseif defined(MSWINDOWS) and defined(CPUX86)}
-    'steam_api.dll'
+    'steam_api' + STEAMLIBVER + '.dll'
     {$else}
     // Steam library not available on this platform
     ''
@@ -302,7 +428,11 @@ uses
 
 procedure FinalizeSteamLibrary;
 begin
+  {$if defined(USE_TESTING_API)}
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_InitFlat) := nil;
+  {$else}
   Pointer({$ifndef FPC}@{$endif} SteamAPI_Init) := nil;
+  {$endif}
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ReleaseCurrentThreadMemory) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_RestartAppIfNecessary) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_RunCallbacks) := nil;
@@ -319,16 +449,27 @@ begin
   Pointer({$ifndef FPC}@{$endif} SteamAPI_UnregisterCallback) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_SetWarningMessageHook) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUser) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamApps) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUserStats) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamFriends) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUtils) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamInput) := nil;
+  {$if not defined(USE_TESTING_API)}
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_RequestCurrentStats) := nil;
+  {$endif}
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievement) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_SetAchievement) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_ClearAchievement) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetNumAchievements) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievementName) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievementIcon) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_IndicateAchievementProgress) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_StoreStats) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_SteamUtils) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_GetImageRGBA) := Nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_GetImageSize) := Nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_GetIPCountry) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_IsOverlayEnabled) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_IsSteamRunningInVR) := nil;
@@ -337,6 +478,14 @@ begin
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamApps_GetAppBuildId) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamApps_BIsDlcInstalled) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamApps_GetCurrentGameLanguage) := nil;
+
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_SteamUser) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUser_GetSteamID) := nil;
+
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_SteamFriends) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamFriends_GetLargeFriendAvatar) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamFriends_GetMediumFriendAvatar) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamFriends_GetSmallFriendAvatar) := nil;
 
   FreeAndNil(SteamLibrary);
 end;
@@ -350,7 +499,11 @@ begin
 
   if SteamLibrary <> nil then
   begin
+    {$if defined(USE_TESTING_API)}
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_InitFlat) := SteamLibrary.Symbol('SteamAPI_InitFlat');
+    {$else}
     Pointer({$ifndef FPC}@{$endif} SteamAPI_Init) := SteamLibrary.Symbol('SteamAPI_Init');
+    {$endif}
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ReleaseCurrentThreadMemory) := SteamLibrary.Symbol('SteamAPI_ReleaseCurrentThreadMemory');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_RestartAppIfNecessary) := SteamLibrary.Symbol('SteamAPI_RestartAppIfNecessary');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_RunCallbacks) := SteamLibrary.Symbol('SteamAPI_RunCallbacks');
@@ -367,17 +520,29 @@ begin
     Pointer({$ifndef FPC}@{$endif} SteamAPI_UnregisterCallback) := SteamLibrary.Symbol('SteamAPI_UnregisterCallback');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_SetWarningMessageHook) := SteamLibrary.Symbol('SteamAPI_ISteamClient_SetWarningMessageHook');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUser) := SteamLibrary.Symbol('SteamAPI_ISteamClient_GetISteamUser');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamApps) := SteamLibrary.Symbol('SteamAPI_ISteamClient_GetISteamApps');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUserStats) := SteamLibrary.Symbol('SteamAPI_ISteamClient_GetISteamUserStats');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamFriends) := SteamLibrary.Symbol('SteamAPI_ISteamClient_GetISteamFriends');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUtils) := SteamLibrary.Symbol('SteamAPI_ISteamClient_GetISteamUtils');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamInput) := SteamLibrary.Symbol('SteamAPI_ISteamClient_GetISteamInput');
+    {$if not defined(USE_TESTING_API)}
+    // RequestCurrentStats removeded in 1.61
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_RequestCurrentStats) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_RequestCurrentStats');
+    {$endif}
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievement) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_GetAchievement');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_SetAchievement) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_SetAchievement');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_ClearAchievement) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_ClearAchievement');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetNumAchievements) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_GetNumAchievements');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievementName) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_GetAchievementName');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_GetAchievementIcon) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_GetAchievementIcon');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_IndicateAchievementProgress) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_IndicateAchievementProgress');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUserStats_StoreStats) := SteamLibrary.Symbol('SteamAPI_ISteamUserStats_StoreStats');
     // alias to versioned entry point
     Pointer({$ifndef FPC}@{$endif} SteamAPI_SteamUtils) := SteamLibrary.Symbol('SteamAPI_SteamUtils_v' + VersionSteamUtils);
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_GetImageRGBA) := SteamLibrary.Symbol('SteamAPI_ISteamUtils_GetImageRGBA');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_GetImageSize) := SteamLibrary.Symbol('SteamAPI_ISteamUtils_GetImageSize');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_GetIPCountry) := SteamLibrary.Symbol('SteamAPI_ISteamUtils_GetIPCountry');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_IsOverlayEnabled) := SteamLibrary.Symbol('SteamAPI_ISteamUtils_IsOverlayEnabled');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUtils_IsSteamRunningInVR) := SteamLibrary.Symbol('SteamAPI_ISteamUtils_IsSteamRunningInVR');
@@ -387,10 +552,22 @@ begin
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamApps_GetAppBuildId) := SteamLibrary.Symbol('SteamAPI_ISteamApps_GetAppBuildId');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamApps_BIsDlcInstalled) := SteamLibrary.Symbol('SteamAPI_ISteamApps_BIsDlcInstalled');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamApps_GetCurrentGameLanguage) := SteamLibrary.Symbol('SteamAPI_ISteamApps_GetCurrentGameLanguage');
+    // alias to versioned entry point
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_SteamUser) := SteamLibrary.Symbol('SteamAPI_SteamUser_v' + VersionSteamUser);
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamUser_GetSteamID) := SteamLibrary.Symbol('SteamAPI_ISteamUser_GetSteamID');
+    // alias to versioned entry point
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_SteamFriends) := SteamLibrary.Symbol('SteamAPI_SteamFriends_v' + VersionSteamFriends);
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamFriends_GetLargeFriendAvatar) := SteamLibrary.Symbol('SteamAPI_ISteamFriends_GetLargeFriendAvatar');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamFriends_GetMediumFriendAvatar) := SteamLibrary.Symbol('SteamAPI_ISteamFriends_GetMediumFriendAvatar');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamFriends_GetSmallFriendAvatar) := SteamLibrary.Symbol('SteamAPI_ISteamFriends_GetSmallFriendAvatar');
+    // alias to versioned entry point
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_SteamInput) := SteamLibrary.Symbol('SteamAPI_SteamInput_v' + VersionSteamInput);
   end;
 end;
 
 initialization
 finalization
   FinalizeSteamLibrary;
+
 end.
+

--- a/src/services/steam/castlesteam.pas
+++ b/src/services/steam/castlesteam.pas
@@ -22,11 +22,74 @@ unit CastleSteam;
 
 interface
 
-uses Classes,
+{$define CASTLE_DEBUG_STEAM_API_TESTING}
+
+uses Classes, CTypes, SysUtils, {SteamTypes,}
+  {$ifndef fpc}System.Generics.Collections,{$else}Contnrs,Generics.Collections,{$endif}
   CastleInternalSteamApi;
 
 type
   TAppId = CastleInternalSteamApi.TAppId;
+  TIconSize = (IconSmall, IconMedium, IconLarge);
+  TAchievementChanged = (AchievedChanged, IconChanged, ImageChanged);
+  TSteamAchievement = Class;
+
+  TAchievementUpdatedEvent = procedure(AValue: TSteamAchievement; const WhatChanged: TAchievementChanged) of object;
+
+  TSteamBitmap = class
+  strict private
+    FIsValid: Boolean;
+    FWidth: Integer;
+    FHeight: Integer;
+    FBPP: Integer;
+    FImage: PByteArray;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    procedure SetImageFormat(const ImWidth, ImHeight, BytesPerPixel: Integer);
+    function GetImageMemorySize(): UInt64;
+    procedure SetImage(const AImage: PByteArray);
+    property IsValid: Boolean read FIsValid write FIsValid;
+    property Width: Integer read FWidth;
+    property Height: Integer read FHeight;
+    property BPP: Integer read FBPP;
+    property Image: PByteArray read FImage;
+  end;
+
+  TCastleSteam = class;
+
+  TSteamAchievement = Class
+    strict private
+      FOwner: TObject;
+      FAchId: UInt32;
+      FApiId: String;
+      FName: String;
+      FDesc: String;
+      FHidden: Boolean;
+      FAchieved: Boolean;
+      FDoneDate: TDateTime;
+      FIcon: CInt;
+      FOnAchievementUpdated: TAchievementUpdatedEvent;
+      procedure SetAchieved(const AChecked: Boolean);
+    protected
+      procedure Populate(SteamUserStats: Pointer; AchievementId: UInt32);
+    public
+      constructor Create(AOwner: TCastleSteam);
+      destructor Destroy; override;
+      function GetIcon(SteamUserStats: Pointer; AchievementId: UInt32): CInt;
+      property ApiId: String read FApiId;
+      property Name: String read FName;
+      property Desc: String read FDesc;
+      property Hidden: Boolean read FHidden;
+      property Achieved: Boolean read FAchieved write SetAchieved;
+      property DoneDate: TDateTime read FDoneDate;
+      property Icon: CInt read FIcon write FIcon;
+      property OnAchievementUpdated: TAchievementUpdatedEvent
+        read FOnAchievementUpdated write FOnAchievementUpdated;
+
+  end;
+
+  TSteamAchievementList = {$ifdef fpc}specialize{$endif} TObjectList<TSteamAchievement>;
 
   { Integration with Steam.
     See @url(https://castle-engine.io/steam Steam and Castle Game Engine documentation)
@@ -39,16 +102,23 @@ type
   strict private
     FAppId: TAppId;
     FEnabled: Boolean;
-    FAchievements: TStrings;
+    FUserID: CUserID;
+    FAchievements: TSteamAchievementList;
     FUserStatsReceived: Boolean;
     FOnUserStatsReceived: TNotifyEvent;
     StoreStats: Boolean;
+    // Pointers for ISteam....
+    // SteamApps: Pointer;
     SteamClient: Pointer;
-    //SteamUser: Pointer; // We aren't using it right now, but it works
+    SteamFriends: Pointer;
+    SteamInput: Pointer;
+    SteamUser: Pointer;
     SteamUserStats: Pointer;
+    SteamUtils: Pointer;
     SteamUserHandle: HSteamUser;
     SteamPipeHandle: HSteamPipe;
     procedure CallbackUserStatsReceived(P: PUserStatsReceived);
+    procedure CallbackUserAchievementIconFetched(P: PUserAchievementIconFetched);
     procedure GetAchievements;
     { Makes a warning.
 
@@ -63,7 +133,13 @@ type
       According to SteamWorks documentation you should run this
       at least 10 times a second, better if every frame. }
     procedure Update(Sender: TObject);
+    { Callback may be set after event is available so trigger it if ready
+      As of 1.61 Stats are no longer async so this callback would not happen
+      without this setter }
+    procedure SetOnUserStatsReceived(const AValue: TNotifyEvent);
   public
+    function GetFriendImageHandle(const FriendID: CUserID; const Size: TIconSize = IconLarge): CInt;
+    function GetSteamBitmap(const ImageHandle: CInt): TSteamBitmap;
     { Connect to Steam and initialize everything.
 
       @orderedList(
@@ -101,17 +177,23 @@ type
       It means that all features of this class work as they should. }
     property Enabled: Boolean read FEnabled;
 
+    // Public Interface Access
+    property ISteamUserStats: Pointer read SteamUserStats;
+
     { Achievement names for this game (read-only).
       These are IDs of achievements, can be used in other calls
       like @link(SetAchievement) or @link(GetAchievement).
       This field is initialized when @link(UserStatsReceived) becomes @true,
       it is @nil before. }
-    property Achievements: TStrings read FAchievements;
+    property Achievements: TSteamAchievementList read FAchievements;
 
     { Have we received user stats from Steam.
       Before this is @true, methods of this class dealing with user stats
       (like achievements) don't do anything. }
     property UserStatsReceived: Boolean read FUserStatsReceived;
+
+    { The currently logged in Steam User's ID }
+    property UserId: CUserID read FUserId;
 
     { We have received user stats from Steam.
       Right before calling this event, @link(UserStatsReceived) changed to @true
@@ -119,7 +201,7 @@ type
       From now on you can use Steam features that depend on it,
       like @link(Achievements). }
     property OnUserStatsReceived: TNotifyEvent
-      read FOnUserStatsReceived write FOnUserStatsReceived;
+      read FOnUserStatsReceived write SetOnUserStatsReceived;
 
     { Set achievement as "achieved",
       Steam will automatically show a small overlay indicating that the
@@ -180,7 +262,7 @@ type
 
 implementation
 
-uses SysUtils, CTypes,
+uses DateUtils,
   CastleLog, CastleUtils, CastleApplicationProperties;
 
 procedure WarningHook(nSeverity: Integer; pchDebugText: PAnsiChar); Cdecl;
@@ -206,9 +288,18 @@ constructor TCastleSteam.Create(const AAppId: TAppId);
     if SteamLibrary <> nil then
     begin
       // Initialize Steam API
+      {$if defined(USE_TESTING_API)}
+      if SteamAPI_InitFlat(Nil) = k_ESteamAPIInitResult_OK then
+      {$else}
       if SteamAPI_Init() then
+      {$endif}
       begin
-        WriteLnLog('SteamAPI_Init successfull');
+        {$if defined(USE_TESTING_API)}
+        WriteLnLog('SteamAPI with USE_TESTING_API using ' + SteamLibraryName);
+        {$else}
+        WriteLnLog('SteamAPI using ' + SteamLibraryName);
+        {$endif}
+        WriteLnLog('SteamAPI_Init successful');
 
         // If the app was started through EXE - restart the game through Steam
         if SteamAPI_RestartAppIfNecessary(AppId) then
@@ -246,14 +337,43 @@ constructor TCastleSteam.Create(const AAppId: TAppId);
     SteamUserHandle := SteamAPI_GetHSteamUser();
     SteamPipeHandle := SteamAPI_GetHSteamPipe();
 
-    // Not used yet
-    // SteamUser := SteamAPI_ISteamClient_GetISteamUser(
-    //   SteamClient, SteamUserHandle, SteamPipeHandle, STEAMUSER_INTERFACE_VERSION);
+    // Init SteamUser
+    SteamUser := SteamAPI_ISteamClient_GetISteamUser(
+       SteamClient, SteamUserHandle, SteamPipeHandle, STEAMUSER_INTERFACE_VERSION);
+
+    // Init SteamApps - returns nil?
+//    SteamApps := SteamAPI_ISteamClient_GetISteamApps(
+//      SteamClient, SteamUserHandle, SteamPipeHandle, STEAMAPPS_INTERFACE_VERSION);
+
+    // Init SteamFriends
+    SteamFriends := SteamAPI_ISteamClient_GetISteamFriends(
+      SteamClient, SteamUserHandle, SteamPipeHandle, STEAMFRIENDS_INTERFACE_VERSION);
+
+    // Init SteamUtils
+    SteamUtils := SteamAPI_ISteamClient_GetISteamUtils(
+       SteamClient, SteamPipeHandle, STEAMUTILS_INTERFACE_VERSION);
+
+    // Init SteamInput
+    SteamInput := SteamAPI_ISteamClient_GetISteamInput(
+       SteamClient, SteamUserHandle, SteamPipeHandle, STEAMINPUT_INTERFACE_VERSION);
+
 
     // Init SteamUserStats and request UserStats (will wait for callback, handled in Update)
     SteamUserStats := SteamAPI_ISteamClient_GetISteamUserStats(
       SteamClient, SteamUserHandle, SteamPipeHandle, STEAMUSERSTATS_INTERFACE_VERSION);
+
+    FUserId := SteamAPI_ISteamUser_GetSteamID(SteamUser);
+    {$if not defined(USE_TESTING_API)}
     SteamAPI_ISteamUserStats_RequestCurrentStats(SteamUserStats);
+    {$else}
+    if SteamUserStats <> Nil then
+      begin
+        GetAchievements;
+        FUserStatsReceived := true;
+        if Assigned(OnUserStatsReceived) then
+          OnUserStatsReceived(Self);
+      end;
+    {$endif}
 
     SteamAPI_ManualDispatch_Init();
   end;
@@ -282,6 +402,47 @@ begin
   inherited;
 end;
 
+procedure TCastleSteam.CallbackUserAchievementIconFetched(
+  P: PUserAchievementIconFetched);
+var
+  S: String;
+  F, I : Integer;
+begin
+  if P.m_nIconHandle = 0 then
+    begin
+      {$if defined(CASTLE_DEBUG_STEAM_API_TESTING)}
+      WriteLnLog('Steam', 'No Icon Available');
+      {$endif}
+      Exit;
+    end;
+
+  S := String(P.m_rgchAchievementName);
+  if Length(S) > 0 then
+    begin
+      F := -1;
+      // Absolutely horrible linear search
+      for I := 0 to FAchievements.Count - 1 do
+        begin
+        if FAchievements[I].ApiId = S then
+          begin
+            F := I;
+            Break;
+          end;
+        end;
+
+      if F <> -1 then
+        begin
+          {$if defined(CASTLE_DEBUG_STEAM_API_TESTING)}
+          WriteLnLog('Image ==>', 'Fetched UserAchievementIcon from Steam for %s with Handle %d',[S, (P^).m_nIconHandle]);
+          {$endif}
+          FAchievements[F].Icon := P.m_nIconHandle;
+          if Assigned(FAchievements[F].OnAchievementUpdated) then
+            FAchievements[F].OnAchievementUpdated(FAchievements[F], ImageChanged);
+        end;
+
+    end;
+end;
+
 procedure TCastleSteam.CallbackUserStatsReceived(P: PUserStatsReceived);
 begin
   WriteLnLog('Steam', 'Received UserStats from Steam');
@@ -295,18 +456,74 @@ procedure TCastleSteam.GetAchievements;
 var
   NumAchievements: UInt32;
   I: Integer;
+  SteamAchievement: TSteamAchievement;
 begin
   if not Enabled then
     Exit;
 
-  FreeAndNil(FAchievements);
-  FAchievements := TStringList.Create;
+  FAchievements := TSteamAchievementList.Create;
 
   NumAchievements := SteamAPI_ISteamUserStats_GetNumAchievements(SteamUserStats);
   if NumAchievements > 0 then
     for I := 0 to NumAchievements - 1 do
-      FAchievements.Add(SteamAPI_ISteamUserStats_GetAchievementName(SteamUserStats, I));
+      begin
+        SteamAchievement := TSteamAchievement.Create(Self);
+        SteamAchievement.Populate(SteamUserStats, I);
+        FAchievements.Add(SteamAchievement);
+      end;
   WriteLnLog('Steam Achievements: %d', [Achievements.Count]);
+end;
+
+function TCastleSteam.GetSteamBitmap(const ImageHandle: CInt): TSteamBitmap;
+var
+  ImWidth, ImHeight: Integer;
+  R: TSteamBool;
+  Buf: Pointer;
+  BufSize: Integer;
+begin
+  Result := nil;
+  if ImageHandle = 0 then
+      Exit;
+
+  R := SteamAPI_ISteamUtils_GetImageSize(SteamUtils, ImageHandle, @ImWidth, @ImHeight);
+  if R then
+    begin
+      {$if defined(CASTLE_DEBUG_STEAM_API_TESTING)}
+//      WriteLnLog('Steam', 'GetImageSize : Width : %d, Height : %d', [ImWidth, ImHeight]);
+      {$endif}
+      Result := TSteamBitmap.Create;
+      Result.SetImageFormat(ImWidth, ImHeight, 4);
+      try
+        BufSize := Result.GetImageMemorySize;
+        Buf := GetMem(BufSize);
+        if SteamAPI_ISteamUtils_GetImageRGBA(SteamUtils, ImageHandle, Buf, BufSize) then
+          begin
+            Result.SetImage(Buf);
+            Result.IsValid := True;
+          end;
+      finally
+      end;
+    end
+  {$if defined(CASTLE_DEBUG_STEAM_API_TESTING)}
+  else
+    WriteLnLog('GetImageSize Failed for %d in GetStreamBitmap', [ImageHandle]);
+  {$else}
+  ;
+  {$endif}
+end;
+
+function TCastleSteam.GetFriendImageHandle(const FriendID: CUserID; const Size: TIconSize): CInt;
+begin
+  case Size of
+    IconSmall:
+      Result := SteamAPI_ISteamFriends_GetSmallFriendAvatar(SteamFriends, FriendID);
+    IconMedium:
+      Result := SteamAPI_ISteamFriends_GetMediumFriendAvatar(SteamFriends, FriendID);
+    IconLarge:
+      Result := SteamAPI_ISteamFriends_GetLargeFriendAvatar(SteamFriends, FriendID);
+  else
+    Result := 0;
+  end;
 end;
 
 procedure TCastleSteam.SteamError(const ErrorMsg: String);
@@ -325,12 +542,19 @@ begin
     Exit;
   if UserStatsReceived then
   begin
-    AchievementIdAnsi := AchievementId;
+    AchievementIdAnsi := AnsiString(AchievementId);
     if not SteamAPI_ISteamUserStats_SetAchievement(SteamUserStats, PAnsiChar(AchievementIdAnsi)) then
       SteamError('Failed to SteamAPI_ISteamUserStats_SetAchievement');
     StoreStats := true;
   end else
     SteamError('SetAchievement failed. ' + SUserStatsNotReceived);
+end;
+
+procedure TCastleSteam.SetOnUserStatsReceived(const AValue: TNotifyEvent);
+begin
+  FOnUserStatsReceived := AValue;
+  if Assigned(FOnUserStatsReceived) and FUserStatsReceived then
+    FOnUserStatsReceived(Self);
 end;
 
 function TCastleSteam.GetAchievement(const AchievementId: String): Boolean;
@@ -343,7 +567,7 @@ begin
     Exit;
   if UserStatsReceived then
   begin
-    AchievementIdAnsi := AchievementId;
+    AchievementIdAnsi := AnsiString(AchievementId);
     if SteamAPI_ISteamUserStats_GetAchievement(SteamUserStats,
         PAnsiChar(AchievementIdAnsi), @CAchieved) then
     begin
@@ -362,7 +586,7 @@ begin
     Exit;
   if UserStatsReceived then
   begin
-    AchievementIdAnsi := AchievementId;
+    AchievementIdAnsi := AnsiString(AchievementId);
     if not SteamAPI_ISteamUserStats_ClearAchievement(SteamUserStats, PAnsiChar(AchievementIdAnsi)) then
       SteamError('Failed to SteamAPI_ISteamUserStats_ClearAchievement');
     StoreStats := true;
@@ -371,17 +595,13 @@ begin
 end;
 
 procedure TCastleSteam.ClearAllAchievements;
-var
-  S: String;
 begin
+
   if not Enabled then
     Exit;
   if UserStatsReceived then
-  begin
-    for S in Achievements do
-      ClearAchievement(S)
-  end else
-    SteamError('ClearAllAchievements failed. ' + SUserStatsNotReceived);
+    FAchievements.Clear;
+
 end;
 
 procedure TCastleSteam.IndicateAchievementProgress(const AchievementId: String;
@@ -393,7 +613,7 @@ begin
     Exit;
   if UserStatsReceived then
   begin
-    AchievementIdAnsi := AchievementId;
+    AchievementIdAnsi := AnsiString(AchievementId);
     if not SteamAPI_ISteamUserStats_IndicateAchievementProgress(SteamUserStats,
        PAnsiChar(AchievementIdAnsi), CurrentProgress, MaxProgress) then
       SteamError('Failed to SteamAPI_ISteamUserStats_IndicateAchievementProgress');
@@ -421,7 +641,7 @@ procedure TCastleSteam.Update(Sender: TObject);
   }
   procedure SteamRunCallbacks;
   { Extra logging of unhandled Steam callbacks (it's normal that we have some). }
-  {.$define CASTLE_DEBUG_STEAM_CALLBACKS}
+  {$define CASTLE_DEBUG_STEAM_CALLBACKS}
   var
     Callback: TCallbackMsg;
     PCallCompleted: PSteamAPICallCompleted;
@@ -433,6 +653,7 @@ procedure TCastleSteam.Update(Sender: TObject);
     begin
       // Look at callback.m_iCallback to see what kind of callback it is,
       // and dispatch to appropriate handler(s)
+      WritelnWarning('Steam', 'Got Callback : ' + IntToStr(Callback.m_iCallback));
       case Callback.m_iCallback of
         TSteamAPICallCompleted.k_iCallback:
           begin
@@ -466,7 +687,17 @@ procedure TCastleSteam.Update(Sender: TObject);
           end;
         TUserStatsReceived.k_iCallback:
           begin
+            {$ifdef CASTLE_DEBUG_STEAM_CALLBACKS}
+            WritelnLog('Steam', 'Handle Stats Received (m_iCallback : %d)', [Callback.m_iCallback]);
+            {$endif}
             CallbackUserStatsReceived(PUserStatsReceived(Callback.m_pubParam));
+          end;
+        TUserAchievementIconFetched.k_iCallback:
+          begin
+            if(SizeOf(TUserAchievementIconFetched) <> Callback.m_cubParam) then
+              WritelnLog('Callbacks', 'TUserAchievementIconFetched Size = %d, should be %d)', [SizeOf(TUserAchievementIconFetched), Callback.m_cubParam])
+            else
+              CallbackUserAchievementIconFetched(PUserAchievementIconFetched(Callback.m_pubParam));
           end;
         else
           begin
@@ -499,28 +730,28 @@ function TCastleSteam.Country: String;
 begin
   if not Enabled then
     Exit('');
-  Result := SteamAPI_ISteamUtils_GetIPCountry(SteamAPI_SteamUtils());
+  Result := String(SteamAPI_ISteamUtils_GetIPCountry(SteamUtils));
 end;
 
 function TCastleSteam.OverlayEnabled: Boolean;
 begin
   if not Enabled then
     Exit(false);
-  Result := SteamAPI_ISteamUtils_IsOverlayEnabled(SteamAPI_SteamUtils());
+  Result := SteamAPI_ISteamUtils_IsOverlayEnabled(SteamUtils);
 end;
 
 function TCastleSteam.RunningInVR: Boolean;
 begin
   if not Enabled then
     Exit(false);
-  Result := SteamAPI_ISteamUtils_IsSteamRunningInVR(SteamAPI_SteamUtils());
+  Result := SteamAPI_ISteamUtils_IsSteamRunningInVR(SteamUtils);
 end;
 
 function TCastleSteam.RunningOnSteamDeck: Boolean;
 begin
   if not Enabled then
     Exit(false);
-  Result := SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck(SteamAPI_SteamUtils());
+  Result := SteamAPI_ISteamUtils_IsSteamRunningOnSteamDeck(SteamUtils);
 end;
 
 function TCastleSteam.BuildId: Integer;
@@ -541,7 +772,110 @@ function TCastleSteam.Language: String;
 begin
   if not Enabled then
     Exit('');
-  Result := SteamAPI_ISteamApps_GetCurrentGameLanguage(SteamAPI_SteamApps());
+  Result := String(SteamAPI_ISteamApps_GetCurrentGameLanguage(SteamAPI_SteamApps()));
+end;
+
+{ TSteamAchievement }
+
+constructor TSteamAchievement.Create(AOwner: TCastleSteam);
+begin
+  Inherited Create;
+  FOwner := AOwner;
+end;
+
+destructor TSteamAchievement.Destroy;
+begin
+  inherited;
+end;
+
+function TSteamAchievement.GetIcon(SteamUserStats: Pointer; AchievementId: UInt32): CInt;
+begin
+  Result := SteamAPI_ISteamUserStats_GetAchievementIcon(SteamUserStats, PAnsiChar(AnsiString(FApiId)));
+  if Result <> 0 then
+    begin
+      {$if defined(CASTLE_DEBUG_STEAM_API_TESTING)}
+      WritelnLog('GetAchievementIcon returned Icon Handle %d for %s', [Result, FApiId]);
+      {$endif}
+    end
+  else
+    WritelnLog('GetAchievementIcon Pending');
+end;
+
+procedure TSteamAchievement.Populate(SteamUserStats: Pointer; AchievementId: UInt32);
+var
+  pchName: PAnsiChar;
+  pchHidden: PAnsiChar;
+  bAchieved: TSteamBool;
+  uDate: UInt32;
+begin
+  FAchId := AchievementId;
+  pchName := SteamAPI_ISteamUserStats_GetAchievementName(SteamUserStats, AchievementId);
+  FApiId := String(pchName);
+  FName := String(SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute(SteamUserStats, pchName, 'name'));
+  FDesc := String(SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute(SteamUserStats, pchName, 'desc'));
+  pchHidden := SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute(SteamUserStats, pchName, 'hidden');
+  if CompareStr(String(pchHidden), '1') = 0 then
+    FHidden := True
+  else
+    FHidden := False;
+  SteamAPI_ISteamUserStats_GetAchievementAndUnlockTime(SteamUserStats, pchName, @bAchieved, @uDate);
+  FAchieved := bAchieved;
+  FDoneDate := UnixToDateTime(uDate);
+  FIcon := GetIcon(SteamUserStats, AchievementId);
+
+end;
+
+procedure TSteamAchievement.SetAchieved(const AChecked: Boolean);
+var
+  NIcon: CInt;
+begin
+  if not(FOwner is TCastleSteam) then
+    Exit;
+
+  FAchieved := AChecked;
+  if FAchieved then
+    TCastleSteam(FOwner).SetAchievement(FApiId)
+  else
+    TCastleSteam(FOwner).ClearAchievement(FApiId);
+  NIcon := GetIcon(TCastleSteam(FOwner).ISteamUserStats, FIcon);
+  if (NIcon <> FIcon) then
+    begin
+      FIcon := NIcon;
+      if Assigned(OnAchievementUpdated) then
+        OnAchievementUpdated(Self, IconChanged);
+    end;
+end;
+
+{ TSteamBitmap }
+
+constructor TSteamBitmap.Create;
+begin
+
+end;
+
+destructor TSteamBitmap.Destroy;
+begin
+  if Assigned(FImage) then
+    FreeMem(Fimage);
+  inherited;
+end;
+
+function TSteamBitmap.GetImageMemorySize: UInt64;
+begin
+  Result := FWidth * FHeight * FBPP;
+end;
+
+procedure TSteamBitmap.SetImage(const AImage: PByteArray);
+begin
+  FImage := AImage;
+end;
+
+procedure TSteamBitmap.SetImageFormat(const ImWidth, ImHeight, BytesPerPixel: Integer);
+begin
+  FWidth := ImWidth;
+  FHeight := ImHeight;
+  FBPP := BytesPerPixel;
 end;
 
 end.
+


### PR DESCRIPTION
This branch has one breaking modification. Changed Achievements from TStringList to TObjectList. This does, however, need more attention anyway as it is desirable to access Achievements by a String Key.

It is possibly better to handle Icons on-request (I just tested on a "game" with almost 10k Achievements which was enlightening)

There are new API entries in castleinternalsteamapi - all have been tested and work. There is a sole entry for SteamInput (it's next) merely to test the hook.

I noticed that TSteamBool is used here and there. The callback with a TUserAchievementIconFetched uses a different Boolean (32 bit) so TCallbackBool added to set them apart. Bit of a headache debugging that one as a result...
