### PR TITLE
User defined Disable of media formats, allows to shrink binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,14 +67,50 @@ castle-game-engine-*.fpm
 /fpmake
 /units/
 
-# alphabetic list of specific subdirs (and files inside)
-
+# manpages output
 /doc/man/man1/*.1
+
+# PasDoc output
 /doc/pasdoc/cache/
 /doc/pasdoc/html/
 /doc/pasdoc/latex/
 /doc/pasdoc/php/
 /doc/reference/
+
+# Bundled FPC (ignore it, in case someone puts it in CGE source tree)
+/tools/contrib/fpc
+
+# Proprietary Android libraries
+# (it may be easy to put them into CGE source tree, but don't commit).
+/tools/build-tool/data/android/integrated-services/chartboost/app/libs/*.jar
+/tools/build-tool/data/android/integrated-services/game_analytics/app/libs/*.jar
+/tools/build-tool/data/android/integrated-services/startapp/app/libs/*.jar
+/tools/build-tool/data/ios/services/game_analytics/cge_project_name/game_analytics/GameAnalytics.h
+/tools/build-tool/data/ios/services/game_analytics/cge_project_name/game_analytics/libGameAnalytics.a
+
+# deprecated_library artifacts
+/examples/deprecated_library/build-qt_library_tester-*
+/examples/deprecated_library/qt_library_tester/build
+/examples/deprecated_library/cpp_winapi_library_tester/Debug
+/examples/deprecated_library/cpp_winapi_library_tester/Release
+/examples/deprecated_library/cpp_winapi_library_tester/x64
+/examples/deprecated_library/lazarus_library_tester/*.app
+/examples/deprecated_library/lazarus_library_tester/cge_dynlib_tester
+/src/deprecated_library/build-*
+/src/deprecated_library/ios-output/
+/src/deprecated_library/libcastleengine.dylib
+/src/deprecated_library/libcastleengine.so
+
+# Lazarus packages artifacts
+/packages/alternative_castle_window_based_on_lcl.pas
+/packages/castle_base.pas
+/packages/castle_components.pas
+/packages/castle_editor_components.pas
+/packages/castle_indy.pas
+/packages/castle_window.pas
+/packages/lib/
+
+# Unix binaries (keep this list alphabetic).
 /examples/advanced_editor/advanced_loading_designs/advanced_loading_designs
 /examples/advanced_editor/custom_component/custom_component
 /examples/animations/animate_bones_by_code/animate_bones_by_code
@@ -101,13 +137,6 @@ castle-game-engine-*.fpm
 /examples/curves/use_designed_curve/use_designed_curve
 /examples/delphi/fmx/CastleFmx
 /examples/delphi/fmx_play_animation/CastleFmxPlayAnimation
-/examples/deprecated_library/build-qt_library_tester-*
-/examples/deprecated_library/qt_library_tester/build
-/examples/deprecated_library/cpp_winapi_library_tester/Debug
-/examples/deprecated_library/cpp_winapi_library_tester/Release
-/examples/deprecated_library/cpp_winapi_library_tester/x64
-/examples/deprecated_library/lazarus_library_tester/*.app
-/examples/deprecated_library/lazarus_library_tester/cge_dynlib_tester
 /examples/deprecated_to_upgrade/fixed_camera_game/rift
 /examples/eye_of_beholder/eye_of_beholder
 /examples/fonts/distance_field_fonts/distance_field_fonts
@@ -181,8 +210,6 @@ castle-game-engine-*.fpm
 /examples/physics/physics_test_scaled_mesh_collider/physics_test_scaled_mesh_collider
 /examples/physics/physics_test_transformation_sync/physics_test_transformation_sync
 /examples/platformer/platformer
-/examples/plugin/cge_3d_viewer/cge_3d_viewer
-/examples/plugin/cge_3d_viewer/npcge_3d_viewer.linux-i386.so
 /examples/portable_game_skeleton/my_fantastic_game
 /examples/research_special_rendering_methods/dynamic_ambient_occlusion/dynamic_ambient_occlusion
 /examples/research_special_rendering_methods/new_renderer_skeleton/new_renderer_skeleton
@@ -261,26 +288,10 @@ castle-game-engine-*.fpm
 /examples/web/simplest/webgl-tests
 /examples/web/simplest_viewport/simplest_viewport
 /examples/web/simplest_invaders/simplest_invaders
-/packages/alternative_castle_window_based_on_lcl.pas
-/packages/castle_base.pas
-/packages/castle_components.pas
-/packages/castle_editor_components.pas
-/packages/castle_indy.pas
-/packages/castle_window.pas
-/packages/lib/
-/src/deprecated_library/build-*
-/src/deprecated_library/ios-output/
-/src/deprecated_library/libcastleengine.dylib
-/src/deprecated_library/libcastleengine.so
 /tests/castle-tester
 /tests/test_castle_game_engine
 /tests/time_measurements_tests/time_measurements_tests
 /tools/build-tool/castle-engine
-/tools/build-tool/data/android/integrated-services/chartboost/app/libs/*.jar
-/tools/build-tool/data/android/integrated-services/game_analytics/app/libs/*.jar
-/tools/build-tool/data/android/integrated-services/startapp/app/libs/*.jar
-/tools/build-tool/data/ios/services/game_analytics/cge_project_name/game_analytics/GameAnalytics.h
-/tools/build-tool/data/ios/services/game_analytics/cge_project_name/game_analytics/libGameAnalytics.a
 /tools/build-tool/tests/test_cge_build_tool
 /tools/castle-curves/castle-curves
 /tools/castle-engine
@@ -296,4 +307,3 @@ castle-game-engine-*.fpm
 /tools/sprite-sheet-to-x3d/sprite-sheet-to-x3d
 /tools/texture-font-to-pascal/texture-font-to-pascal
 /tools/to-data-uri/to-data-uri
-/tools/contrib

--- a/.gitignore
+++ b/.gitignore
@@ -296,3 +296,4 @@ castle-game-engine-*.fpm
 /tools/sprite-sheet-to-x3d/sprite-sheet-to-x3d
 /tools/texture-font-to-pascal/texture-font-to-pascal
 /tools/to-data-uri/to-data-uri
+/tools/contrib

--- a/src/common_includes/castleconf.inc
+++ b/src/common_includes/castleconf.inc
@@ -636,3 +636,21 @@
 {.$define CASTLE_ANDROID_ARGV_LOGGING}
 
 {$endif not CASTLE_CONF_INCLUDED}
+
+{ User defined Disabling support for media formats --------------------------- }
+
+{$ifdef RELEASE}
+  {.$define CASTLE_GEO_SUPPORT_DISABLE}{$ifdef CASTLE_GEO_SUPPORT_DISABLE}{$INFO 'GEO support disabled'}{$endif}
+  {.$define CASTLE_OBJ_SUPPORT_DISABLE}{$ifdef CASTLE_OBJ_SUPPORT_DISABLE}{$INFO 'OBJ support disabled'}{$endif}
+  {.$define CASTLE_COLLADA_SUPPORT_DISABLE}{$ifdef CASTLE_COLLADA_SUPPORT_DISABLE}{$INFO 'COLLADA support disabled'}{$endif}
+  {.$define CASTLE_SPINE_SUPPORT_DISABLE}{$ifdef CASTLE_SPINE_SUPPORT_DISABLE}{$INFO 'SPINE support disabled'}{$endif}
+  {.$define CASTLE_STL_SUPPORT_DISABLE}{$ifdef CASTLE_STL_SUPPORT_DISABLE}{$INFO 'STL support disabled'}{$endif}
+  {.$define CASTLE_MD3_SUPPORT_DISABLE}{$ifdef CASTLE_MD3_SUPPORT_DISABLE}{$INFO 'MD3 support disabled'}{$endif}
+  {.$define CASTLE_GLTF_SUPPORT_DISABLE}{$ifdef CASTLE_GLTF_SUPPORT_DISABLE}{$INFO 'GLTF support disabled'}{$endif}
+  {.$define CASTLE_IMAGE_SUPPORT_DISABLE}{$ifdef CASTLE_IMAGE_SUPPORT_DISABLE}{$INFO 'IMAGE support disabled'}{$endif}
+  {.$define CASTLE_COCOS2D_SUPPORT_DISABLE}{$ifdef CASTLE_COCOS2D_SUPPORT_DISABLE}{$INFO 'COCOS2D support disabled'}{$endif}
+  {.$define CASTLE_SPRITESHEET_SUPPORT_DISABLE}{$ifdef CASTLE_SPRITESHEET_SUPPORT_DISABLE}{$INFO 'SPRITESHEET support disabled'}{$endif}
+  {.$define CASTLE_TILED_MAP_SUPPORT_DISABLE}{$ifdef CASTLE_TILED_MAP_SUPPORT_DISABLE}{$INFO 'TILED_MAP support disabled'}{$endif}
+  {.$define CASTLE_IFC_SUPPORT_DISABLE}{$ifdef CASTLE_IFC_SUPPORT_DISABLE}{$INFO 'IFC support disabled'}{$endif}
+  {.$define CASTLE_3DS_SUPPORT_DISABLE}{$ifdef CASTLE_3DS_SUPPORT_DISABLE}{$INFO '3DS support disabled'}{$endif}
+{$endif}

--- a/src/common_includes/castleconf.inc
+++ b/src/common_includes/castleconf.inc
@@ -637,20 +637,36 @@
 
 {$endif not CASTLE_CONF_INCLUDED}
 
-{ User defined Disabling support for media formats --------------------------- }
+{ Model formats support ------------------------------------------------------
+  Disable support for some model formats to make the exe smaller.
 
-{$ifdef RELEASE}
-  {.$define CASTLE_GEO_SUPPORT_DISABLE}{$ifdef CASTLE_GEO_SUPPORT_DISABLE}{$INFO 'GEO support disabled'}{$endif}
-  {.$define CASTLE_OBJ_SUPPORT_DISABLE}{$ifdef CASTLE_OBJ_SUPPORT_DISABLE}{$INFO 'OBJ support disabled'}{$endif}
-  {.$define CASTLE_COLLADA_SUPPORT_DISABLE}{$ifdef CASTLE_COLLADA_SUPPORT_DISABLE}{$INFO 'COLLADA support disabled'}{$endif}
-  {.$define CASTLE_SPINE_SUPPORT_DISABLE}{$ifdef CASTLE_SPINE_SUPPORT_DISABLE}{$INFO 'SPINE support disabled'}{$endif}
-  {.$define CASTLE_STL_SUPPORT_DISABLE}{$ifdef CASTLE_STL_SUPPORT_DISABLE}{$INFO 'STL support disabled'}{$endif}
-  {.$define CASTLE_MD3_SUPPORT_DISABLE}{$ifdef CASTLE_MD3_SUPPORT_DISABLE}{$INFO 'MD3 support disabled'}{$endif}
-  {.$define CASTLE_GLTF_SUPPORT_DISABLE}{$ifdef CASTLE_GLTF_SUPPORT_DISABLE}{$INFO 'GLTF support disabled'}{$endif}
-  {.$define CASTLE_IMAGE_SUPPORT_DISABLE}{$ifdef CASTLE_IMAGE_SUPPORT_DISABLE}{$INFO 'IMAGE support disabled'}{$endif}
-  {.$define CASTLE_COCOS2D_SUPPORT_DISABLE}{$ifdef CASTLE_COCOS2D_SUPPORT_DISABLE}{$INFO 'COCOS2D support disabled'}{$endif}
-  {.$define CASTLE_SPRITESHEET_SUPPORT_DISABLE}{$ifdef CASTLE_SPRITESHEET_SUPPORT_DISABLE}{$INFO 'SPRITESHEET support disabled'}{$endif}
-  {.$define CASTLE_TILED_MAP_SUPPORT_DISABLE}{$ifdef CASTLE_TILED_MAP_SUPPORT_DISABLE}{$INFO 'TILED_MAP support disabled'}{$endif}
-  {.$define CASTLE_IFC_SUPPORT_DISABLE}{$ifdef CASTLE_IFC_SUPPORT_DISABLE}{$INFO 'IFC support disabled'}{$endif}
-  {.$define CASTLE_3DS_SUPPORT_DISABLE}{$ifdef CASTLE_3DS_SUPPORT_DISABLE}{$INFO '3DS support disabled'}{$endif}
-{$endif}
+  Note: Don't define these symbols in castleconf.inc,
+  as this would mean you need to maintain your CGE modification,
+  and it affects all projects (including CGE examples that may rely on specific
+  formats).
+
+  Rather, define these symbols in your project, e.g. using <defines> in the
+  CastleEngineManifest.xml.
+  See https://castle-engine.io/project_manifest#_compiler_options_and_paths .
+  Like:
+
+  <compiler_options>
+    <defines>
+      <define>CASTLE_COLLADA_SUPPORT_DISABLE</define>
+      <define>CASTLE_IFC_SUPPORT_DISABLE</define>
+    </defines>
+  </compiler_options>
+}
+{$ifdef CASTLE_GEO_SUPPORT_DISABLE}{$INFO 'GEO support disabled'}{$endif}
+{$ifdef CASTLE_OBJ_SUPPORT_DISABLE}{$INFO 'OBJ support disabled'}{$endif}
+{$ifdef CASTLE_COLLADA_SUPPORT_DISABLE}{$INFO 'COLLADA support disabled'}{$endif}
+{$ifdef CASTLE_SPINE_SUPPORT_DISABLE}{$INFO 'SPINE support disabled'}{$endif}
+{$ifdef CASTLE_STL_SUPPORT_DISABLE}{$INFO 'STL support disabled'}{$endif}
+{$ifdef CASTLE_MD3_SUPPORT_DISABLE}{$INFO 'MD3 support disabled'}{$endif}
+{$ifdef CASTLE_GLTF_SUPPORT_DISABLE}{$INFO 'GLTF support disabled'}{$endif}
+{$ifdef CASTLE_IMAGE_SUPPORT_DISABLE}{$INFO 'IMAGE support disabled'}{$endif}
+{$ifdef CASTLE_COCOS2D_SUPPORT_DISABLE}{$INFO 'COCOS2D support disabled'}{$endif}
+{$ifdef CASTLE_SPRITESHEET_SUPPORT_DISABLE}{$INFO 'SPRITESHEET support disabled'}{$endif}
+{$ifdef CASTLE_TILED_MAP_SUPPORT_DISABLE}{$INFO 'TILED_MAP support disabled'}{$endif}
+{$ifdef CASTLE_IFC_SUPPORT_DISABLE}{$INFO 'IFC support disabled'}{$endif}
+{$ifdef CASTLE_3DS_SUPPORT_DISABLE}{$INFO '3DS support disabled'}{$endif}

--- a/src/scene/load/x3dload.pas
+++ b/src/scene/load/x3dload.pas
@@ -254,13 +254,20 @@ procedure RegisterModelFormat(const ModelFormat: TModelFormat);
 implementation
 
 uses Generics.Collections,
-  CastleClassUtils, CastleImages, CastleUriUtils,
-  X3DLoadInternalGEO, X3DLoadInternal3DS, X3DLoadInternalOBJ,
-  X3DLoadInternalCollada, X3DLoadInternalSpine, X3DLoadInternalSTL,
-  X3DLoadInternalMD3, X3DLoadInternalGLTF, X3DLoadInternalImage,
-  X3DLoadInternalCocos2d, CastleInternalNodeInterpolator,
-  CastleInternalSpritesheet, CastleDownload, X3DLoadInternalTiledMap,
-  CastleIfc;
+  CastleClassUtils, CastleImages, CastleUriUtils, CastleInternalNodeInterpolator, CastleDownload
+  {$IFNDEF CASTLE_GEO_SUPPORT_DISABLE}, X3DLoadInternalGEO {$ENDIF}
+  {$IFNDEF CASTLE_3DS_SUPPORT_DISABLE}, X3DLoadInternal3DS {$ENDIF}
+  {$IFNDEF CASTLE_OBJ_SUPPORT_DISABLE}, X3DLoadInternalOBJ {$ENDIF}
+  {$IFNDEF CASTLE_COLLADA_SUPPORT_DISABLE}, X3DLoadInternalCollada {$ENDIF}
+  {$IFNDEF CASTLE_SPINE_SUPPORT_DISABLE}, X3DLoadInternalSpine {$ENDIF}
+  {$IFNDEF CASTLE_STL_SUPPORT_DISABLE}, X3DLoadInternalSTL {$ENDIF}
+  {$IFNDEF CASTLE_MD3_SUPPORT_DISABLE}, X3DLoadInternalMD3 {$ENDIF}
+  {$IFNDEF CASTLE_GLTF_SUPPORT_DISABLE}, X3DLoadInternalGLTF {$ENDIF}
+  {$IFNDEF CASTLE_IMAGE_SUPPORT_DISABLE}, X3DLoadInternalImage {$ENDIF}
+  {$IFNDEF CASTLE_COCOS2D_SUPPORT_DISABLE}, X3DLoadInternalCocos2d {$ENDIF}
+  {$IFNDEF CASTLE_SPRITESHEET_SUPPORT_DISABLE}, CastleInternalSpritesheet {$ENDIF}
+  {$IFNDEF CASTLE_TILED_MAP_SUPPORT_DISABLE}, X3DLoadInternalTiledMap {$ENDIF}
+  {$IFNDEF CASTLE_IFC_SUPPORT_DISABLE}, CastleIfc {$ENDIF};
 
 { declare FRegisteredModelFormats early ------------------------------------- }
 


### PR DESCRIPTION
This is only a suggestion, I don't expect that it would be merged to upstream, but let's see if @michaliskambi sees benefits of it.

For example I use only GLTF and SpriteSheets in my game, when I checked the castle-engine-output, I see big compiled files like castleicf and other similar from src/scene/load, I don't need support of those formats in Release build, and I know linker is not so smart to remove unused code, so I did it via conditional compilation (and it works as those modules are just pluggable, and no other module depend on them).
comparison (I defined all other formats disabling, except gtlf and spritesheet):
![image](https://github.com/user-attachments/assets/df3d89d6-b1c9-4e9c-973d-90ccaeb0659e)
so the benefit is 2.5 mb, which is 20-25% of exe file size.

Ofc, this is not intended to be enabled by default, only by user who knows the outcome, and it makes sense only for release I think.
P.S. also a bit corrected gitignore to ignore embedded fpc/lazarus, as I'm tired already by constantly manipulating while working with sources.