### PR TITLE
Set default Android API LVL to 36 required by Google Play

### DIFF
--- a/tools/common-code/toolmanifest.pas
+++ b/tools/common-code/toolmanifest.pas
@@ -169,7 +169,7 @@ type
     const
       { Android SDK versions.
         See https://castle-engine.io/project_manifest#_android_information . }
-      DefaultAndroidCompileSdkVersion = 35;
+      DefaultAndroidCompileSdkVersion = 36;
       DefaultAndroidTargetSdkVersion = DefaultAndroidCompileSdkVersion;
       { See https://castle-engine.io/android_faq
         for reasons behind this minimal version. }


### PR DESCRIPTION
Hi, small patch to set default API level to 36 required by Google Play from 31 August 2026. Tested in my mobile game, everything seems to be working.