### PR TITLE
Android http error responses

### DIFF
--- a/src/files/castledownload_url_http_android.inc
+++ b/src/files/castledownload_url_http_android.inc
@@ -50,6 +50,11 @@ const
     'GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'HEAD'
   );
 
+  function HttpMethodName: String;
+  begin
+    Result := HttpMethodNames[HttpMethod];
+  end;
+
   function HttpRequestBodyStr: String;
   begin
     if HttpRequestBody <> nil then

--- a/src/files/castledownload_url_http_android.inc
+++ b/src/files/castledownload_url_http_android.inc
@@ -162,6 +162,9 @@ begin
     Status := dsError;
     ErrorMessage := Received[2];
     Result := true;
+    Contents.Position := 0; // rewind
+    DownloadedBytes := Contents.Size;
+    TotalBytes := Contents.Size;
   end;
 
   if (Received.Count >= 2) and

--- a/tools/build-tool/data/android/services/download_urls/app/src/main/java/io/castleengine/ServiceDownloadUrls.java
+++ b/tools/build-tool/data/android/services/download_urls/app/src/main/java/io/castleengine/ServiceDownloadUrls.java
@@ -175,8 +175,11 @@ public class ServiceDownloadUrls extends ServiceAbstract
                     }
 
                     inStream.close();
-
-                    messageSendFromThread(new String[]{"download-success", downloadIdStr});
+                    
+                    if (responseCode < 400)
+                        messageSendFromThread(new String[]{"download-success", downloadIdStr});
+                    else
+                        messageSendFromThread(new String[]{"download-error", downloadIdStr, "Response Status code " + responseCode.toString()});
                 }
                 catch (Exception e) {
                     logError(CATEGORY, "downloadDataFromUrl exception: " + PrintStackTrace(e));


### PR DESCRIPTION
Corrected Android error handling, Requests with Http response status 400+ are treated as TCastleDownload.DownloadStatus = dsError

also a small compilation fix after Web HttpRequests branch changes