### PR TITLE
[steam] Add SteamAPI_ISteamClient_BReleaseSteamPipe 

### DIFF
--- a/src/services/steam/castleinternalsteamapi.pas
+++ b/src/services/steam/castleinternalsteamapi.pas
@@ -227,6 +227,7 @@ var
   // which is actually "flat" (C, no classes) Steam API corresponding to the C++ API
 
   // ISteamClient
+  SteamAPI_ISteamClient_BReleaseSteamPipe: function (SteamClient: Pointer; hSteamPipe: HSteamPipe): LongBool; CDecl;
   SteamAPI_ISteamClient_SetWarningMessageHook: procedure (SteamClient: Pointer; WarningMessageHook: SteamAPIWarningMessageHook); CDecl;
   SteamAPI_ISteamClient_GetISteamUser: function (SteamClient: Pointer; SteamUserHandle: HSteamUser; SteamPipeHandle: HSteamPipe; const SteamUserInterfaceVersion: PAnsiChar): Pointer; CDecl;
   SteamAPI_ISteamClient_GetISteamUserStats: function (SteamClient: Pointer; SteamUserHandle: HSteamUser; SteamPipeHandle: HSteamPipe; const SteamUserStatsInterfaceVersion: PAnsiChar): Pointer; CDecl;
@@ -317,6 +318,7 @@ begin
   Pointer({$ifndef FPC}@{$endif} SteamAPI_GetHSteamPipe) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_RegisterCallback) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_UnregisterCallback) := nil;
+  Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_BReleaseSteamPipe) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_SetWarningMessageHook) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUser) := nil;
   Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUserStats) := nil;
@@ -365,6 +367,7 @@ begin
     Pointer({$ifndef FPC}@{$endif} SteamAPI_GetHSteamPipe) := SteamLibrary.Symbol('SteamAPI_GetHSteamPipe');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_RegisterCallback) := SteamLibrary.Symbol('SteamAPI_RegisterCallback');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_UnregisterCallback) := SteamLibrary.Symbol('SteamAPI_UnregisterCallback');
+    Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_BReleaseSteamPipe) := SteamLibrary.Symbol('SteamAPI_ISteamClient_BReleaseSteamPipe');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_SetWarningMessageHook) := SteamLibrary.Symbol('SteamAPI_ISteamClient_SetWarningMessageHook');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUser) := SteamLibrary.Symbol('SteamAPI_ISteamClient_GetISteamUser');
     Pointer({$ifndef FPC}@{$endif} SteamAPI_ISteamClient_GetISteamUserStats) := SteamLibrary.Symbol('SteamAPI_ISteamClient_GetISteamUserStats');

--- a/src/services/steam/castlesteam.pas
+++ b/src/services/steam/castlesteam.pas
@@ -276,7 +276,10 @@ destructor TCastleSteam.Destroy;
 begin
   FreeAndNil(FAchievements);
   if Enabled then
-    SteamAPI_Shutdown();
+    begin
+      SteamAPI_ISteamClient_BReleaseSteamPipe(SteamClient, SteamPipeHandle);
+      SteamAPI_Shutdown();
+    end;
   if ApplicationProperties(false) <> nil then
     ApplicationProperties(false).OnUpdate.Remove({$ifdef FPC}@{$endif} Update);
   inherited;


### PR DESCRIPTION
As discussed in #656 

Small changes, add definition for SteamAPI_ISteamClient_BReleaseSteamPipe 
Alter TCastleSteam.Destroy to call it in order to release the pipe (theoretically a resource leak)
No wrapping yet as it's only of any real use on Shutdown ATM (may be exposed later if required)