### PR TITLE
Fix touch controls rendering in library interface

### DIFF
--- a/src/deprecated_library/castleengine.lpr
+++ b/src/deprecated_library/castleengine.lpr
@@ -133,7 +133,7 @@ begin
     TouchNavigation := TCastleTouchNavigation.Create(nil);
     TouchNavigation.FullSize := true;
     TouchNavigation.Viewport := Viewport;
-    Viewport.InsertFront(TouchNavigation);
+    Window.Controls.InsertFront(TouchNavigation);
 
     PreviousNavigationType := Viewport.NavigationType;
 


### PR DESCRIPTION
Put touch control over the screen in the library interface, else screen effects get applied to touch controls as well. This can be observed with SSAO or other ScreenEffects.

The change is only in the place where the controls are placed. We used to place them into Viewport, this PR puts them into Window.Controls, above the viewport.