### PR TITLE
Fix EAccessViolation when loading Inline node with DEF

### DIFF
--- a/src/scene/x3d/x3dnodes_standard_networking.inc
+++ b/src/scene/x3d/x3dnodes_standard_networking.inc
@@ -394,7 +394,7 @@ procedure TInlineNode.LoadInlined(CanReload: boolean;
     for I := 0 to Source.Count - 1 do
     begin
       NodeName := Source[I].ExportedAlias;
-      if NodeName = '' then
+      if (NodeName = '') and (Source[I].ExportedNode <> nil) then
         NodeName := Source[I].ExportedNode.X3DName;
       Target.Bind(Source[I].ExportedNode, true, NodeName);
     end;


### PR DESCRIPTION
This solves the issue https://github.com/castle-engine/castle-engine/issues/708

However I am not sure if NodeName can be left empty and used in Target.Bind
